### PR TITLE
Describe each application of a solution as its own module

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,7 +5,7 @@
   </PropertyGroup>
   <ItemGroup>
     <!-- Cratis -->
-    <PackageVersion Include="Cratis.Arc.Screenplay" Version="20.66.0" />
+    <PackageVersion Include="Cratis.Arc.Screenplay" Version="20.68.0" />
     <PackageVersion Include="Cratis.Chronicle.Connections" Version="16.11.0" />
     <PackageVersion Include="Cratis.Chronicle.Contracts" Version="16.11.0" />
     <PackageVersion Include="Cratis.Fundamentals" Version="7.16.6" />


### PR DESCRIPTION
# Summary

Generating from a solution described every application in it as one module named after the solution file.

## Changed

- `cratis screenplay generate` run against a solution now describes each application in it as its own module, taken from the outermost namespace segment, rather than gathering them all into one module named after the solution. Passing `--module` still produces that single module, and generating from a single project is unchanged.
