### PR TITLE
Fix the update hint going silent and checking the wrong source

### DIFF
--- a/Source/Cli.Specs/for_LatestVersion/when_normalizing_a_tag/and_it_carries_no_prefix.cs
+++ b/Source/Cli.Specs/for_LatestVersion/when_normalizing_a_tag/and_it_carries_no_prefix.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Cli.for_LatestVersion.when_normalizing_a_tag;
+
+public class and_it_carries_no_prefix : Specification
+{
+    string? _result;
+
+    void Because() => _result = LatestVersion.NormalizeTag("2.3.6");
+
+    [Fact] void should_keep_the_version() => _result.ShouldEqual("2.3.6");
+}

--- a/Source/Cli.Specs/for_LatestVersion/when_normalizing_a_tag/and_it_carries_the_release_prefix.cs
+++ b/Source/Cli.Specs/for_LatestVersion/when_normalizing_a_tag/and_it_carries_the_release_prefix.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Cli.for_LatestVersion.when_normalizing_a_tag;
+
+public class and_it_carries_the_release_prefix : Specification
+{
+    string? _result;
+
+    void Because() => _result = LatestVersion.NormalizeTag("v2.3.6");
+
+    [Fact] void should_drop_the_prefix() => _result.ShouldEqual("2.3.6");
+}

--- a/Source/Cli.Specs/for_LatestVersion/when_normalizing_a_tag/and_it_is_empty.cs
+++ b/Source/Cli.Specs/for_LatestVersion/when_normalizing_a_tag/and_it_is_empty.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Cli.for_LatestVersion.when_normalizing_a_tag;
+
+public class and_it_is_empty : Specification
+{
+    string? _result;
+
+    void Because() => _result = LatestVersion.NormalizeTag("   ");
+
+    [Fact] void should_have_nothing_to_report() => _result.ShouldBeNull();
+}

--- a/Source/Cli.Specs/for_LatestVersion/when_resolving_the_source/and_installed_as_a_dotnet_tool.cs
+++ b/Source/Cli.Specs/for_LatestVersion/when_resolving_the_source/and_installed_as_a_dotnet_tool.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Cli.for_LatestVersion.when_resolving_the_source;
+
+public class and_installed_as_a_dotnet_tool : Specification
+{
+    LatestVersionSource _result;
+
+    void Because() => _result = LatestVersion.SourceFor(CliUpdateStrategy.DotNetTool);
+
+    [Fact] void should_read_from_nuget() => _result.ShouldEqual(LatestVersionSource.NuGet);
+}

--- a/Source/Cli.Specs/for_LatestVersion/when_resolving_the_source/and_installed_as_a_linux_binary.cs
+++ b/Source/Cli.Specs/for_LatestVersion/when_resolving_the_source/and_installed_as_a_linux_binary.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Cli.for_LatestVersion.when_resolving_the_source;
+
+public class and_installed_as_a_linux_binary : Specification
+{
+    LatestVersionSource _result;
+
+    void Because() => _result = LatestVersion.SourceFor(CliUpdateStrategy.ManualLinux);
+
+    [Fact] void should_read_from_the_github_release() => _result.ShouldEqual(LatestVersionSource.GitHubRelease);
+}

--- a/Source/Cli.Specs/for_LatestVersion/when_resolving_the_source/and_installed_by_hand.cs
+++ b/Source/Cli.Specs/for_LatestVersion/when_resolving_the_source/and_installed_by_hand.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Cli.for_LatestVersion.when_resolving_the_source;
+
+public class and_installed_by_hand : Specification
+{
+    LatestVersionSource _result;
+
+    void Because() => _result = LatestVersion.SourceFor(CliUpdateStrategy.Manual);
+
+    [Fact] void should_read_from_the_github_release() => _result.ShouldEqual(LatestVersionSource.GitHubRelease);
+}

