### PR TITLE
Fix MA0206 analyzer errors on empty marker branch classes

### DIFF
--- a/Source/Cli/Registration/ArcBranch.cs
+++ b/Source/Cli/Registration/ArcBranch.cs
@@ -13,9 +13,9 @@ public static class ArcBranch
 {
     /// <summary>Command introspection.</summary>
     [CliBranch("commands", "Introspect registered command endpoints in the Arc application. List all commands with their routes, namespaces, and documentation.")]
-    public static class Commands { }
+    public static class Commands;
 
     /// <summary>Query introspection.</summary>
     [CliBranch("queries", "Introspect registered query endpoints in the Arc application. List all queries with their routes, namespaces, and documentation.")]
-    public static class Queries { }
+    public static class Queries;
 }

--- a/Source/Cli/Registration/ChronicleBranch.cs
+++ b/Source/Cli/Registration/ChronicleBranch.cs
@@ -14,61 +14,61 @@ public static class ChronicleBranch
 {
     /// <summary>Event store management.</summary>
     [CliBranch("event-stores", "List and discover event stores registered on the Chronicle server. Use to find valid --event-store values.")]
-    public static class EventStores { }
+    public static class EventStores;
 
     /// <summary>Namespace management within an event store.</summary>
     [CliBranch("namespaces", "List namespaces within an event store. Use to discover valid --namespace values.")]
-    public static class Namespaces { }
+    public static class Namespaces;
 
     /// <summary>Event type inspection.</summary>
     [CliBranch("event-types", "List and inspect event type registrations and their JSON Schema definitions. Use to explore the domain schema.")]
-    public static class EventTypes { }
+    public static class EventTypes;
 
     /// <summary>Event querying and inspection.</summary>
     [CliBranch("events", "Query and retrieve raw events from an event sequence. Supports filtering by type, source, sequence range, and time range.")]
-    public static class Events { }
+    public static class Events;
 
     /// <summary>Observer management (reactors, reducers, projections).</summary>
     [CliBranch("observers", "Manage observers (projections, reactors, reducers, client observers). Supports listing, inspecting, replaying, and recovering failed partitions.")]
-    public static class Observers { }
+    public static class Observers;
 
     /// <summary>Event store subscription management.</summary>
     [CliBranch("subscriptions", "Manage event store subscriptions for cross-store event flow. Supports listing, adding, and removing subscriptions.")]
-    public static class EventStoreSubscriptions { }
+    public static class EventStoreSubscriptions;
 
     /// <summary>Failed partition inspection.</summary>
     [CliBranch("failed-partitions", "List and inspect observer partitions that have failed and are paused. Use to diagnose and recover from processing failures.")]
-    public static class FailedPartitions { }
+    public static class FailedPartitions;
 
     /// <summary>System recommendations.</summary>
     [CliBranch("recommendations", "List, perform, and ignore automated maintenance recommendations from the Chronicle server (e.g. schema migrations, projection rebuilds).")]
-    public static class Recommendations { }
+    public static class Recommendations;
 
     /// <summary>Background job management.</summary>
     [CliBranch("jobs", "List, inspect, stop, and resume long-running background jobs such as replay and migration jobs.")]
-    public static class Jobs { }
+    public static class Jobs;
 
     /// <summary>Identity inspection.</summary>
     [CliBranch("identities", "List known identities (users who have interacted with the system). Use to map event actor subjects to display names and emails.")]
-    public static class Identities { }
+    public static class Identities;
 
     /// <summary>Projection management.</summary>
     [CliBranch("projections", "List and inspect projection definitions including event mappings, pipeline configuration, and model schemas.")]
-    public static class Projections { }
+    public static class Projections;
 
     /// <summary>Read model data inspection.</summary>
     [CliBranch("read-models", "Inspect current projected state. List definitions, retrieve instances by key, browse all instances, and view snapshots and replay history.")]
-    public static class ReadModels { }
+    public static class ReadModels;
 
     /// <summary>Authentication management.</summary>
     [CliBranch("auth", "Manage authentication. Check current token status, log in with username and password, and log out to clear cached credentials.")]
-    public static class Auth { }
+    public static class Auth;
 
     /// <summary>User management.</summary>
     [CliBranch("users", "Manage Chronicle user accounts. List, add, and remove users.")]
-    public static class Users { }
+    public static class Users;
 
     /// <summary>OAuth application management.</summary>
     [CliBranch("applications", "Manage OAuth client application registrations. List, add, and remove applications.")]
-    public static class Applications { }
+    public static class Applications;
 }

--- a/Source/Cli/Registration/CompletionsBranch.cs
+++ b/Source/Cli/Registration/CompletionsBranch.cs
@@ -9,4 +9,4 @@ namespace Cratis.Cli.Registration;
 /// Shell completion script generation and installation.
 /// </summary>
 [CliBranch("completions", "Generate and install shell completion scripts for bash, zsh, fish, and powershell. Use 'install' to auto-configure the current shell, or print scripts manually with the shell name.")]
-public static class CompletionsBranch { }
+public static class CompletionsBranch;

--- a/Source/Cli/Registration/ContextBranch.cs
+++ b/Source/Cli/Registration/ContextBranch.cs
@@ -9,4 +9,4 @@ namespace Cratis.Cli.Registration;
 /// Named connection context management.
 /// </summary>
 [CliBranch("context", "Manage named connection contexts (server profiles). Create, list, switch, rename, delete contexts, and set configuration values such as the server connection string, client ID, and client secret.")]
-public static class ContextBranch { }
+public static class ContextBranch;


### PR DESCRIPTION
## Fixed
- Fixed a build failure in the Publish workflow caused by Meziantou.Analyzer's MA0206 rule flagging empty `{ }` bodies on CLI branch marker classes; these now use the semicolon-bodied type declaration form.