### PR TITLE
Fix cratis update reporting incorrect results and add progress feedback

### DIFF
--- a/Source/Cli.Specs/for_CliUpdate/when_parsing_installed_version.cs
+++ b/Source/Cli.Specs/for_CliUpdate/when_parsing_installed_version.cs
@@ -8,24 +8,24 @@ public class when_parsing_installed_version : Specification
     [Fact]
     void should_find_version_in_dotnet_tool_list_output()
     {
-        var stdout =
+        const string Stdout =
             "Package Id      Version      Commands\n" +
             "-------------------------------------\n" +
             "cratis.cli      2.0.1        cratis\n";
 
-        var version = CliUpdate.ParseDotNetToolListVersion(stdout);
+        var version = CliUpdate.ParseDotNetToolListVersion(Stdout);
         version.ShouldEqual("2.0.1");
     }
 
     [Fact]
     void should_return_null_when_package_not_in_dotnet_tool_list_output()
     {
-        var stdout =
+        const string Stdout =
             "Package Id      Version      Commands\n" +
             "-------------------------------------\n" +
             "some.other.tool 1.0.0        other\n";
 
-        var version = CliUpdate.ParseDotNetToolListVersion(stdout);
+        var version = CliUpdate.ParseDotNetToolListVersion(Stdout);
         version.ShouldBeNull();
     }
 

--- a/Source/Cli.Specs/for_CliUpdate/when_parsing_installed_version.cs
+++ b/Source/Cli.Specs/for_CliUpdate/when_parsing_installed_version.cs
@@ -1,0 +1,52 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Cli.for_CliUpdate;
+
+public class when_parsing_installed_version : Specification
+{
+    [Fact]
+    void should_find_version_in_dotnet_tool_list_output()
+    {
+        var stdout =
+            "Package Id      Version      Commands\n" +
+            "-------------------------------------\n" +
+            "cratis.cli      2.0.1        cratis\n";
+
+        var version = CliUpdate.ParseDotNetToolListVersion(stdout);
+        version.ShouldEqual("2.0.1");
+    }
+
+    [Fact]
+    void should_return_null_when_package_not_in_dotnet_tool_list_output()
+    {
+        var stdout =
+            "Package Id      Version      Commands\n" +
+            "-------------------------------------\n" +
+            "some.other.tool 1.0.0        other\n";
+
+        var version = CliUpdate.ParseDotNetToolListVersion(stdout);
+        version.ShouldBeNull();
+    }
+
+    [Fact]
+    void should_find_latest_version_in_brew_list_output_with_single_version()
+    {
+        var version = CliUpdate.ParseBrewListVersion("cratis 2.0.1\n");
+        version.ShouldEqual("2.0.1");
+    }
+
+    [Fact]
+    void should_find_latest_version_in_brew_list_output_with_multiple_versions()
+    {
+        var version = CliUpdate.ParseBrewListVersion("cratis 1.6.3 2.0.1\n");
+        version.ShouldEqual("2.0.1");
+    }
+
+    [Fact]
+    void should_return_null_for_empty_brew_list_output()
+    {
+        var version = CliUpdate.ParseBrewListVersion(string.Empty);
+        version.ShouldBeNull();
+    }
+}

--- a/Source/Cli/CliUpdate.cs
+++ b/Source/Cli/CliUpdate.cs
@@ -151,6 +151,69 @@ public static class CliUpdate
         };
 
     /// <summary>
