### PR TITLE
Bump SharpConsoleUI to 2.5.0 and drop redundant nav invalidation

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -12,7 +12,7 @@
     <PackageVersion Include="MongoDB.Driver" Version="3.9.0" />
     <PackageVersion Include="Spectre.Console" Version="0.57.1" />
     <PackageVersion Include="Spectre.Console.Cli" Version="0.55.0" />
-    <PackageVersion Include="SharpConsoleUI" Version="2.4.78" />
+    <PackageVersion Include="SharpConsoleUI" Version="2.5.0" />
     <PackageVersion Include="Grpc.Net.Client" Version="2.80.0" />
     <PackageVersion Include="System.Text.Json" Version="10.0.9" />
     <!-- Source Generator -->

--- a/Source/Cli/Commands/Chronicle/Workbench/windows/WorkbenchNavigation.cs
+++ b/Source/Cli/Commands/Chronicle/Workbench/windows/WorkbenchNavigation.cs
@@ -238,8 +238,6 @@ public class WorkbenchNavigation(
                 ? data.Recommendations.Count.ToString()
                 : string.Empty;
         }
-
-        _navView?.Invalidate();
     }
 
     /// <summary>Opens a modal picker that lets the user select a different event store.</summary>


### PR DESCRIPTION
## Changed
- Update SharpConsoleUI to 2.5.0.

## Fixed
- Remove a redundant explicit navigation invalidation in the workbench. `NavigationItem.Subtitle` now self-invalidates via its setter in SharpConsoleUI 2.5.0, so badge subtitle updates refresh without the extra call.