### PR TITLE
Lift the Chronicle pin to 16.30.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,5 +32,17 @@ jobs:
       - name: Build
         run: dotnet build --configuration Release
 
+      # The integration fixture starts a Chronicle container whose image is named after the Chronicle
+      # package version, so a version bump always faces a cold ~400MB pull. Testcontainers times the first
+      # start attempt out while that pull is running, and every retry then collides with the port the
+      # timed-out attempt is still holding — surfacing as "Bind for 0.0.0.0:27018 failed: port is already
+      # allocated", which reads like a code failure and is not one. Pulling first takes the download off
+      # the start clock.
+      - name: Pull the Chronicle test image
+        run: |
+          VERSION=$(grep -oE 'Include="Cratis.Chronicle.Connections" Version="[^"]+"' Directory.Packages.props | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
+          echo "Pulling cratis/chronicle:$VERSION-development"
+          docker pull "cratis/chronicle:$VERSION-development"
+
       - name: Test
         run: dotnet test --configuration Release

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,8 +6,8 @@
   <ItemGroup>
     <!-- Cratis -->
     <PackageVersion Include="Cratis.Arc.Screenplay" Version="21.2.0" />
-    <PackageVersion Include="Cratis.Chronicle.Connections" Version="16.19.3" />
-    <PackageVersion Include="Cratis.Chronicle.Contracts" Version="16.19.3" />
+    <PackageVersion Include="Cratis.Chronicle.Connections" Version="16.30.1" />
+    <PackageVersion Include="Cratis.Chronicle.Contracts" Version="16.30.1" />
     <PackageVersion Include="Cratis.Fundamentals" Version="7.17.1" />
     <!-- Prologue -->
     <PackageVersion Include="Cratis.Prologue.Configuration" Version="1.2.0" />
@@ -47,7 +47,7 @@
     <!-- Testing -->
     <PackageVersion Include="Cratis.Specifications" Version="4.0.0" />
     <PackageVersion Include="Cratis.Specifications.XUnit" Version="4.0.0" />
-    <PackageVersion Include="Cratis.Chronicle.XUnit.Integration" Version="16.19.3" />
+    <PackageVersion Include="Cratis.Chronicle.XUnit.Integration" Version="16.30.1" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />

--- a/Integration/Chronicle/ChronicleOutOfProcessFixtureWithLocalImage.cs
+++ b/Integration/Chronicle/ChronicleOutOfProcessFixtureWithLocalImage.cs
@@ -77,8 +77,14 @@ public class ChronicleOutOfProcessFixtureWithLocalImage : ChronicleOutOfProcessF
     /// <inheritdoc/>
     protected override IContainer BuildContainer(INetwork network)
     {
+        // Two minutes rather than fifteen seconds. Chronicle serves HTTPS about twelve seconds after start on
+        // a warm image and a fast machine, which left no margin at all on a two-core runner - and running out
+        // of it does not report a timeout. Testcontainers retries the start ten times, and the container from
+        // the attempt that timed out is still holding the published ports, so every retry fails with
+        // "Bind for 0.0.0.0:27018 failed: port is already allocated" and the real cause never appears.
+        // Waiting longer costs nothing when the container is quick: the strategy returns as soon as it answers.
         var waitStrategy = Wait.ForUnixContainer()
-            .AddCustomWaitStrategy(new HttpsHealthWait(35000), s => s.WithTimeout(TimeSpan.FromSeconds(15)));
+            .AddCustomWaitStrategy(new HttpsHealthWait(35000), s => s.WithTimeout(TimeSpan.FromMinutes(2)));
 
         var builder = new ContainerBuilder(ChronicleImageName);
         builder = ConfigureImage(builder)


### PR DESCRIPTION
## Changed

- Chronicle moves from 16.19.3 to 16.30.1, which restores connecting to a development server with no certificate setup. (#67)