--- a/Source/Cli.Specs/for_LatestVersion/when_resolving_the_source/and_installed_with_homebrew.cs
+++ b/Source/Cli.Specs/for_LatestVersion/when_resolving_the_source/and_installed_with_homebrew.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Cli.for_LatestVersion.when_resolving_the_source;
+
+/// <summary>
+/// Homebrew upgrades from the tap, which the release workflow writes from a GitHub release - never NuGet.
+/// </summary>
+public class and_installed_with_homebrew : Specification
+{
+    LatestVersionSource _result;
+
+    void Because() => _result = LatestVersion.SourceFor(CliUpdateStrategy.Homebrew);
+
+    [Fact] void should_read_from_the_github_release() => _result.ShouldEqual(LatestVersionSource.GitHubRelease);
+}

--- a/Source/Cli.Specs/for_UpdateChecker/when_checking_freshness/and_an_update_has_been_waiting_over_a_day.cs
+++ b/Source/Cli.Specs/for_UpdateChecker/when_checking_freshness/and_an_update_has_been_waiting_over_a_day.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Cli.for_UpdateChecker.when_checking_freshness;
+
+public class and_an_update_has_been_waiting_over_a_day : Specification
+{
+    static readonly DateTime _now = new(2026, 7, 30, 20, 0, 0, DateTimeKind.Utc);
+
+    bool _result;
+
+    void Because() => _result = UpdateChecker.IsFresh("2.3.6", _now.AddHours(-25), "2.3.4", _now);
+
+    [Fact] void should_no_longer_be_trusted() => _result.ShouldBeFalse();
+}

--- a/Source/Cli.Specs/for_UpdateChecker/when_checking_freshness/and_an_update_is_waiting.cs
+++ b/Source/Cli.Specs/for_UpdateChecker/when_checking_freshness/and_an_update_is_waiting.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Cli.for_UpdateChecker.when_checking_freshness;
+
+/// <summary>
+/// An update stays available until the user installs it, so this answer survives far longer.
+/// </summary>
+public class and_an_update_is_waiting : Specification
+{
+    static readonly DateTime _now = new(2026, 7, 30, 20, 0, 0, DateTimeKind.Utc);
+
+    bool _result;
+
+    void Because() => _result = UpdateChecker.IsFresh("2.3.6", _now.AddHours(-12), "2.3.4", _now);
+
+    [Fact] void should_still_be_trusted() => _result.ShouldBeTrue();
+}

--- a/Source/Cli.Specs/for_UpdateChecker/when_checking_freshness/and_the_up_to_date_answer_has_aged.cs
+++ b/Source/Cli.Specs/for_UpdateChecker/when_checking_freshness/and_the_up_to_date_answer_has_aged.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Cli.for_UpdateChecker.when_checking_freshness;
+
+/// <summary>
+/// A check that lands in the window between a release being tagged and the package becoming visible records
+/// the previous version. Trusting that for a day means every release published after it goes unannounced for
+/// a day, which is exactly what happened between 2.3.4 and 2.3.6.
+/// </summary>
+public class and_the_up_to_date_answer_has_aged : Specification
+{
+    static readonly DateTime _now = new(2026, 7, 30, 20, 0, 0, DateTimeKind.Utc);
+
+    bool _result;
+
+    void Because() => _result = UpdateChecker.IsFresh("2.3.4", _now.AddHours(-2), "2.3.4", _now);
+
+    [Fact] void should_no_longer_be_trusted() => _result.ShouldBeFalse();
+}

--- a/Source/Cli.Specs/for_UpdateChecker/when_checking_freshness/and_the_up_to_date_answer_is_recent.cs
+++ b/Source/Cli.Specs/for_UpdateChecker/when_checking_freshness/and_the_up_to_date_answer_is_recent.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Cli.for_UpdateChecker.when_checking_freshness;
+
+public class and_the_up_to_date_answer_is_recent : Specification
+{
+    static readonly DateTime _now = new(2026, 7, 30, 20, 0, 0, DateTimeKind.Utc);
+
+    bool _result;
+
+    void Because() => _result = UpdateChecker.IsFresh("2.3.4", _now.AddMinutes(-30), "2.3.4", _now);
+
+    [Fact] void should_still_be_trusted() => _result.ShouldBeTrue();
+}

