### PR TITLE
Support Chronicle's single-port TLS Kernel

### DIFF
--- a/CHRONICLE.md
+++ b/CHRONICLE.md
@@ -18,7 +18,7 @@ The CLI resolves the server connection in this order:
 
 ```bash
 # Set up a named context
-cratis context create dev --server chronicle://localhost:35000/?disableTls=true
+cratis context create dev --server chronicle://localhost:35000
 cratis context set dev
 ```
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,8 +5,8 @@
   </PropertyGroup>
   <ItemGroup>
     <!-- Cratis -->
-    <PackageVersion Include="Cratis.Chronicle.Connections" Version="15.40.0" />
-    <PackageVersion Include="Cratis.Chronicle.Contracts" Version="15.40.0" />
+    <PackageVersion Include="Cratis.Chronicle.Connections" Version="16.0.1" />
+    <PackageVersion Include="Cratis.Chronicle.Contracts" Version="16.0.1" />
     <PackageVersion Include="Cratis.Fundamentals" Version="7.16.2" />
     <!-- CLI -->
     <PackageVersion Include="MongoDB.Driver" Version="3.10.0" />
@@ -30,7 +30,7 @@
     <!-- Testing -->
     <PackageVersion Include="Cratis.Specifications" Version="3.0.5" />
     <PackageVersion Include="Cratis.Specifications.XUnit" Version="3.0.5" />
-    <PackageVersion Include="Cratis.Chronicle.XUnit.Integration" Version="15.40.0" />
+    <PackageVersion Include="Cratis.Chronicle.XUnit.Integration" Version="16.0.1" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />

--- a/Documentation/chronicle/event-stores.md
+++ b/Documentation/chronicle/event-stores.md
@@ -12,7 +12,7 @@ cratis chronicle event-stores list
 
 ### Options
 
-This command accepts only the global flags and the `--server` / `--management-port` connection flags. It does not accept `-e` or `-n` because it operates above the event store level.
+This command accepts only the global flags and the `--server` connection flag. It does not accept `-e` or `-n` because it operates above the event store level.
 
 ### Output
 

--- a/Documentation/chronicle/index.md
+++ b/Documentation/chronicle/index.md
@@ -4,12 +4,11 @@ The `cratis chronicle` command group provides the primary interface for interact
 
 ## Connection Flags
 
-Most commands accept the following connection flags:
+Most commands accept the following connection flag:
 
 | Flag | Description |
 |---|---|
 | `--server <CONNECTION_STRING>` | Chronicle server connection string. Overrides the active context and the `CHRONICLE_CONNECTION_STRING` environment variable. |
-| `--management-port <PORT>` | Management API port. Defaults to the port embedded in the connection string. |
 
 For the full connection string format, see the [Connection](../reference/connection.md) reference page.
 

--- a/Documentation/context/index.md
+++ b/Documentation/context/index.md
@@ -13,7 +13,7 @@ When the CLI resolves which server to connect to, it checks in this order:
 1. `--server` flag on the current command
 2. `CHRONICLE_CONNECTION_STRING` environment variable
 3. Active context in `~/.cratis/config.json`
-4. Default: `chronicle://localhost:35000/?disableTls=true`
+4. Default: `chronicle://localhost:35000`
 
 ## Commands
 
@@ -34,7 +34,7 @@ cratis context list -o plain
 Example output:
 
 ```
-* dev    chronicle://localhost:35000/?disableTls=true
+* dev    chronicle://localhost:35000
   prod   chronicle://prod.example.com:35000/
 ```
 
@@ -56,10 +56,10 @@ cratis context create <NAME> --server <CONNECTION_STRING>
 | `--event-store` | `-e` | Default event store for this context (default: `default`) |
 | `--namespace` | `-n` | Default namespace for this context (default: `Default`) |
 
-**Example — local development server with TLS disabled:**
+**Example — local development server:**
 
 ```bash
-cratis context create dev --server chronicle://localhost:35000/?disableTls=true
+cratis context create dev --server chronicle://localhost:35000
 ```
 
 **Example — staging server with a specific event store and namespace:**
@@ -108,7 +108,7 @@ cratis context show -o json
 Example output (plain):
 
 ```
-Server:       chronicle://localhost:35000/?disableTls=true
+Server:       chronicle://localhost:35000
 Event store:  default
 Namespace:    Default
 Client ID:    (not set)
@@ -182,12 +182,11 @@ cratis context set-value <KEY> <VALUE>
 | `namespace` | Default namespace name |
 | `client-id` | OAuth client ID for authenticated servers |
 | `client-secret` | OAuth client secret (masked in output) |
-| `management-port` | HTTP management port (default: `8080`) |
 
 **Example — update the server URL:**
 
 ```bash