+    /// Queries the actually installed CLI version after an update has run, using the package
+    /// manager itself as the source of truth rather than a pre-update availability check.
+    /// </summary>
+    /// <param name="strategy">The detected update strategy.</param>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    /// <returns>The installed version if it could be determined, otherwise null.</returns>
+    public static async Task<string?> GetInstalledVersion(CliUpdateStrategy strategy, CancellationToken cancellationToken = default)
+    {
+        var startInfo = strategy switch
+        {
+            CliUpdateStrategy.DotNetTool => new ProcessStartInfo
+            {
+                FileName = "dotnet",
+                Arguments = "tool list -g",
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true
+            },
+            CliUpdateStrategy.Homebrew => new ProcessStartInfo
+            {
+                FileName = "brew",
+                Arguments = "list --versions cratis",
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true
+            },
+            _ => null
+        };
+
+        if (startInfo is null)
+        {
+            return null;
+        }
+
+        try
+        {
+            using var process = Process.Start(startInfo);
+            if (process is null)
+            {
+                return null;
+            }
+
+            var stdout = await process.StandardOutput.ReadToEndAsync(cancellationToken);
+            await process.WaitForExitAsync(cancellationToken);
+
+            if (process.ExitCode != 0)
+            {
+                return null;
+            }
+
+            return strategy == CliUpdateStrategy.DotNetTool
+                ? ParseDotNetToolListVersion(stdout)
+                : ParseBrewListVersion(stdout);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
     /// Gets update hint text for interactive output when a newer version is available.
     /// </summary>
     /// <param name="strategy">The detected strategy.</param>
@@ -196,6 +259,28 @@ public static class CliUpdate
         }
 
         return CliUpdateStrategy.Manual;
+    }
+
+    internal static string? ParseDotNetToolListVersion(string stdout)
+    {
+        foreach (var line in stdout.Split('\n'))
+        {
+            var columns = line.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+            if (columns.Length >= 2 && string.Equals(columns[0], PackageId, StringComparison.OrdinalIgnoreCase))
+            {
+                return columns[1];
+            }
+        }
+
+        return null;
+    }
+
+    internal static string? ParseBrewListVersion(string stdout)
+    {
+        var columns = stdout.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+
+        // "brew list --versions" can list more than one installed version; the last column is the newest.
+        return columns.Length >= 2 ? columns[^1].Trim() : null;
     }
 
     static bool IsDotNetToolPath(string? path) =>