--- a/Source/Cli.Specs/for_UpdateChecker/when_checking_freshness/and_the_user_has_updated_past_the_cached_answer.cs
+++ b/Source/Cli.Specs/for_UpdateChecker/when_checking_freshness/and_the_user_has_updated_past_the_cached_answer.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Cli.for_UpdateChecker.when_checking_freshness;
+
+/// <summary>
+/// The cached answer is now behind what is installed, so it says nothing about what comes next.
+/// </summary>
+public class and_the_user_has_updated_past_the_cached_answer : Specification
+{
+    static readonly DateTime _now = new(2026, 7, 30, 20, 0, 0, DateTimeKind.Utc);
+
+    bool _result;
+
+    void Because() => _result = UpdateChecker.IsFresh("2.3.4", _now.AddHours(-2), "2.3.6", _now);
+
+    [Fact] void should_no_longer_be_trusted() => _result.ShouldBeFalse();
+}

--- a/Source/Cli.Specs/for_UpdateChecker/when_keying_the_cache/and_the_source_is_nuget.cs
+++ b/Source/Cli.Specs/for_UpdateChecker/when_keying_the_cache/and_the_source_is_nuget.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Cli.for_UpdateChecker.when_keying_the_cache;
+
+public class and_the_source_is_nuget : Specification
+{
+    string _result = null!;
+
+    void Because() => _result = UpdateChecker.CacheKeyFor(LatestVersionSource.NuGet, UpdateChecker.CliPackageId);
+
+    [Fact] void should_key_by_the_package() => _result.ShouldEqual(UpdateChecker.CliPackageId);
+}

--- a/Source/Cli.Specs/for_UpdateChecker/when_keying_the_cache/and_the_source_is_the_github_release.cs
+++ b/Source/Cli.Specs/for_UpdateChecker/when_keying_the_cache/and_the_source_is_the_github_release.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Cli.for_UpdateChecker.when_keying_the_cache;
+
+/// <summary>
+/// Keyed apart from the package so an answer read from NuGet is never served to a native installation.
+/// </summary>
+public class and_the_source_is_the_github_release : Specification
+{
+    string _result = null!;
+
+    void Because() => _result = UpdateChecker.CacheKeyFor(LatestVersionSource.GitHubRelease, UpdateChecker.CliPackageId);
+
+    [Fact] void should_not_collide_with_the_package_key() => _result.ShouldNotEqual(UpdateChecker.CliPackageId);
+}

--- a/Source/Cli/Commands/Version/SelfUpdateCommand.cs
+++ b/Source/Cli/Commands/Version/SelfUpdateCommand.cs
@@ -34,9 +34,11 @@ public class SelfUpdateCommand : AsyncCommand<SelfUpdateSettings>
             using var updateCheckCts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
             try
             {
+                // Asking for an update is the user saying the cached answer is not good enough, so this one
+                // always goes to the source.
                 expectedNewVersion = await RunWithStatus(
                     "Checking for updates...",
-                    () => UpdateChecker.CheckForUpdate(currentVersion, updateCheckCts.Token));
+                    () => UpdateChecker.CheckForCliUpdate(currentVersion, true, updateCheckCts.Token));
             }
             catch
             {

--- a/Source/Cli/Commands/Version/SelfUpdateCommand.cs
+++ b/Source/Cli/Commands/Version/SelfUpdateCommand.cs
@@ -36,7 +36,7 @@ public class SelfUpdateCommand : AsyncCommand<SelfUpdateSettings>
             {
                 expectedNewVersion = await RunWithStatus(
                     "Checking for updates...",
-                    () => UpdateChecker.CheckForUpdate(UpdateChecker.CliPackageId, currentVersion, updateCheckCts.Token));
+                    () => UpdateChecker.CheckForUpdate(currentVersion, updateCheckCts.Token));
             }
             catch
             {

--- a/Source/Cli/Commands/Version/VersionCommand.cs
+++ b/Source/Cli/Commands/Version/VersionCommand.cs
@@ -49,9 +49,10 @@ public class VersionCommand : AsyncCommand<ChronicleSettings>
             // Server unavailable, misconfigured, or doesn't support GetVersionInfo — all fine.
         }
 