-cratis context set-value server chronicle://localhost:35000/?disableTls=true
+cratis context set-value server chronicle://localhost:35000
 ```
 
 **Example — set credentials for an authenticated server:**

--- a/Documentation/reference/connection.md
+++ b/Documentation/reference/connection.md
@@ -1,6 +1,6 @@
 # Connection
 
-This page documents how the `cratis` CLI connects to a Chronicle server: the connection string format, how the server address is resolved, and the management port used for HTTP operations.
+This page documents how the `cratis` CLI connects to a Chronicle server: the connection string format and how the server address is resolved.
 
 ## Connection String Format
 
@@ -13,15 +13,19 @@ chronicle://<host>:<port>/?<options>
 **Examples:**
 
 ```
-chronicle://localhost:35000/?disableTls=true
+chronicle://localhost:35000
 chronicle://prod.example.com:35000/
 ```
+
+Chronicle serves gRPC and the OAuth/HTTP API over a single TLS port (default `35000`). TLS is mandatory on that port: in development, the server auto-generates a self-signed certificate for `localhost` and the CLI trusts it automatically — no certificate setup is required to connect to a local server.
 
 ### Options
 
 | Option | Values | Description |
 |---|---|---|
-| `disableTls` | `true` / `false` | Disables TLS for the gRPC connection. Required for local servers that do not have a certificate configured. |
+| `disableTls` | `true` / `false` | Disables TLS for the connection. Only needed when connecting through a plaintext-terminating proxy — the Chronicle server itself always serves TLS. |
+| `certificatePath` | path | Path to a client certificate file, for pinning a specific expected server certificate. |
+| `certificatePassword` | string | Password for the certificate file. |
 
 ## Resolution Order
 
@@ -30,7 +34,7 @@ When the CLI determines which server to connect to, it checks sources in this or
 1. `--server` flag on the current command
 2. `CHRONICLE_CONNECTION_STRING` environment variable
 3. Active context in `~/.cratis/config.json`
-4. Default: `chronicle://localhost:35000/?disableTls=true`
+4. Default: `chronicle://localhost:35000`
 
 The `--server` flag always wins. The default applies only when none of the other sources provide a value.
 
@@ -45,32 +49,13 @@ cratis chronicle event-stores list
 
 The variable is checked after `--server` but before the active context, so a context always overrides it when both are present unless `--server` is used explicitly.
 
-## Management Port
-
-Some Chronicle operations — including authentication token exchange and certain HTTP management APIs — use a separate HTTP port rather than the gRPC port in the connection string.
-
-The default management port is `8080`.
-
-Override it with the `--management-port` flag, which is available on all `cratis` subcommands that communicate with the server:
-
-```bash
-cratis chronicle auth status --management-port 9090
-```
-
-You can also persist the management port in a context so you do not need to specify it on every command:
-
-```bash
-cratis context set-value management-port 9090
-```
-
 ## Per-Command Server Options
 
-Every subcommand that communicates with Chronicle accepts these options directly, which take precedence over context and environment variable values:
+Every subcommand that communicates with Chronicle accepts this option directly, which takes precedence over context and environment variable values:
 
 | Option | Description |
 |---|---|
 | `--server <CONNECTION_STRING>` | Chronicle server connection string |
-| `--management-port <PORT>` | HTTP management port (default: `8080`) |
 
 **Example — connect to a specific server for a single command without changing the active context:**
 

--- a/Documentation/reference/global-options.md
+++ b/Documentation/reference/global-options.md
@@ -64,7 +64,6 @@ The debug panel includes:
 - Config file path
 - Active context name
 - Connection string (credentials are redacted)
-- Management port
 - Resolved output format
 - RPC timing for each gRPC call
 

--- a/Documentation/reference/index.md
+++ b/Documentation/reference/index.md
@@ -6,4 +6,4 @@ This section documents the cross-cutting mechanics of the `cratis` CLI: the flag
 
 - [Global Options](global-options.md) — Flags such as `--output`, `--quiet`, `--yes`, and `--debug` that apply to every command.
 - [Output Formats](output-formats.md) — The four output formats (`table`, `plain`, `json`, `json-compact`) with guidance on when to use each and token cost comparisons.
-- [Connection](connection.md) — Connection string format, resolution order, management port, and environment variable configuration.
+- [Connection](connection.md) — Connection string format, resolution order, and environment variable configuration.

--- a/Integration/Chronicle/ChronicleOutOfProcessFixtureWithLocalImage.cs
+++ b/Integration/Chronicle/ChronicleOutOfProcessFixtureWithLocalImage.cs
@@ -18,11 +18,11 @@ namespace Cratis.Cli.Integration.Chronicle;
 /// </summary>
 /// <remarks>
 /// <para>