--- a/Source/Cli/Commands/Version/SelfUpdateCommand.cs
+++ b/Source/Cli/Commands/Version/SelfUpdateCommand.cs
@@ -20,17 +20,23 @@ public class SelfUpdateCommand : AsyncCommand<SelfUpdateSettings>
     protected override async Task<int> ExecuteAsync(CommandContext context, SelfUpdateSettings settings, CancellationToken cancellationToken)
     {
         var format = ResolveFormat(settings.Output);
+        var isInteractive = string.Equals(format, OutputFormats.Table, StringComparison.Ordinal);
         var currentVersion = VersionCommand.GetCliVersion();
         var strategy = CliUpdate.DetectStrategy();
 
-        // Check for available updates before performing the update
+        // Check for available updates before performing the update. This is only used to
+        // show the user what to expect - the actual outcome is always verified afterward
+        // by asking the package manager what got installed, since this check can be stale
+        // (cached) or fail outright without that meaning the real update will also fail.
         var expectedNewVersion = settings.TargetVersion;
         if (string.IsNullOrWhiteSpace(expectedNewVersion))
         {
             using var updateCheckCts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
             try
             {
-                expectedNewVersion = await UpdateChecker.CheckForUpdate(UpdateChecker.CliPackageId, currentVersion, updateCheckCts.Token);
+                expectedNewVersion = await RunWithStatus(
+                    "Checking for updates...",
+                    () => UpdateChecker.CheckForUpdate(UpdateChecker.CliPackageId, currentVersion, updateCheckCts.Token));
             }
             catch
             {
@@ -38,15 +44,18 @@ public class SelfUpdateCommand : AsyncCommand<SelfUpdateSettings>
             }
         }
 
-        if (string.Equals(format, OutputFormats.Table, StringComparison.Ordinal))
+        if (isInteractive)
         {
-            AnsiConsole.MarkupLine($"[bold]Updating Cratis CLI...[/] (current: {currentVersion.EscapeMarkup()})");
+            var message = !string.IsNullOrWhiteSpace(expectedNewVersion)
+                ? $"[bold]Updating Cratis CLI...[/] ({currentVersion.EscapeMarkup()} -> {expectedNewVersion.EscapeMarkup()})"
+                : $"[bold]Updating Cratis CLI...[/] (current: {currentVersion.EscapeMarkup()})";
+            AnsiConsole.MarkupLine(message);
         }
 
         var preUpdateStartInfo = CliUpdate.CreatePreUpdateProcessStartInfo(strategy, settings.TargetVersion);
         if (preUpdateStartInfo is not null)
         {
-            var preUpdateResult = await RunProcess(preUpdateStartInfo);
+            var preUpdateResult = await RunWithStatus("Refreshing Homebrew...", () => RunProcess(preUpdateStartInfo));
             if (preUpdateResult is not null)
             {
                 return preUpdateResult.Value;
@@ -81,16 +90,20 @@ public class SelfUpdateCommand : AsyncCommand<SelfUpdateSettings>
             return ExitCodes.Success;
         }
 
-        var updateResult = await RunProcess(startInfo);
+        var updateResult = await RunWithStatus(
+            strategy == CliUpdateStrategy.Homebrew ? "Updating via Homebrew..." : "Updating via dotnet tool...",
+            () => RunProcess(startInfo));
         if (updateResult is not null)
         {
             return updateResult.Value;
         }
 
-        // Use the expected new version instead of checking the currently running assembly
-        // The currently running process won't change version until it's restarted
-        var newVersion = expectedNewVersion ?? currentVersion;
-        var wasUpdated = !string.IsNullOrWhiteSpace(expectedNewVersion);
+        // The currently running process won't reflect the new version until it's restarted, so
+        // ask the package manager directly what's actually installed now. This is the ground
+        // truth - the pre-update check above is only a hint and may not have found anything.
+        var installedVersion = await CliUpdate.GetInstalledVersion(strategy, cancellationToken);
+        var newVersion = installedVersion ?? expectedNewVersion ?? currentVersion;
+        var wasUpdated = !string.Equals(newVersion, currentVersion, StringComparison.OrdinalIgnoreCase);
 
         if (string.Equals(format, OutputFormats.Json, StringComparison.Ordinal) || string.Equals(format, OutputFormats.JsonCompact, StringComparison.Ordinal))
         {
@@ -140,6 +153,19 @@ public class SelfUpdateCommand : AsyncCommand<SelfUpdateSettings>
             }
 
             return null;
+        }
+
+        async Task<T> RunWithStatus<T>(string statusText, Func<Task<T>> action)
+        {
+            if (!isInteractive)
+            {
+                return await action();
+            }
+
+            return await AnsiConsole.Status()
+                .Spinner(Spinner.Known.Dots)
+                .SpinnerStyle(new Style(OutputFormatter.Accent))
+                .StartAsync(statusText, _ => action());
         }
     }
 

--- a/Source/Cli/Program.cs
+++ b/Source/Cli/Program.cs
@@ -28,13 +28,15 @@ var exitCode = await CliApp.Create().RunAsync(args);
 
 if (!ShouldSkipUpdateHint(args) &&
     !Console.IsOutputRedirected &&
-    !GlobalSettings.IsAiAgentEnvironment() &&
-    updateCheckTask.IsCompleted)
+    !GlobalSettings.IsAiAgentEnvironment())
 {
     try
     {
-        var latestVersion = await updateCheckTask;
-        if (latestVersion is not null)
+        // Most commands finish faster than the NuGet check, so give it a short grace
+        // window to catch up rather than only showing the hint when it happens to have
+        // finished already - otherwise the hint would rarely appear in practice.
+        await Task.WhenAny(updateCheckTask, Task.Delay(300));
+        if (updateCheckTask.IsCompletedSuccessfully && await updateCheckTask is { } latestVersion)
         {
             var strategy = CliUpdate.DetectStrategy();
             var hint = CliUpdate.GetUpdateHint(strategy, currentVersion, latestVersion);


### PR DESCRIPTION
## Fixed
- `cratis update` now verifies the actually installed version with the package manager after running, instead of trusting a pre-update NuGet availability check that could be stale or time out — fixing cases where it reported "already at the latest version" right after installing a newer one (#34)
- The "update available" hint shown after commands now reliably appears instead of only surfacing when the background check happened to finish before the command did

## Changed
- `cratis update` now shows a progress spinner while checking for and installing updates, and displays the target version up front when known