-        // Check NuGet for newer versions — both fire in parallel and never block on failure.
+        // Check for newer versions — both fire in parallel and never block on failure. The CLI is checked
+        // against wherever this installation updates from, the server against its NuGet package.
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
-        var cliUpdateTask = UpdateChecker.CheckForUpdate(UpdateChecker.CliPackageId, cliVersion, cts.Token);
+        var cliUpdateTask = UpdateChecker.CheckForUpdate(cliVersion, cts.Token);
         var serverUpdateTask = serverInfo is not null
             ? UpdateChecker.CheckForUpdate(UpdateChecker.ServerPackageId, serverInfo.Version, cts.Token)
             : Task.FromResult<string?>(null);

--- a/Source/Cli/LatestVersion.cs
+++ b/Source/Cli/LatestVersion.cs
@@ -1,0 +1,121 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Cli;
+
+/// <summary>
+/// Reads the latest published version from the places a CLI installation can come from.
+/// </summary>
+public static class LatestVersion
+{
+    /// <summary>
+    /// The GitHub repository the native downloads and the Homebrew formula are released from.
+    /// </summary>
+    public const string GitHubRepository = "Cratis/cli";
+
+    static readonly TimeSpan _timeout = TimeSpan.FromSeconds(5);
+
+    /// <summary>
+    /// Resolves the place an installation updating through the given strategy should be compared against.
+    /// </summary>
+    /// <param name="strategy">The detected update strategy.</param>
+    /// <returns>The <see cref="LatestVersionSource"/> to read from.</returns>
+    /// <remarks>
+    /// Only the dotnet tool installs from NuGet. Every native installation - Homebrew, the Linux tarball, or a
+    /// binary put somewhere by hand - is built from a GitHub release, so that is the version those have to be
+    /// told about. The Homebrew formula is written by the same workflow after the release exists, which means
+    /// the release can never be behind the tap.
+    /// </remarks>
+    public static LatestVersionSource SourceFor(CliUpdateStrategy strategy) =>
+        strategy == CliUpdateStrategy.DotNetTool
+            ? LatestVersionSource.NuGet
+            : LatestVersionSource.GitHubRelease;
+
+    /// <summary>
+    /// Reads the latest stable version of a package from NuGet.
+    /// </summary>
+    /// <param name="packageId">The NuGet package identifier.</param>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    /// <returns>The latest stable version, or null when it could not be read.</returns>
+    public static async Task<string?> FromNuGet(string packageId, CancellationToken cancellationToken = default)
+    {
+        using var http = new HttpClient { Timeout = _timeout };
+        var url = $"https://api.nuget.org/v3-flatcontainer/{packageId.ToLowerInvariant()}/index.json";
+        var response = await http.GetAsync(url, cancellationToken);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            return null;
+        }
+
+        var json = await response.Content.ReadAsStringAsync(cancellationToken);
+        using var document = JsonDocument.Parse(json);
+
+        if (!document.RootElement.TryGetProperty("versions", out var versions) ||
+            versions.ValueKind != JsonValueKind.Array)
+        {
+            return null;
+        }
+
+        // NuGet returns versions in ascending order; the last stable version is what we want.
+        string? latest = null;
+
+        foreach (var v in versions.EnumerateArray())
+        {
+            var versionString = v.GetString();
+            if (versionString?.Contains('-') == false)
+            {
+                latest = versionString;
+            }
+        }
+
+        return latest;
+    }
+
+    /// <summary>
+    /// Reads the version of the latest GitHub release.
+    /// </summary>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    /// <returns>The latest released version, or null when it could not be read.</returns>
+    public static async Task<string?> FromGitHubRelease(CancellationToken cancellationToken = default)
+    {
+        using var http = new HttpClient { Timeout = _timeout };
+
+        // GitHub rejects requests without a user agent, and serves the release metadata under its own media type.
+        http.DefaultRequestHeaders.UserAgent.ParseAdd("Cratis.Cli");
+        http.DefaultRequestHeaders.Accept.ParseAdd("application/vnd.github+json");
+
+        var url = $"https://api.github.com/repos/{GitHubRepository}/releases/latest";
+        var response = await http.GetAsync(url, cancellationToken);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            return null;
+        }
+
+        var json = await response.Content.ReadAsStringAsync(cancellationToken);
+        using var document = JsonDocument.Parse(json);
+
+        return document.RootElement.TryGetProperty("tag_name", out var tag)
+            ? NormalizeTag(tag.GetString())
+            : null;
+    }
+
+    /// <summary>
+    /// Turns a release tag into a comparable version.
+    /// </summary>
+    /// <param name="tagName">The tag name, which the release workflow writes as <c>v{version}</c>.</param>
+    /// <returns>The version without the tag prefix, or null when there was nothing to read.</returns>
+    internal static string? NormalizeTag(string? tagName)
+    {
+        if (string.IsNullOrWhiteSpace(tagName))
+        {
+            return null;
+        }
+
+        var trimmed = tagName.Trim();
+        return trimmed.StartsWith('v') || trimmed.StartsWith('V')
+            ? trimmed[1..]
+            : trimmed;
+    }
+}