-/// The CLI connects to the Chronicle server externally via gRPC. The management
-/// port is mapped to host port 8081 (instead of the default 8080) to avoid
-/// conflicts with a locally running Chronicle instance used during development.
-/// Tests pass <c>--management-port 8081</c> to the CLI so that the
-/// <c>OAuthTokenProvider</c> reaches <c>https://localhost:8081/connect/token</c>.
+/// The CLI connects to the Chronicle server externally via gRPC. The single Chronicle
+/// port is mapped to host port 35001 (instead of the default 35000) to avoid conflicts
+/// with a locally running Chronicle instance used during development. The OAuth token
+/// endpoint is served on that same port, so the <c>OAuthTokenProvider</c> reaches
+/// <c>https://localhost:35001/connect/token</c> without any extra configuration.
 /// </para>
 /// <para>
 /// TLS is configured using a self-signed certificate generated at test startup.
@@ -78,13 +78,12 @@ public class ChronicleOutOfProcessFixtureWithLocalImage : ChronicleOutOfProcessF
     protected override IContainer BuildContainer(INetwork network)
     {
         var waitStrategy = Wait.ForUnixContainer()
-            .AddCustomWaitStrategy(new HttpsHealthWait(8080), s => s.WithTimeout(TimeSpan.FromSeconds(15)));
+            .AddCustomWaitStrategy(new HttpsHealthWait(35000), s => s.WithTimeout(TimeSpan.FromSeconds(15)));
 
         var builder = new ContainerBuilder(ChronicleImageName);
         builder = ConfigureImage(builder)
             .WithEnvironment("Storage__ConnectionDetails", "mongodb://localhost:27017")
             .WithPortBinding(MongoDBPort, 27017)
-            .WithPortBinding(8081, 8080)
             .WithPortBinding(35001, 35000)
             .WithHostname(HostName)
             .WithBindMount(Path.Combine(Directory.GetCurrentDirectory(), "backups"), "/backups")

--- a/Integration/Chronicle/given/a_connected_cli.cs
+++ b/Integration/Chronicle/given/a_connected_cli.cs
@@ -25,11 +25,11 @@ public class a_connected_cli : Specification
     /// <summary>
     /// Runs a CLI command against the live server with JSON output format.
     /// </summary>
-    /// <param name="args">The command arguments (without --server, --management-port, and --output flags).</param>
+    /// <param name="args">The command arguments (without --server and --output flags).</param>
     /// <returns>The command execution result.</returns>
     protected static Task<CliCommandResult> RunCliAsync(params string[] args)
     {
-        var allArgs = new List<string>(args) { "--server", ConnectionString, "--management-port", "8081", "--output", "json" };
+        var allArgs = new List<string>(args) { "--server", ConnectionString, "--output", "json" };
         return CliCommandRunner.RunAsync([.. allArgs]);
     }
 }

--- a/README.md
+++ b/README.md
@@ -104,21 +104,21 @@ cratis get-started
 If no context is configured yet, the command will walk you through the setup:
 
 ```
-╭─ Getting Started ───────────────────────────────────────────────╮
-│                                                                 │
-│  No configuration found. Set up a context to get started:       │
-│                                                                 │
-│  1. Create a context pointing at your server:                   │
-│     cratis context create dev \                                 │
-│       --server chronicle://localhost:35000/?disableTls=true     │
-│                                                                 │
-│  2. Verify the connection:                                      │
-│     cratis get-started                                          │
-│                                                                 │
-│  3. Start exploring:                                            │
-│     cratis chronicle event-stores list                          │
-│                                                                 │
-╰─────────────────────────────────────────────────────────────────╯
+╭─ Getting Started ──────────────────────────────────────────╮
+│                                                            │
+│   No configuration found. Set up a context to get started: │
+│                                                            │
+│   1. Create a context pointing at your server:             │
+│      cratis context create dev \                           │
+│        --server chronicle://localhost:35000                │
+│                                                            │
+│   2. Verify the connection:                                │
+│      cratis get-started                                    │
+│                                                            │
+│   3. Start exploring:                                      │
+│      cratis chronicle event-stores list                    │
+│                                                            │
+╰────────────────────────────────────────────────────────────╯
 ```
 
 Once a context is configured, `get-started` shows your active context, connection status, and a curated list of commands to explore and debug your event store.
