### PR TITLE
Move to Cratis.Arc.Screenplay 21.14.2

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,7 +5,7 @@
   </PropertyGroup>
   <ItemGroup>
     <!-- Cratis -->
-    <PackageVersion Include="Cratis.Arc.Screenplay" Version="21.2.0" />
+    <PackageVersion Include="Cratis.Arc.Screenplay" Version="21.14.2" />
     <PackageVersion Include="Cratis.Chronicle.Connections" Version="16.30.1" />
     <PackageVersion Include="Cratis.Chronicle.Contracts" Version="16.30.1" />
     <PackageVersion Include="Cratis.Fundamentals" Version="7.17.1" />


### PR DESCRIPTION
## Fixed

- `cratis screenplay generate` no longer captures projections declared inside specifications as though the application shipped them, which made a read model appear to be built more than once and stopped the generated document from compiling.