--- a/Source/Cli/LatestVersionSource.cs
+++ b/Source/Cli/LatestVersionSource.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Cli;
+
+/// <summary>
+/// Represents where the latest available version of the CLI should be read from.
+/// </summary>
+/// <remarks>
+/// An installation has to be compared against the place it actually updates from. A tool installed with
+/// <c>dotnet tool install</c> updates from NuGet, while the native downloads - Homebrew included - update from
+/// the GitHub releases. Those are published by separate jobs and do not become visible at the same moment.
+/// </remarks>
+public enum LatestVersionSource
+{
+    /// <summary>
+    /// Read the latest version from the NuGet package feed.
+    /// </summary>
+    NuGet,
+
+    /// <summary>
+    /// Read the latest version from the GitHub releases.
+    /// </summary>
+    GitHubRelease
+}

--- a/Source/Cli/Program.cs
+++ b/Source/Cli/Program.cs
@@ -4,9 +4,12 @@
 using Cratis.Cli;
 using Cratis.Cli.Commands.Version;
 
-using var updateCts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
 var currentVersion = VersionCommand.GetCliVersion();
-var updateCheckTask = UpdateChecker.CheckForUpdate(currentVersion, updateCts.Token);
+
+// The request carries its own five second timeout. A deadline measured from here would instead be spent while
+// the command runs, so anything slower than that - the workbench, a run, generating a screenplay - would cancel
+// the check before it ever finished, leaving both the hint and the cached answer permanently out of reach.
+var updateCheckTask = UpdateChecker.CheckForUpdate(currentVersion);
 
 if (args.Length == 0 && !Console.IsOutputRedirected && !GlobalSettings.IsAiAgentEnvironment())
 {

--- a/Source/Cli/UpdateChecker.cs
+++ b/Source/Cli/UpdateChecker.cs
@@ -29,7 +29,8 @@ public static class UpdateChecker
     /// </summary>
     public const string DisableEnvVar = "CRATIS_NO_UPDATE_CHECK";
 
-    static readonly TimeSpan _checkInterval = TimeSpan.FromHours(24);
+    static readonly TimeSpan _updateAvailableInterval = TimeSpan.FromHours(24);
+    static readonly TimeSpan _upToDateInterval = TimeSpan.FromHours(1);
     static readonly JsonSerializerOptions _cacheJsonOptions = new() { WriteIndented = true };
 
     /// <summary>
@@ -52,17 +53,28 @@ public static class UpdateChecker
     /// <param name="currentVersion">The current CLI version.</param>
     /// <param name="cancellationToken">A cancellation token for timeout control.</param>
     /// <returns>The latest version string if newer, otherwise null.</returns>
+    public static Task<string?> CheckForUpdate(string currentVersion, CancellationToken cancellationToken = default)
+        => CheckForCliUpdate(currentVersion, false, cancellationToken);
+
+    /// <summary>
+    /// Checks whether a newer version of the CLI is available, from the place this installation updates from.
+    /// </summary>
+    /// <param name="currentVersion">The current CLI version.</param>
+    /// <param name="bypassCache">Whether to ask the source directly rather than trusting the cached answer.</param>
+    /// <param name="cancellationToken">A cancellation token for timeout control.</param>
+    /// <returns>The latest version string if newer, otherwise null.</returns>
     /// <remarks>
     /// A dotnet tool is compared against NuGet and a native installation against the GitHub releases, because
     /// those are published separately and comparing against the wrong one reports an update that the user's own
     /// update command cannot yet install, or none when one is waiting.
     /// </remarks>
-    public static Task<string?> CheckForUpdate(string currentVersion, CancellationToken cancellationToken = default)
+    public static async Task<string?> CheckForCliUpdate(string currentVersion, bool bypassCache, CancellationToken cancellationToken = default)
     {
         var source = LatestVersion.SourceFor(CliUpdate.DetectStrategy());
-        return Check(
+        return await Check(
             CacheKeyFor(source, CliPackageId),
             currentVersion,
+            bypassCache,
             token => source == LatestVersionSource.NuGet
                 ? LatestVersion.FromNuGet(CliPackageId, token)
                 : LatestVersion.FromGitHubRelease(token),
@@ -80,7 +92,7 @@ public static class UpdateChecker
     /// <param name="cancellationToken">A cancellation token for timeout control.</param>
     /// <returns>The latest version string if newer, otherwise null.</returns>
     public static Task<string?> CheckForUpdate(string packageId, string currentVersion, CancellationToken cancellationToken = default) =>
-        Check(packageId, currentVersion, token => LatestVersion.FromNuGet(packageId, token), cancellationToken);
+        Check(packageId, currentVersion, false, token => LatestVersion.FromNuGet(packageId, token), cancellationToken);
 
     /// <summary>
     /// Gets the cache key an answer read from the given source is stored under.
@@ -94,6 +106,23 @@ public static class UpdateChecker
     /// </remarks>
     internal static string CacheKeyFor(LatestVersionSource source, string packageId) =>
         source == LatestVersionSource.NuGet ? packageId : $"github:{LatestVersion.GitHubRepository}";
+
+    /// <summary>
+    /// Determines whether a cached answer can still be trusted.
+    /// </summary>
+    /// <param name="cachedLatestVersion">The latest version recorded when the check ran.</param>
+    /// <param name="checkedAt">When the check ran.</param>
+    /// <param name="currentVersion">The version currently installed.</param>
+    /// <param name="utcNow">The current time, in UTC.</param>
+    /// <returns>True when the cached answer is still fresh enough to serve.</returns>
+    /// <remarks>
+    /// The two answers do not go stale at the same rate. "An update is available" stays true until the user
+    /// updates, so it is held for a day. "You are up to date" stops being true the moment a release happens,
+    /// and a check landing in the window between the release and the package becoming visible records the
+    /// previous version - holding that for a day means the release goes unannounced for a day.
+    /// </remarks>
+    internal static bool IsFresh(string cachedLatestVersion, DateTime checkedAt, string currentVersion, DateTime utcNow) =>
+        utcNow - checkedAt < (IsNewer(cachedLatestVersion, currentVersion) ? _updateAvailableInterval : _upToDateInterval);
 
     /// <summary>
     /// Determines whether the latest version is newer than the current version.
@@ -114,6 +143,7 @@ public static class UpdateChecker
     static async Task<string?> Check(
         string cacheKey,
         string currentVersion,
+        bool bypassCache,
         Func<CancellationToken, Task<string?>> fetch,
         CancellationToken cancellationToken)
     {
@@ -123,8 +153,9 @@ public static class UpdateChecker
         }
 
         var cache = ReadCache();
-        if (cache?.Packages.TryGetValue(cacheKey, out var entry) == true &&
-            DateTime.UtcNow - entry.CheckedAt < _checkInterval)
+        if (!bypassCache &&
+            cache?.Packages.TryGetValue(cacheKey, out var entry) == true &&
+            IsFresh(entry.LatestVersion, entry.CheckedAt, currentVersion, DateTime.UtcNow))
         {
             return IsNewer(entry.LatestVersion, currentVersion) ? entry.LatestVersion : null;
         }

--- a/Source/Cli/UpdateChecker.cs
+++ b/Source/Cli/UpdateChecker.cs
@@ -4,9 +4,13 @@
 namespace Cratis.Cli;
 
 /// <summary>
-/// Checks NuGet for the latest available version of a package and caches the result.
-/// The check runs at most once per configured interval to avoid slowing down every command.
+/// Checks whether a newer version is available and caches the result, so that the check runs at most once per
+/// interval rather than on every command.
 /// </summary>
+/// <remarks>
+/// The CLI's own version is read from wherever the running installation updates from - NuGet for a dotnet tool,
+/// the GitHub releases for the native downloads - while other packages are read from NuGet.
+/// </remarks>
 public static class UpdateChecker
 {
     /// <summary>
@@ -43,13 +47,27 @@ public static class UpdateChecker
         Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".cratis", "version-check.json");
 
     /// <summary>
-    /// Checks whether a newer version of the CLI is available.
+    /// Checks whether a newer version of the CLI is available, from the place this installation updates from.
     /// </summary>
     /// <param name="currentVersion">The current CLI version.</param>
     /// <param name="cancellationToken">A cancellation token for timeout control.</param>
     /// <returns>The latest version string if newer, otherwise null.</returns>
+    /// <remarks>
+    /// A dotnet tool is compared against NuGet and a native installation against the GitHub releases, because
+    /// those are published separately and comparing against the wrong one reports an update that the user's own
+    /// update command cannot yet install, or none when one is waiting.
+    /// </remarks>
     public static Task<string?> CheckForUpdate(string currentVersion, CancellationToken cancellationToken = default)
-        => CheckForUpdate(CliPackageId, currentVersion, cancellationToken);
+    {
+        var source = LatestVersion.SourceFor(CliUpdate.DetectStrategy());
+        return Check(
+            CacheKeyFor(source, CliPackageId),
+            currentVersion,
+            token => source == LatestVersionSource.NuGet
+                ? LatestVersion.FromNuGet(CliPackageId, token)
+                : LatestVersion.FromGitHubRelease(token),
+            cancellationToken);
+    }
 
     /// <summary>
     /// Checks whether a newer version of the specified NuGet package is available.
@@ -61,39 +79,21 @@ public static class UpdateChecker
     /// <param name="currentVersion">The current version.</param>
     /// <param name="cancellationToken">A cancellation token for timeout control.</param>
     /// <returns>The latest version string if newer, otherwise null.</returns>
-    public static async Task<string?> CheckForUpdate(string packageId, string currentVersion, CancellationToken cancellationToken = default)
-    {
-        if (IsDisabled())
-        {
-            return null;
-        }
+    public static Task<string?> CheckForUpdate(string packageId, string currentVersion, CancellationToken cancellationToken = default) =>
+        Check(packageId, currentVersion, token => LatestVersion.FromNuGet(packageId, token), cancellationToken);
 
-        var cache = ReadCache();
-        if (cache?.Packages.TryGetValue(packageId, out var entry) == true &&
-            DateTime.UtcNow - entry.CheckedAt < _checkInterval)
-        {
-            return IsNewer(entry.LatestVersion, currentVersion) ? entry.LatestVersion : null;
-        }
-
-        try
-        {
-            var latestVersion = await FetchLatestVersion(packageId, cancellationToken);
-            if (latestVersion is null)
-            {
-                return null;
-            }
-
-            cache ??= new VersionCache();
-            cache.Packages[packageId] = new PackageVersionEntry(latestVersion, DateTime.UtcNow);
-            WriteCache(cache);
-
-            return IsNewer(latestVersion, currentVersion) ? latestVersion : null;
-        }
-        catch
-        {
-            return null;
-        }
-    }
+    /// <summary>
+    /// Gets the cache key an answer read from the given source is stored under.
+    /// </summary>
+    /// <param name="source">The source the answer came from.</param>
+    /// <param name="packageId">The package identifier, used when reading from NuGet.</param>
+    /// <returns>The cache key.</returns>
+    /// <remarks>
+    /// The sources are keyed apart so an answer read from one is never served for the other - the same
+    /// installation can change how it updates, and the two do not publish at the same moment.
+    /// </remarks>
+    internal static string CacheKeyFor(LatestVersionSource source, string packageId) =>
+        source == LatestVersionSource.NuGet ? packageId : $"github:{LatestVersion.GitHubRepository}";
 
     /// <summary>
     /// Determines whether the latest version is newer than the current version.
@@ -111,39 +111,42 @@ public static class UpdateChecker
                latestVer > currentVer;
     }
 
-    static async Task<string?> FetchLatestVersion(string packageId, CancellationToken cancellationToken)
+    static async Task<string?> Check(
+        string cacheKey,
+        string currentVersion,
+        Func<CancellationToken, Task<string?>> fetch,
+        CancellationToken cancellationToken)
     {
-        using var http = new HttpClient { Timeout = TimeSpan.FromSeconds(5) };
-        var url = $"https://api.nuget.org/v3-flatcontainer/{packageId.ToLowerInvariant()}/index.json";
-        var response = await http.GetAsync(url, cancellationToken);
-
-        if (!response.IsSuccessStatusCode)
+        if (IsDisabled())
         {
             return null;
         }
 
-        var json = await response.Content.ReadAsStringAsync(cancellationToken);
-        using var document = JsonDocument.Parse(json);
-
-        if (!document.RootElement.TryGetProperty("versions", out var versions) ||
-            versions.ValueKind != JsonValueKind.Array)
+        var cache = ReadCache();
+        if (cache?.Packages.TryGetValue(cacheKey, out var entry) == true &&
+            DateTime.UtcNow - entry.CheckedAt < _checkInterval)
         {
-            return null;
+            return IsNewer(entry.LatestVersion, currentVersion) ? entry.LatestVersion : null;
         }
 
-        // NuGet returns versions in ascending order; the last stable version is what we want.
-        string? latest = null;
-
-        foreach (var v in versions.EnumerateArray())
+        try
         {
-            var versionString = v.GetString();
-            if (versionString?.Contains('-') == false)
+            var latestVersion = await fetch(cancellationToken);
+            if (latestVersion is null)
             {
-                latest = versionString;
+                return null;
             }
-        }
 
-        return latest;
+            cache ??= new VersionCache();
+            cache.Packages[cacheKey] = new PackageVersionEntry(latestVersion, DateTime.UtcNow);
+            WriteCache(cache);
+
+            return IsNewer(latestVersion, currentVersion) ? latestVersion : null;
+        }
+        catch
+        {
+            return null;
+        }
     }
 
     static VersionCache? ReadCache()


### PR DESCRIPTION
# Summary

The "update available" hint could stay silent for a day after a release, and never matched how a Homebrew install actually updates.

## Fixed

- The update hint no longer stays silent for up to 24 hours after a release. An "up to date" answer is now re-checked within the hour, so a check that ran moments before a release no longer hides every release after it.
- Homebrew and other native installs are now checked against the GitHub releases they actually update from, rather than the NuGet package they never install.
- `cratis update` now always asks the source rather than trusting a cached answer.
- The update hint no longer goes missing after commands that take more than five seconds, such as `workbench`, `run`, and `screenplay generate`.