@@ -130,7 +130,7 @@ A context stores a named connection to a Chronicle server:
 ```shell
 # Create a context for local development
 cratis context create dev \
-  --server chronicle://localhost:35000/?disableTls=true
+  --server chronicle://localhost:35000
 
 # Make it the active context
 cratis context set dev

--- a/Source/Cli/CliContext.cs
+++ b/Source/Cli/CliContext.cs
@@ -34,11 +34,6 @@ public class CliContext
     public string? ClientSecret { get; set; }
 
     /// <summary>
-    /// Gets or sets the management port for the HTTP API and token endpoint.
-    /// </summary>
-    public int? ManagementPort { get; set; }
-
-    /// <summary>
     /// Gets or sets the cached access token from a previous login.
     /// </summary>
     public string? AccessToken { get; set; }

--- a/Source/Cli/Commands/Chronicle/Auth/LoginCommand.cs
+++ b/Source/Cli/Commands/Chronicle/Auth/LoginCommand.cs
@@ -46,8 +46,7 @@ public class LoginCommand : AsyncCommand<LoginSettings>
             var connectionString = new ChronicleConnectionString(settings.ResolveConnectionString());
             var disableTls = connectionString.DisableTls;
             var scheme = disableTls ? "http" : "https";
-            var managementPort = settings.ResolveManagementPort();
-            var tokenEndpoint = $"{scheme}://{connectionString.ServerAddress.Host}:{managementPort}/connect/token";
+            var tokenEndpoint = $"{scheme}://{connectionString.ServerAddress.Host}:{connectionString.ServerAddress.Port}/connect/token";
 
             using var handler = CreateHandler();
             using var httpClient = new HttpClient(handler);

--- a/Source/Cli/Commands/Chronicle/ChronicleCommand.cs
+++ b/Source/Cli/Commands/Chronicle/ChronicleCommand.cs
@@ -40,8 +40,7 @@ public abstract partial class ChronicleCommand<TSettings> : AsyncCommand<TSettin
             try
             {
                 var connectionString = new ChronicleConnectionString(settings.ResolveConnectionString());
-                var managementPort = settings.ResolveManagementPort();
-                using var client = await CliChronicleConnection.Connect(connectionString, managementPort, cancellationToken);
+                using var client = await CliChronicleConnection.Connect(connectionString, cancellationToken);
 
                 int exitCode;
                 var sw = settings.Debug ? Stopwatch.StartNew() : null;
@@ -125,18 +124,16 @@ public abstract partial class ChronicleCommand<TSettings> : AsyncCommand<TSettin
         var configPath = CliConfiguration.GetConfigPath();
         var config = CliConfiguration.Load();
         var connectionString = settings.ResolveConnectionString();
-        var managementPort = settings.ResolveManagementPort();
 
-        Console.Error.WriteLine($"[debug] config:          {configPath}");
-        Console.Error.WriteLine($"[debug] context:         {config.ActiveContextName}");
-        Console.Error.WriteLine($"[debug] server:          {RedactConnectionString(connectionString)}");
-        Console.Error.WriteLine($"[debug] management-port: {managementPort}");
-        Console.Error.WriteLine($"[debug] output:          {settings.ResolveOutputFormat()}");
+        Console.Error.WriteLine($"[debug] config:       {configPath}");
+        Console.Error.WriteLine($"[debug] context:      {config.ActiveContextName}");
+        Console.Error.WriteLine($"[debug] server:       {RedactConnectionString(connectionString)}");
+        Console.Error.WriteLine($"[debug] output:       {settings.ResolveOutputFormat()}");
 
         if (settings is EventStoreSettings ess)
         {
-            Console.Error.WriteLine($"[debug] event-store:     {ess.ResolveEventStore()}");
-            Console.Error.WriteLine($"[debug] namespace:       {ess.ResolveNamespace()}");
+            Console.Error.WriteLine($"[debug] event-store:  {ess.ResolveEventStore()}");
+            Console.Error.WriteLine($"[debug] namespace:    {ess.ResolveNamespace()}");
         }
     }
 

--- a/Source/Cli/Commands/Chronicle/ChronicleSettings.cs
+++ b/Source/Cli/Commands/Chronicle/ChronicleSettings.cs
@@ -16,13 +16,6 @@ public class ChronicleSettings : GlobalSettings
     public string? Server { get; set; }
 
     /// <summary>
-    /// Gets or sets the management port for the HTTP API and token endpoint.
-    /// </summary>
-    [CommandOption("--management-port <PORT>")]
-    [Description("Management port for the HTTP API and token endpoint (default: 8080)")]
-    public int? ManagementPort { get; set; }
-
-    /// <summary>
     /// Resolves the effective connection string by checking flag, environment variable, current context, then default.
     /// When the resolved connection string has no embedded credentials, client credentials from the context are composed in.
     /// </summary>
@@ -48,34 +41,11 @@ public class ChronicleSettings : GlobalSettings
                 var ctx = config.GetCurrentContext();
                 connectionString = !string.IsNullOrWhiteSpace(ctx.Server)
                     ? ctx.Server
-                    : "chronicle://localhost:35000/?disableTls=true";
+                    : "chronicle://localhost:35000";
             }
         }
 
         return ComposeCredentials(connectionString);
-    }
-
-    /// <summary>
-    /// Resolves the effective management port by checking flag, environment variable, current context, then default.
-    /// </summary>
-    /// <returns>The resolved management port.</returns>
-    public int ResolveManagementPort()
-    {
-        if (ManagementPort.HasValue)
-        {
-            return ManagementPort.Value;
-        }
-
-        var envVar = Environment.GetEnvironmentVariable(CliDefaults.ManagementPortEnvVar);
-        if (!string.IsNullOrWhiteSpace(envVar) && int.TryParse(envVar, out var envPort))
-        {
-            return envPort;
-        }
-
-        var config = CliConfiguration.Load();
-        var ctx = config.GetCurrentContext();
-
-        return ctx.ManagementPort ?? CliDefaults.DefaultManagementPort;
     }
 
     static string ComposeCredentials(string connectionString)

--- a/Source/Cli/Commands/Chronicle/CliChronicleConnection.cs
+++ b/Source/Cli/Commands/Chronicle/CliChronicleConnection.cs
@@ -22,10 +22,9 @@ public sealed class CliChronicleConnection(ChronicleConnection connection, Cance
     /// Creates and connects a <see cref="CliChronicleConnection"/> from a connection string.
     /// </summary>
     /// <param name="connectionString">The parsed Chronicle connection string.</param>
-    /// <param name="managementPort">The management port for the token endpoint.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>A connected <see cref="CliChronicleConnection"/>.</returns>
-    public static async Task<CliChronicleConnection> Connect(ChronicleConnectionString connectionString, int managementPort, CancellationToken cancellationToken = default)
+    public static async Task<CliChronicleConnection> Connect(ChronicleConnectionString connectionString, CancellationToken cancellationToken = default)
     {
 #pragma warning disable CA2000 // cts and connection ownership is transferred to CliChronicleConnection on success; both are disposed in the catch block on failure
         var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
@@ -38,7 +37,7 @@ public sealed class CliChronicleConnection(ChronicleConnection connection, Cance
             var config = CliConfiguration.Load();
             var tokenProvider = connectionString.AuthenticationMode switch
             {
-                AuthenticationMode.ClientCredentials => (ITokenProvider?)CreateCachingTokenProvider(connectionString, managementPort, config.ActiveContextName),
+                AuthenticationMode.ClientCredentials => (ITokenProvider?)CreateCachingTokenProvider(connectionString, config.ActiveContextName),
                 AuthenticationMode.ApiKey when !string.IsNullOrEmpty(connectionString.ApiKey) =>
                     new StaticTokenProvider(connectionString.ApiKey),
                 _ => null
@@ -66,7 +65,7 @@ public sealed class CliChronicleConnection(ChronicleConnection connection, Cance
                 skipCompatibilityCheck: true,
                 skipKeepAlive: true);
 
-            // Eagerly fetch the token so HttpRequestException from an unreachable management port
+            // Eagerly fetch the token so HttpRequestException from an unreachable server
             // propagates directly instead of being wrapped as RpcException by the gRPC interceptor.
             if (tokenProvider is not null)
             {
@@ -91,11 +90,10 @@ public sealed class CliChronicleConnection(ChronicleConnection connection, Cance
     /// blocking on async here is intentional and safe because this is always called from a thread-pool context without a synchronization context.
     /// </summary>
     /// <param name="connectionString">The parsed Chronicle connection string.</param>
-    /// <param name="managementPort">The management port for the token endpoint.</param>
     /// <returns>A connected <see cref="CliChronicleConnection"/>.</returns>
 #pragma warning disable CA2000 // Caller is responsible for disposing the returned instance
-    public static CliChronicleConnection ConnectSync(ChronicleConnectionString connectionString, int managementPort)
-        => Connect(connectionString, managementPort).GetAwaiter().GetResult();
+    public static CliChronicleConnection ConnectSync(ChronicleConnectionString connectionString)
+        => Connect(connectionString).GetAwaiter().GetResult();
 #pragma warning restore CA2000
 
     /// <summary>
@@ -122,7 +120,7 @@ public sealed class CliChronicleConnection(ChronicleConnection connection, Cance
         connection.Dispose();
     }
 
-    static FileSystemCachingTokenProvider CreateCachingTokenProvider(ChronicleConnectionString connectionString, int managementPort, string contextName)
+    static FileSystemCachingTokenProvider CreateCachingTokenProvider(ChronicleConnectionString connectionString, string contextName)
     {
         var cachePath = CliConfiguration.GetTokenCachePath($"{contextName}_{connectionString.Username ?? string.Empty}");
         Directory.CreateDirectory(Path.GetDirectoryName(cachePath)!);
@@ -131,7 +129,6 @@ public sealed class CliChronicleConnection(ChronicleConnection connection, Cance
             connectionString.ServerAddress,
             connectionString.Username ?? string.Empty,
             connectionString.Password ?? string.Empty,
-            managementPort,
             connectionString.DisableTls,
             NullLogger<OAuthTokenProvider>.Instance);
 #pragma warning restore CA2000

--- a/Source/Cli/Commands/Chronicle/CliDefaults.cs
+++ b/Source/Cli/Commands/Chronicle/CliDefaults.cs
@@ -24,19 +24,9 @@ public static class CliDefaults
     public const string DefaultNamespaceName = "Default";
 
     /// <summary>
-    /// The default management port.
-    /// </summary>
-    public const int DefaultManagementPort = 8080;
-
-    /// <summary>
     /// Environment variable name for the Chronicle connection string.
     /// </summary>
     public const string ConnectionStringEnvVar = "CHRONICLE_CONNECTION_STRING";
-
-    /// <summary>
-    /// Environment variable name for the management port override.
-    /// </summary>
-    public const string ManagementPortEnvVar = "CHRONICLE_MANAGEMENT_PORT";
 
     /// <summary>
     /// Standard error message when the CLI cannot reach the Chronicle server.

--- a/Source/Cli/Commands/Chronicle/EventStoreInterceptor.cs
+++ b/Source/Cli/Commands/Chronicle/EventStoreInterceptor.cs
@@ -39,10 +39,9 @@ public class EventStoreInterceptor : ICommandInterceptor
         var config = CliConfiguration.Load();
         var ctx = config.GetCurrentContext();
         var connectionString = new ChronicleConnectionString(eventStoreSettings.ResolveConnectionString());
-        var managementPort = eventStoreSettings.ResolveManagementPort();
 
         // Pass the currently stored event store so the selector can validate it is still present.
         // If it is missing or empty the selector will prompt the user and save the selection.
-        EventStoreSelector.TryPromptAndSave(connectionString, managementPort, config, ctx, ctx.EventStore);
+        EventStoreSelector.TryPromptAndSave(connectionString, config, ctx, ctx.EventStore);
     }
 }

--- a/Source/Cli/Commands/Chronicle/EventStoreSelector.cs
+++ b/Source/Cli/Commands/Chronicle/EventStoreSelector.cs
@@ -35,7 +35,6 @@ public static class EventStoreSelector
     /// default selection, and saves the choice to the context in the provided <see cref="CliConfiguration"/>.
     /// </summary>
     /// <param name="connectionString">The Chronicle connection string to use.</param>
-    /// <param name="managementPort">The management port.</param>
     /// <param name="config">The CLI configuration to update and save.</param>
     /// <param name="ctx">The current context to update.</param>
     /// <param name="currentEventStore">
@@ -46,7 +45,6 @@ public static class EventStoreSelector
     /// <returns>An <see cref="EventStoreSelectorResult"/> describing the outcome.</returns>
     public static EventStoreSelectorResult TryPromptAndSave(
         ChronicleConnectionString connectionString,
-        int managementPort,
         CliConfiguration config,
         CliContext ctx,
         string? currentEventStore = null)
@@ -61,7 +59,7 @@ public static class EventStoreSelector
         {
             eventStores = Task.Run(async () =>
             {
-                using var client = await CliChronicleConnection.Connect(connectionString, managementPort);
+                using var client = await CliChronicleConnection.Connect(connectionString);
                 return (await client.Services.EventStores.GetEventStores()).ToList();
             }).GetAwaiter().GetResult();
         }

--- a/Source/Cli/Commands/Completions/CliCommandTree.cs
+++ b/Source/Cli/Commands/Completions/CliCommandTree.cs
@@ -21,7 +21,6 @@ public static class CliCommandTree
         "-o", "--output",
         "-q", "--quiet",
         "-y", "--yes",
-        "--management-port",
         "--debug"
     ];
 

--- a/Source/Cli/Commands/Completions/FishCompletionGenerator.cs
+++ b/Source/Cli/Commands/Completions/FishCompletionGenerator.cs
@@ -25,7 +25,6 @@ public static class FishCompletionGenerator
             .AppendLine("complete -c cratis -s o -l output -d 'Output format' -r -f -a '(cratis _complete output-formats 2>/dev/null)'")
             .AppendLine("complete -c cratis -s q -l quiet -d 'Suppress non-essential output'")
             .AppendLine("complete -c cratis -s y -l yes -d 'Skip confirmation prompts'")
-            .AppendLine("complete -c cratis -l management-port -d 'Management port' -r")
             .AppendLine();
 
         var commands = CliCommandTree.Commands;

--- a/Source/Cli/Commands/Completions/ZshCompletionGenerator.cs
+++ b/Source/Cli/Commands/Completions/ZshCompletionGenerator.cs
@@ -30,7 +30,6 @@ public static class ZshCompletionGenerator
             .AppendLine("        {-o,--output}'[Output format]:format:(json json-compact plain table)' \\")
             .AppendLine("        {-q,--quiet}'[Suppress non-essential output]' \\")
             .AppendLine("        {-y,--yes}'[Skip confirmation prompts]' \\")
-            .AppendLine("        '--management-port[Management port]:port:' \\")
             .AppendLine("        '1: :->command' \\")
             .AppendLine("        '*::arg:->args'")
             .AppendLine()

--- a/Source/Cli/Commands/Context/CreateContextCommand.cs
+++ b/Source/Cli/Commands/Context/CreateContextCommand.cs
@@ -8,7 +8,7 @@ namespace Cratis.Cli.Commands.Context;
 /// </summary>
 [LlmDescription("Creates a new named context (server profile) with a connection string. Use to save connection settings for different Chronicle environments.")]
 [CliCommand("create", "Create a new context", Branch = typeof(ContextBranch))]
-[CliExample("context", "create", "dev", "--server", "chronicle://localhost:35000/?disableTls=true")]
+[CliExample("context", "create", "dev", "--server", "chronicle://localhost:35000")]
 [CliExample("context", "create", "prod", "--server", "chronicle://prod:35000", "-e", "production")]
 [LlmOutputAdvice("plain", "Plain outputs a confirmation message.")]
 [LlmOption("<NAME>", "string", "Name of the context to create (positional)")]

--- a/Source/Cli/Commands/Context/SetValueCommand.cs
+++ b/Source/Cli/Commands/Context/SetValueCommand.cs
@@ -10,7 +10,7 @@ namespace Cratis.Cli.Commands.Context;
 [CliCommand("set-value", "Set a value in the current context", Branch = typeof(ContextBranch))]
 [CliExample("context", "set-value", "server", "chronicle://myhost:35000")]
 [CliExample("context", "set-value", "client-id", "my-app")]
-[LlmOption("<KEY>", "string", "Key to set: server, event-store, namespace, client-id, client-secret, management-port (positional). These update the active context's defaults.")]
+[LlmOption("<KEY>", "string", "Key to set: server, event-store, namespace, client-id, client-secret (positional). These update the active context's defaults.")]
 [LlmOption("<VALUE>", "string", "Value to assign (positional)")]
 public class SetValueCommand : AsyncCommand<SetValueSettings>
 {
@@ -38,20 +38,8 @@ public class SetValueCommand : AsyncCommand<SetValueSettings>
             case "client-secret":
                 ctx.ClientSecret = settings.Value;
                 break;
-            case "management-port":
-                if (int.TryParse(settings.Value, out var port))
-                {
-                    ctx.ManagementPort = port;
-                }
-                else
-                {
-                    OutputFormatter.WriteError(format, $"Invalid port value: '{settings.Value}'", "management-port must be a valid integer.", ExitCodes.ValidationErrorCode);
-                    return Task.FromResult(ExitCodes.ValidationError);
-                }
-
-                break;
             default:
-                OutputFormatter.WriteError(format, $"Unknown context key: '{settings.Key}'", "Valid keys: server, event-store, namespace, client-id, client-secret, management-port", ExitCodes.NotFoundCode);
+                OutputFormatter.WriteError(format, $"Unknown context key: '{settings.Key}'", "Valid keys: server, event-store, namespace, client-id, client-secret", ExitCodes.NotFoundCode);
                 return Task.FromResult(ExitCodes.NotFound);
         }
 

--- a/Source/Cli/Commands/Context/SetValueSettings.cs
+++ b/Source/Cli/Commands/Context/SetValueSettings.cs
@@ -12,7 +12,7 @@ public class SetValueSettings : GlobalSettings
     /// Gets or sets the configuration key.
     /// </summary>
     [CommandArgument(0, "<KEY>")]
-    [Description("Configuration key (server, event-store, namespace, client-id, client-secret, management-port)")]
+    [Description("Configuration key (server, event-store, namespace, client-id, client-secret)")]
     public string Key { get; set; } = string.Empty;
 
     /// <summary>

--- a/Source/Cli/Commands/GetStarted/GetStartedCommand.cs
+++ b/Source/Cli/Commands/GetStarted/GetStartedCommand.cs
@@ -45,7 +45,6 @@ public class GetStartedCommand : AsyncCommand<ChronicleSettings>
         var contextName = config.ActiveContextName;
 
         var resolvedServer = settings.ResolveConnectionString();
-        var managementPort = settings.ResolveManagementPort();
 
         // The display server shown to the user should be the raw context value (without injected credentials).
         var envServer = Environment.GetEnvironmentVariable(CliDefaults.ConnectionStringEnvVar);
@@ -60,7 +59,7 @@ public class GetStartedCommand : AsyncCommand<ChronicleSettings>
         }
         else
         {
-            displayServer = "chronicle://localhost:35000/?disableTls=true";
+            displayServer = "chronicle://localhost:35000";
         }
 
         var authState = ResolveAuthState(ctx);
@@ -72,7 +71,7 @@ public class GetStartedCommand : AsyncCommand<ChronicleSettings>
         try
         {
             var connectionString = new ChronicleConnectionString(resolvedServer);
-            using var connection = await CliChronicleConnection.Connect(connectionString, managementPort, cts.Token);
+            using var connection = await CliChronicleConnection.Connect(connectionString, cts.Token);
             canConnect = true;
         }
         catch
@@ -140,7 +139,7 @@ public class GetStartedCommand : AsyncCommand<ChronicleSettings>
             "  No configuration found. Set up a context to get started:\n\n" +
             $"  [{accent}]1.[/] Create a context pointing at your server:\n" +
             "     [bold]cratis context create dev \\\n" +
-            "       --server chronicle://localhost:35000/?disableTls=true[/]\n\n" +
+            "       --server chronicle://localhost:35000[/]\n\n" +
             $"  [{accent}]2.[/] Verify the connection:\n" +
             "     [bold]cratis get-started[/]\n\n" +
             $"  [{accent}]3.[/] Start exploring:\n" +

--- a/Source/Cli/Commands/Init/ChronicleDocGenerator.cs
+++ b/Source/Cli/Commands/Init/ChronicleDocGenerator.cs
@@ -39,7 +39,7 @@ public static class ChronicleDocGenerator
             .AppendLine()
             .AppendLine("```bash")
             .AppendLine("# Create a named context")
