### PR TITLE
Fix UI freeze when viewing read model instances

### DIFF
--- a/Source/Cli/Commands/Chronicle/Workbench/views/ReadModelsView.cs
+++ b/Source/Cli/Commands/Chronicle/Workbench/views/ReadModelsView.cs
@@ -81,17 +81,42 @@ public class ReadModelsView : FilterableTableView<WorkbenchReadModel>
             $"[{mut}]Queryable[/]    [{queryableColor}]{(rm.IsQueryable ? "Yes" : "No")}[/]",
             $"[{mut}]Identifier[/]   {rm.Identifier}");
 
-        var instancesContent = BuildInstancesContent(rm);
+        // Open immediately with a placeholder for the Instances tab, then fetch off the UI thread so
+        // activating a row never blocks (or deadlocks) the render loop. The fetched content is pushed
+        // back into the tab editor on the UI thread once it arrives.
+        const string instancesTab = "Instances";
+        var loadingContent = OnFetchInstances is null
+            ? $"[{mut}](No instance loader configured)[/]"
+            : $"[{mut}]Loading instances…[/]";
 
         List<(string TabName, string Content)> tabs =
         [
             ("Info", infoContent),
-            ("Instances", instancesContent)
+            (instancesTab, loadingContent)
         ];
 
         var overlay = new DetailOverlayWindow();
         var window = overlay.Build(_windowSystem, $" {rm.ContainerName} ", tabs, []);
         _windowSystem.AddWindow(window, activateWindow: true);
+
+        if (OnFetchInstances is null)
+        {
+            return;
+        }
+
+        var windowSystem = _windowSystem;
+        _ = Task.Run(async () =>
+        {
+            var content = await FetchInstancesContentAsync(rm).ConfigureAwait(false);
+            windowSystem.EnqueueOnUIThread(() =>
+            {
+                if (overlay.TabEditors.TryGetValue(instancesTab, out var editor))
+                {
+                    // The overlay strips markup to plain text for its read-only editors.
+                    editor.SetContent(Markup.Remove(content));
+                }
+            });
+        });
     }
 
     /// <inheritdoc/>
@@ -154,7 +179,7 @@ public class ReadModelsView : FilterableTableView<WorkbenchReadModel>
     /// <inheritdoc/>
     protected override void OnRowActivated(WorkbenchReadModel item) => OpenDetailOverlay(item);
 
-    string BuildInstancesContent(WorkbenchReadModel rm)
+    async Task<string> FetchInstancesContentAsync(WorkbenchReadModel rm)
     {
         var mut = WorkbenchColors.Muted.ToMarkup();
         var dan = WorkbenchColors.Danger.ToMarkup();
@@ -166,8 +191,8 @@ public class ReadModelsView : FilterableTableView<WorkbenchReadModel>
 
         try
         {
-            var data = OnFetchInstances(rm.ContainerName, CancellationToken.None)
-                .GetAwaiter().GetResult();
+            var data = await OnFetchInstances(rm.ContainerName, CancellationToken.None)
+                .ConfigureAwait(false);
 
             if (data.ReadModelInstancesError is not null)
             {

--- a/Source/Cli/Commands/Chronicle/Workbench/windows/DetailOverlayWindow.cs
+++ b/Source/Cli/Commands/Chronicle/Workbench/windows/DetailOverlayWindow.cs
@@ -13,6 +13,13 @@ namespace Cratis.Cli.Commands.Chronicle.Workbench;
 public class DetailOverlayWindow
 {
     Window? _window;
+    readonly Dictionary<string, MultilineEditControl> _tabEditors = [];
+
+    /// <summary>
+    /// Gets the read-only editors backing each tab, keyed by tab name. Lets callers update a tab's
+    /// content after <see cref="Build"/> (for example, when a tab is populated by an async fetch).
+    /// </summary>
+    public IReadOnlyDictionary<string, MultilineEditControl> TabEditors => _tabEditors;
 
     /// <summary>
     /// Builds a detail overlay window with the specified title, tabbed content, and action buttons.
@@ -49,6 +56,7 @@ public class DetailOverlayWindow
                 .Build();
 
             tabBuilder.AddTab(tabName, editor);
+            _tabEditors[tabName] = editor;
         }
 
         var tabControl = tabBuilder.Fill().Build();

--- a/Source/Cli/Commands/Chronicle/Workbench/windows/DetailOverlayWindow.cs
+++ b/Source/Cli/Commands/Chronicle/Workbench/windows/DetailOverlayWindow.cs
@@ -12,8 +12,8 @@ namespace Cratis.Cli.Commands.Chronicle.Workbench;
 /// </summary>
 public class DetailOverlayWindow
 {
-    Window? _window;
     readonly Dictionary<string, MultilineEditControl> _tabEditors = [];
+    Window? _window;
 
     /// <summary>
     /// Gets the read-only editors backing each tab, keyed by tab name. Lets callers update a tab's


### PR DESCRIPTION
# Summary

Activating a read model row in the Chronicle Workbench blocked the UI thread on the instances fetch: `OpenDetailOverlay` called `BuildInstancesContent`, which ran `OnFetchInstances(...).GetAwaiter().GetResult()` synchronously before building the overlay. The whole TUI froze for the duration of the network call, and the detail overlay only appeared once data returned.

This opens the overlay immediately with a `Loading instances…` placeholder, fetches off the UI thread, and updates the Instances tab when the data arrives.

## Fixed

- Read model instances now load asynchronously: the detail overlay opens immediately and the UI thread no longer blocks on the instances fetch when activating a read model row.

## Changed

- `DetailOverlayWindow` exposes its per-tab editors (`TabEditors`) so a tab’s content can be updated after `Build` — used to fill the Instances tab once the async fetch completes. The fetch runs on a background task (`Task.Run` + `ConfigureAwait(false)`) and the result is marshalled back onto the UI thread via `EnqueueOnUIThread`.

---

The change is confined to `ReadModelsView` and `DetailOverlayWindow` (no public API removed; `DetailOverlayWindow` change is additive).

> Note: I could not produce a full local build — this repo’s source generators require a newer Roslyn than my local SDK ships (`CS9057`), so generator-emitted symbols are unavailable in my environment. The two changed files compile clean; CI with the project’s toolchain should build normally.