-            .AppendLine("cratis context create dev --server chronicle://localhost:35000/?disableTls=true")
+            .AppendLine("cratis context create dev --server chronicle://localhost:35000")
             .AppendLine("cratis context set dev")
             .AppendLine("```")
             .AppendLine()

--- a/Source/Cli/Commands/Version/VersionCommand.cs
+++ b/Source/Cli/Commands/Version/VersionCommand.cs
@@ -41,8 +41,7 @@ public class VersionCommand : AsyncCommand<ChronicleSettings>
         try
         {
             var connectionString = new ChronicleConnectionString(settings.ResolveConnectionString());
-            var managementPort = settings.ResolveManagementPort();
-            using var client = await CliChronicleConnection.Connect(connectionString, managementPort, cancellationToken);
+            using var client = await CliChronicleConnection.Connect(connectionString, cancellationToken);
             serverInfo = await client.Services.Server.GetVersionInfo();
         }
         catch

--- a/Source/Cli/FirstRunDetector.cs
+++ b/Source/Cli/FirstRunDetector.cs
@@ -10,7 +10,7 @@ namespace Cratis.Cli;
 /// </summary>
 public static class FirstRunDetector
 {
-    const string DefaultServer = "chronicle://localhost:35000/?disableTls=true";
+    const string DefaultServer = "chronicle://localhost:35000";
 
     /// <summary>
     /// Bootstraps a default context when no configuration file is found and prints a welcome message.

--- a/Source/Cli/Program.cs
+++ b/Source/Cli/Program.cs
@@ -17,7 +17,7 @@ if (args.Length == 0 && !Console.IsOutputRedirected && !GlobalSettings.IsAiAgent
     // This reads from config only — no connection attempt, instant output.
     var config = CliConfiguration.Load();
     var ctx = config.GetCurrentContext();
-    var server = ctx.Server ?? "chronicle://localhost:35000/?disableTls=true";
+    var server = ctx.Server ?? "chronicle://localhost:35000";
     var muted = OutputFormatter.Muted.ToMarkup();
     var accent = OutputFormatter.Accent.ToMarkup();
     AnsiConsole.MarkupLine($"  [{muted}]Context:[/] [{accent}]{config.ActiveContextName.EscapeMarkup()}[/] [{muted}]→[/] {server.EscapeMarkup()}");


### PR DESCRIPTION
## Summary

Chronicle's Kernel has consolidated gRPC and OAuth/HTTP traffic onto a single TLS port (default `35000`), removing the separate HTTP management port (`8080`). TLS is now mandatory on that port; in development the Kernel auto-generates a self-signed certificate and the client trusts it automatically. This PR updates the CLI to match, using the same approach as the reference .NET client changes.

## Removed

- `--management-port` flag, `CHRONICLE_MANAGEMENT_PORT` environment variable, and the `management-port` context key. The OAuth token endpoint is now derived from the connection string's server address instead of a separately configured port.

## Changed

- The default connection string no longer disables TLS. The CLI connects over TLS by default and automatically trusts the Chronicle server's self-signed development certificate, so local setups need no manual TLS configuration.
- Bumped `Cratis.Chronicle.Connections`, `Cratis.Chronicle.Contracts`, and `Cratis.Chronicle.XUnit.Integration` to `16.0.1` (first release with the single-port client APIs), and `Testcontainers` to `4.13.0` to satisfy its new minimum version requirement.

## Test plan

- [x] `dotnet build` (Cli, Cli.Specs, Integration/Chronicle) — 0 warnings, 0 errors in Release
- [x] `dotnet test` on `Cli.Specs` — 142/142 passed
- [x] `dotnet test` on `Integration/Chronicle` against a locally built single-port Chronicle dev image — 161/161 passed (auth/login, connection errors, and every command group)
- [x] Manually ran `cratis get-started` with no config to verify the onboarding panel renders correctly with the new connection string