### PR TITLE
Add 'cratis render' as a root command

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,7 +5,6 @@
   </PropertyGroup>
   <ItemGroup>
     <!-- Cratis -->
-    <PackageVersion Include="Cratis" Version="21.13.0" />
     <PackageVersion Include="Cratis.Arc.Screenplay" Version="21.14.2" />
     <PackageVersion Include="Cratis.Chronicle.Connections" Version="16.30.1" />
     <PackageVersion Include="Cratis.Chronicle.Contracts" Version="16.30.1" />
@@ -17,9 +16,8 @@
     <PackageVersion Include="Cratis.Prologue.Interpreter.Contracts" Version="1.2.0" />
     <PackageVersion Include="Cratis.Prologue.Screenplay" Version="1.2.0" />
     <PackageVersion Include="Cratis.Screenplay" Version="2.1.0" />
-    <PackageVersion Include="Cratis.Stage.Contracts" Version="2.3.0" />
-    <PackageVersion Include="NuGet.Frameworks" Version="6.13.2" />
-    <PackageVersion Include="Cratis.Stage.Rendering.Cratis" Version="2.3.0" />
+    <PackageVersion Include="Cratis.Stage.Contracts" Version="2.4.0" />
+    <PackageVersion Include="Cratis.Stage.Rendering.Cratis" Version="2.4.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.10" />
     <!-- CLI -->
     <PackageVersion Include="MongoDB.Driver" Version="3.10.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,6 +5,7 @@
   </PropertyGroup>
   <ItemGroup>
     <!-- Cratis -->
+    <PackageVersion Include="Cratis" Version="21.13.0" />
     <PackageVersion Include="Cratis.Arc.Screenplay" Version="21.2.0" />
     <PackageVersion Include="Cratis.Chronicle.Connections" Version="16.19.3" />
     <PackageVersion Include="Cratis.Chronicle.Contracts" Version="16.19.3" />
@@ -16,6 +17,9 @@
     <PackageVersion Include="Cratis.Prologue.Interpreter.Contracts" Version="1.2.0" />
     <PackageVersion Include="Cratis.Prologue.Screenplay" Version="1.2.0" />
     <PackageVersion Include="Cratis.Screenplay" Version="2.1.0" />
+    <PackageVersion Include="Cratis.Stage.Contracts" Version="2.3.0" />
+    <PackageVersion Include="NuGet.Frameworks" Version="6.13.2" />
+    <PackageVersion Include="Cratis.Stage.Rendering.Cratis" Version="2.3.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.10" />
     <!-- CLI -->
     <PackageVersion Include="MongoDB.Driver" Version="3.10.0" />

--- a/Source/Cli.Specs/Cli.Specs.csproj
+++ b/Source/Cli.Specs/Cli.Specs.csproj
@@ -13,12 +13,6 @@
     </ItemGroup>
 
     <ItemGroup>
-        <!--
-            Taken directly only to keep its build assets out: the Cratis package's global usings reach this project
-            transitively through the renderer the CLI now references, and they make CommandContext and
-            ObserverRunningState ambiguous against what these specs already import (Cratis/Stage#34).
-        -->
-        <PackageReference Include="Cratis" ExcludeAssets="build;buildTransitive;analyzers" />
         <!-- MSBuildLocator refuses to run with a copy of this beside the test host; it comes from the SDK. -->
         <PackageReference Include="Microsoft.Build.Framework" ExcludeAssets="runtime" PrivateAssets="all" />
         <PackageReference Include="Cratis.Specifications.XUnit" />

--- a/Source/Cli.Specs/Cli.Specs.csproj
+++ b/Source/Cli.Specs/Cli.Specs.csproj
@@ -13,6 +13,14 @@
     </ItemGroup>
 
     <ItemGroup>
+        <!--
+            Taken directly only to keep its build assets out: the Cratis package's global usings reach this project
+            transitively through the renderer the CLI now references, and they make CommandContext and
+            ObserverRunningState ambiguous against what these specs already import (Cratis/Stage#34).
+        -->
+        <PackageReference Include="Cratis" ExcludeAssets="build;buildTransitive;analyzers" />
+        <!-- MSBuildLocator refuses to run with a copy of this beside the test host; it comes from the SDK. -->
+        <PackageReference Include="Microsoft.Build.Framework" ExcludeAssets="runtime" PrivateAssets="all" />
         <PackageReference Include="Cratis.Specifications.XUnit" />
         <PackageReference Include="xunit" />
         <PackageReference Include="xunit.runner.visualstudio" />

--- a/Source/Cli.Specs/Usings.cs
+++ b/Source/Cli.Specs/Usings.cs
@@ -9,6 +9,7 @@ global using Cratis.Cli.Commands.Completions;
 global using Cratis.Cli.Commands.Init;
 global using Cratis.Cli.Commands.Llm;
 global using Cratis.Cli.Commands.Prologue;
+global using Cratis.Cli.Commands.Render;
 global using Cratis.Cli.Commands.Run;
 global using Cratis.Cli.Commands.Screenplay;
 global using Cratis.Specifications;

--- a/Source/Cli.Specs/for_RenderCommand/given/a_render_command.cs
+++ b/Source/Cli.Specs/for_RenderCommand/given/a_render_command.cs
@@ -1,0 +1,56 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Cli.for_RenderCommand.given;
+
+/// <summary>
+/// Base context that puts a document in a temporary folder and substitutes the rendering.
+/// </summary>
+public class a_render_command : Specification
+{
+    protected string _folder;
+    protected string _document;
+    protected string _previousDirectory;
+    protected IScreenplayRendering _rendering;
+    protected RenderCommand _command;
+    protected RenderSettings _settings;
+
+    void Establish()
+    {
+        var created = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString())).FullName;
+        _previousDirectory = Directory.GetCurrentDirectory();
+        Directory.SetCurrentDirectory(created);
+
+        // Read the folder back so that specs compare against the same fully resolved path the command sees —
+        // the temp folder is reached through a symbolic link on macOS.
+        _folder = Directory.GetCurrentDirectory();
+        _document = Path.Combine(_folder, "MyApp.play");
+        File.WriteAllText(_document, "domain Library\n");
+
+        _rendering = Substitute.For<IScreenplayRendering>();
+        _rendering.Render(Arg.Any<string>(), Arg.Any<string>()).Returns(new RenderedScreenplay(1, [], []));
+
+        _command = new RenderCommand(_rendering);
+        _settings = new RenderSettings { Output = OutputFormats.JsonCompact };
+    }
+
+    /// <summary>
+    /// Executes the command with the established settings.
+    /// </summary>
+    /// <returns>The exit code.</returns>
+    protected Task<int> Execute() =>
+        ((ICommand<RenderSettings>)_command).ExecuteAsync(
+            new CommandContext([], Substitute.For<IRemainingArguments>(), "render", null),
+            _settings,
+            CancellationToken.None);
+
+    void Destroy()
+    {
+        Directory.SetCurrentDirectory(_previousDirectory);
+
+        if (Directory.Exists(_folder))
+        {
+            Directory.Delete(_folder, true);
+        }
+    }
+}

--- a/Source/Cli.Specs/for_RenderCommand/when_rendering/and_an_output_directory_is_given.cs
+++ b/Source/Cli.Specs/for_RenderCommand/when_rendering/and_an_output_directory_is_given.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Cli.for_RenderCommand.when_rendering;
+
+[Collection(CliSpecsCollection.Name)]
+public class and_an_output_directory_is_given : given.a_render_command
+{
+    int _result;
+
+    void Establish()
+    {
+        _settings.Path = "MyApp.play";
+        _settings.Target = "src/MyApp";
+    }
+
+    async Task Because() => _result = await Execute();
+
+    [Fact] void should_succeed() => _result.ShouldEqual(ExitCodes.Success);
+    [Fact] void should_render_into_it() => _rendering.Received(1).Render(_document, Path.Combine(_folder, "src", "MyApp"));
+}

--- a/Source/Cli.Specs/for_RenderCommand/when_rendering/and_no_documents_are_found.cs
+++ b/Source/Cli.Specs/for_RenderCommand/when_rendering/and_no_documents_are_found.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Cli.for_RenderCommand.when_rendering;
+
+[Collection(CliSpecsCollection.Name)]
+public class and_no_documents_are_found : given.a_render_command
+{
+    int _result;
+
+    void Establish() => _rendering.Render(Arg.Any<string>(), Arg.Any<string>()).Returns(new RenderedScreenplay(0, [], []));
+
+    async Task Because() => _result = await Execute();
+
+    [Fact] void should_report_that_nothing_was_found() => _result.ShouldEqual(ExitCodes.NotFound);
+}

--- a/Source/Cli.Specs/for_RenderCommand/when_rendering/and_the_application_cannot_carry_everything.cs
+++ b/Source/Cli.Specs/for_RenderCommand/when_rendering/and_the_application_cannot_carry_everything.cs
@@ -1,0 +1,40 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Cli.for_RenderCommand.when_rendering;
+
+/// <summary>
+/// A Screenplay document states more than any one target can express. What does not survive the crossing is
+/// reported rather than dropped silently — and it is not a failure, so the command still succeeds.
+/// </summary>
+[Collection(CliSpecsCollection.Name)]
+public class and_the_application_cannot_carry_everything : given.a_render_command
+{
+    int _result;
+    string _error;
+    TextWriter _previousError;
+    StringWriter _capturedError;
+
+    void Establish()
+    {
+        _previousError = Console.Error;
+        _capturedError = new StringWriter();
+        Console.SetError(_capturedError);
+
+        _rendering
+            .Render(Arg.Any<string>(), Arg.Any<string>())
+            .Returns(new RenderedScreenplay(1, [], ["Slice 'Register' declares 2 screen declaration(s) with no rendered equivalent"]));
+    }
+
+    async Task Because()
+    {
+        _result = await Execute();
+        _error = _capturedError.ToString();
+    }
+
+    [Fact] void should_succeed() => _result.ShouldEqual(ExitCodes.Success);
+    [Fact] void should_say_what_the_rendered_application_does_not_carry() =>
+        _error.ShouldContain("Slice 'Register' declares 2 screen declaration(s) with no rendered equivalent");
+
+    void Destroy() => Console.SetError(_previousError);
+}

--- a/Source/Cli.Specs/for_RenderCommand/when_rendering/and_the_document_has_an_error.cs
+++ b/Source/Cli.Specs/for_RenderCommand/when_rendering/and_the_document_has_an_error.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Cli.for_RenderCommand.when_rendering;
+
+[Collection(CliSpecsCollection.Name)]
+public class and_the_document_has_an_error : given.a_render_command
+{
+    int _result;
+
+    void Establish() =>
+        _rendering
+            .Render(Arg.Any<string>(), Arg.Any<string>())
+            .Returns(new RenderedScreenplay(
+                1,
+                [new ScreenplayDiagnostic(ScreenplayDiagnosticSeverity.Error, "PLAY0001", "an error", "MyApp.play(3,1)")],
+                []));
+
+    async Task Because() => _result = await Execute();
+
+    [Fact] void should_report_a_validation_error() => _result.ShouldEqual(ExitCodes.ValidationError);
+}

--- a/Source/Cli.Specs/for_RenderCommand/when_rendering/and_the_document_renders.cs
+++ b/Source/Cli.Specs/for_RenderCommand/when_rendering/and_the_document_renders.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Cli.for_RenderCommand.when_rendering;
+
+[Collection(CliSpecsCollection.Name)]
+public class and_the_document_renders : given.a_render_command
+{
+    int _result;
+
+    void Establish() => _settings.Path = "MyApp.play";
+
+    async Task Because() => _result = await Execute();
+
+    [Fact] void should_succeed() => _result.ShouldEqual(ExitCodes.Success);
+    [Fact] void should_render_the_resolved_document() =>
+        _rendering.Received(1).Render(_document, Path.Combine(_folder, RenderCommand.DefaultTarget));
+}

--- a/Source/Cli.Specs/for_RenderCommand/when_rendering/and_the_path_cannot_be_resolved.cs
+++ b/Source/Cli.Specs/for_RenderCommand/when_rendering/and_the_path_cannot_be_resolved.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Cli.for_RenderCommand.when_rendering;
+
+[Collection(CliSpecsCollection.Name)]
+public class and_the_path_cannot_be_resolved : given.a_render_command
+{
+    int _result;
+
+    void Establish() => _settings.Path = "Missing/MyApp.play";
+
+    async Task Because() => _result = await Execute();
+
+    [Fact] void should_report_that_it_was_not_found() => _result.ShouldEqual(ExitCodes.NotFound);
+    [Fact] void should_not_render_anything() => _rendering.DidNotReceive().Render(Arg.Any<string>(), Arg.Any<string>());
+}

--- a/Source/Cli/Cli.csproj
+++ b/Source/Cli/Cli.csproj
@@ -39,13 +39,6 @@
         <PackageReference Include="Cratis.Prologue.Interpreter.Contracts" />
         <PackageReference Include="Cratis.Prologue.Screenplay" />
         <PackageReference Include="Cratis.Screenplay" />
-        <!--
-            The renderer package carries the Arc + Chronicle runtime it generates code for (Cratis/Stage#34).
-            Its build assets contribute 28 global usings to whatever consumes it, which makes User, AppendedEvent
-            and FailedPartition ambiguous against the Chronicle contracts this CLI already imports - so the
-            package is taken directly with those assets excluded.
-        -->
-        <PackageReference Include="Cratis" ExcludeAssets="build;buildTransitive;analyzers" PrivateAssets="build;buildTransitive;analyzers;contentfiles" />
         <!-- Rendering a Screenplay document into a Cratis application for 'cratis render'. -->
         <PackageReference Include="Cratis.Stage.Contracts" />
         <PackageReference Include="Cratis.Stage.Rendering.Cratis" />
@@ -63,12 +56,6 @@
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" />
         <!-- MSBuild itself must come from the installed SDK that MSBuildLocator registers, never from the output folder. -->
         <PackageReference Include="Microsoft.Build.Framework" ExcludeAssets="runtime" PrivateAssets="all" />
-        <!--
-            The Stage renderer's template engine brings NuGet.Frameworks transitively, and MSBuildLocator refuses
-            to run when a copy of it sits beside the executable (MSBL001) - it has to come from the registered SDK,
-            the same rule Microsoft.Build.Framework above already follows.
-        -->
-        <PackageReference Include="NuGet.Frameworks" ExcludeAssets="runtime" PrivateAssets="all" />
         <!--
             The repository default treats Workspaces.Common as an analyzer-only dependency, and PrivateAssets="all"
             keeps Microsoft.CodeAnalysis.Workspaces.dll out of publish output while still copying it on build - so a

--- a/Source/Cli/Cli.csproj
+++ b/Source/Cli/Cli.csproj
@@ -39,6 +39,16 @@
         <PackageReference Include="Cratis.Prologue.Interpreter.Contracts" />
         <PackageReference Include="Cratis.Prologue.Screenplay" />
         <PackageReference Include="Cratis.Screenplay" />
+        <!--
+            The renderer package carries the Arc + Chronicle runtime it generates code for (Cratis/Stage#34).
+            Its build assets contribute 28 global usings to whatever consumes it, which makes User, AppendedEvent
+            and FailedPartition ambiguous against the Chronicle contracts this CLI already imports - so the
+            package is taken directly with those assets excluded.
+        -->
+        <PackageReference Include="Cratis" ExcludeAssets="build;buildTransitive;analyzers" PrivateAssets="build;buildTransitive;analyzers;contentfiles" />
+        <!-- Rendering a Screenplay document into a Cratis application for 'cratis render'. -->
+        <PackageReference Include="Cratis.Stage.Contracts" />
+        <PackageReference Include="Cratis.Stage.Rendering.Cratis" />
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
         <PackageReference Include="Spectre.Console" />
         <PackageReference Include="Spectre.Console.Cli" />
@@ -53,6 +63,12 @@
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" />
         <!-- MSBuild itself must come from the installed SDK that MSBuildLocator registers, never from the output folder. -->
         <PackageReference Include="Microsoft.Build.Framework" ExcludeAssets="runtime" PrivateAssets="all" />
+        <!--
+            The Stage renderer's template engine brings NuGet.Frameworks transitively, and MSBuildLocator refuses
+            to run when a copy of it sits beside the executable (MSBL001) - it has to come from the registered SDK,
+            the same rule Microsoft.Build.Framework above already follows.
+        -->
+        <PackageReference Include="NuGet.Frameworks" ExcludeAssets="runtime" PrivateAssets="all" />
         <!--
             The repository default treats Workspaces.Common as an analyzer-only dependency, and PrivateAssets="all"
             keeps Microsoft.CodeAnalysis.Workspaces.dll out of publish output while still copying it on build - so a

--- a/Source/Cli/Commands/Render/IScreenplayRendering.cs
+++ b/Source/Cli/Commands/Render/IScreenplayRendering.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Cli.Commands.Screenplay;
+
+namespace Cratis.Cli.Commands.Render;
+
+/// <summary>
+/// Defines a system that renders Screenplay documents into a working application.
+/// </summary>
+/// <remarks>
+/// The seam between the CLI and the Stage renderer, mirroring <see cref="IScreenplayValidation"/> on the other
+/// arrow. Everything the CLI does around rendering — resolving the path, reporting, deciding the exit code — is
+/// expressed against this interface so it stays independent of which target is rendered into.
+/// </remarks>
+public interface IScreenplayRendering
+{
+    /// <summary>
+    /// Renders the Screenplay document, or every document beneath the folder, into the target directory.
+    /// </summary>
+    /// <param name="targetPath">The full path of a <c>.play</c> file, or of a folder to search.</param>
+    /// <param name="outputDirectory">The full path of the directory to render into.</param>
+    /// <returns>The <see cref="RenderedScreenplay"/> holding what was rendered and what could not be.</returns>
+    Task<RenderedScreenplay> Render(string targetPath, string outputDirectory);
+}

--- a/Source/Cli/Commands/Render/RenderCommand.cs
+++ b/Source/Cli/Commands/Render/RenderCommand.cs
@@ -1,0 +1,142 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Cli.Commands.Screenplay;
+
+namespace Cratis.Cli.Commands.Render;
+
+/// <summary>
+/// Renders Screenplay (<c>.play</c>) documents into a working Cratis application.
+/// </summary>
+/// <remarks>
+/// A sibling of <c>run</c> rather than a mode of it: <c>run</c> hands a folder to a container and watches, while
+/// this materializes the application as source on disk and exits. They share only how a document is found.
+/// </remarks>
+[LlmDescription("Renders Cratis Screenplay (.play) documents into a Cratis application on disk. Takes a .play file, or a folder in which case every .play file beneath it is rendered into one application. Nothing needs to be running. The target project is scaffolded on first use. What the document states but the rendered application cannot express is reported to standard error rather than dropped silently; the command still succeeds. A document the compiler rejects is not rendered at all.")]
+[CliCommand("render", "Render Screenplay (.play) documents into a Cratis application")]
+[CliExample("render")]
+[CliExample("render", "./MyApp.play")]
+[CliExample("render", "./plays", "--target", "./src/MyApp")]
+[LlmOption("[PATH]", "string", "Screenplay (.play) file, or folder to render every .play file beneath. Defaults to the current directory.")]
+[LlmOption("--target", "string", "Directory to render the application into (default: ./out).")]
+[LlmOutputAdvice("json-compact", "The summary goes to standard output and what could not be rendered to standard error; json-compact makes both machine-readable.")]
+public class RenderCommand : AsyncCommand<RenderSettings>
+{
+    /// <summary>
+    /// The directory rendered into when none is given.
+    /// </summary>
+    public const string DefaultTarget = "out";
+
+    readonly IScreenplayRendering _rendering;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RenderCommand"/> class.
+    /// </summary>
+    public RenderCommand()
+        : this(new ScreenplayRendering())
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RenderCommand"/> class.
+    /// </summary>
+    /// <param name="rendering">The rendering to render the documents with.</param>
+    internal RenderCommand(IScreenplayRendering rendering)
+    {
+        _rendering = rendering;
+    }
+
+    /// <inheritdoc/>
+    protected override async Task<int> ExecuteAsync(CommandContext context, RenderSettings settings, CancellationToken cancellationToken)
+    {
+        var format = settings.ResolveOutputFormat();
+        var currentDirectory = Directory.GetCurrentDirectory();
+
+        var resolved = PlayFileTargetResolver.Resolve(settings.Path, currentDirectory);
+        if (!resolved.IsResolved)
+        {
+            OutputFormatter.WriteError(format, resolved.Error!, resolved.Suggestion, ExitCodes.NotFoundCode);
+            return ExitCodes.NotFound;
+        }
+
+        var target = Path.GetFullPath(settings.Target ?? DefaultTarget, currentDirectory);
+        var rendered = await _rendering.Render(resolved.Path!, target);
+
+        if (rendered.Documents == 0)
+        {
+            // Silently succeeding on a folder holding nothing turns the command into a no-op in CI, which is
+            // exactly where it is trusted the most.
+            OutputFormatter.WriteError(
+                format,
+                $"No Screenplay ({PlayFileTargetResolver.Extension}) files found in '{resolved.Path}'",
+                $"Point the command at a {PlayFileTargetResolver.Extension} file, or at a folder holding one",
+                ExitCodes.NotFoundCode);
+            return ExitCodes.NotFound;
+        }
+
+        ScreenplayDiagnosticsWriter.Write(format, rendered.Diagnostics);
+
+        var exitCode = ScreenplayDiagnostics.ExitCodeFor(rendered.Diagnostics);
+        if (exitCode != ExitCodes.Success)
+        {
+            var errors = rendered.Diagnostics.Count(diagnostic => diagnostic.Severity == ScreenplayDiagnosticSeverity.Error);
+            OutputFormatter.WriteError(
+                format,
+                $"Nothing was rendered — the document reported {errors} error(s)",
+                "Fix the reported errors in the Screenplay document, then render again",
+                ExitCodes.ValidationErrorCode);
+            return exitCode;
+        }
+
+        WriteReported(rendered);
+        WriteResult(format, target, rendered);
+        return ExitCodes.Success;
+    }
+
+    /// <summary>
+    /// Writes what the rendered application does not carry. This is not a failure — a Screenplay document states
+    /// more than any one target expresses — but it is the difference between the document and what was produced,
+    /// so it goes to standard error where it will be read rather than into a summary line.
+    /// </summary>
+    /// <param name="rendered">What rendering produced.</param>
+    static void WriteReported(RenderedScreenplay rendered)
+    {
+        foreach (var reported in rendered.Reported)
+        {
+            Console.Error.WriteLine(reported);
+        }
+    }
+
+    static void WriteResult(string format, string targetDirectory, RenderedScreenplay rendered)
+    {
+        if (string.Equals(format, OutputFormats.Quiet, StringComparison.Ordinal))
+        {
+            Console.WriteLine(targetDirectory);
+            return;
+        }
+
+        OutputFormatter.WriteObject(
+            format,
+            new
+            {
+                Target = targetDirectory,
+                rendered.Documents,
+                NotCarried = rendered.Reported.Count
+            },
+            result =>
+            {
+                var content = new Markup(
+                    $"[bold]{result.Target.EscapeMarkup()}[/]\n" +
+                    $"Documents:   {result.Documents}\n" +
+                    $"Not carried: {result.NotCarried}");
+                var panel = new Panel(content)
+                    .Header(" Rendered ")
+                    .Border(BoxBorder.Rounded)
+                    .BorderStyle(new Style(OutputFormatter.Success))
+                    .Padding(1, 0);
+
+                AnsiConsole.WriteLine();
+                AnsiConsole.Write(panel);
+            });
+    }
+}

--- a/Source/Cli/Commands/Render/RenderSettings.cs
+++ b/Source/Cli/Commands/Render/RenderSettings.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Cli.Commands.Render;
+
+/// <summary>
+/// Settings for the render command.
+/// </summary>
+public class RenderSettings : GlobalSettings
+{
+    /// <summary>
+    /// Gets or sets the document or folder to render.
+    /// </summary>
+    [CommandArgument(0, "[PATH]")]
+    [Description("Screenplay (.play) file, or folder to render every .play file beneath. Defaults to the current directory.")]
+    public string? Path { get; set; }
+
+    /// <summary>
+    /// Gets or sets the directory to render into.
+    /// </summary>
+    /// <remarks>
+    /// Named <c>--target</c> rather than <c>--output</c> because every command already carries a global
+    /// <c>-o|--output</c> for the output <i>format</i>, and it is the renderer's own word for where it writes.
+    /// </remarks>
+    [CommandOption("--target <DIRECTORY>")]
+    [Description("Directory to render the application into. Defaults to './out'.")]
+    public string? Target { get; set; }
+}

--- a/Source/Cli/Commands/Render/RenderedScreenplay.cs
+++ b/Source/Cli/Commands/Render/RenderedScreenplay.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Cli.Commands.Screenplay;
+
+namespace Cratis.Cli.Commands.Render;
+
+/// <summary>
+/// Represents what rendering a set of Screenplay documents produced.
+/// </summary>
+/// <param name="Documents">How many documents were rendered.</param>
+/// <param name="Diagnostics">Everything the compiler reported about the documents.</param>
+/// <param name="Reported">
+/// Everything the renderer could not carry into the rendered application, in the order it was reported.
+/// </param>
+/// <remarks>
+/// <see cref="Reported"/> is the point of the command as much as the files are. A Screenplay document states more
+/// than any one target can express, and the promise is that whatever does not survive the crossing is said out
+/// loud rather than quietly left behind — so it is carried back as a result, not written past the user.
+/// </remarks>
+public record RenderedScreenplay(int Documents, IReadOnlyList<ScreenplayDiagnostic> Diagnostics, IReadOnlyList<string> Reported);

--- a/Source/Cli/Commands/Render/ScreenplayRendering.cs
+++ b/Source/Cli/Commands/Render/ScreenplayRendering.cs
@@ -1,0 +1,53 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Cli.Commands.Screenplay;
+using Cratis.Stage.Contracts.Rendering;
+using Cratis.Stage.Rendering.Cratis;
+
+namespace Cratis.Cli.Commands.Render;
+
+/// <summary>
+/// Renders Screenplay documents into a Cratis application with the Stage renderer.
+/// </summary>
+/// <remarks>
+/// This is the only place in the CLI that knows the renderer exists, the way
+/// <see cref="ScreenplayValidation"/> is the only place that knows the compiler does.
+/// </remarks>
+/// <param name="validation">Compiles the documents and reports what the compiler found.</param>
+/// <param name="renderer">Renders the compiled applications.</param>
+public sealed class ScreenplayRendering(IScreenplayValidation validation, IRenderer renderer) : IScreenplayRendering
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ScreenplayRendering"/> class with the default compiler and the
+    /// Cratis renderer.
+    /// </summary>
+    public ScreenplayRendering()
+        : this(new ScreenplayValidation(), CratisRenderer.CreateDefault())
+    {
+    }
+
+    /// <inheritdoc/>
+    public async Task<RenderedScreenplay> Render(string targetPath, string outputDirectory)
+    {
+        var compiled = validation.Validate(targetPath);
+        var diagnostics = compiled.Diagnostics;
+
+        // A document the compiler rejected has no application to render, and rendering the ones beside it would
+        // produce an application missing whatever the rejected document declared - without saying which parts.
+        if (diagnostics.Any(diagnostic => diagnostic.Severity == ScreenplayDiagnosticSeverity.Error))
+        {
+            return new(compiled.FileCount, diagnostics, []);
+        }
+
+        var output = new StringWriter();
+        var error = new StringWriter();
+
+        await renderer.Render(compiled.Applications, new DirectoryInfo(outputDirectory), output, error);
+
+        return new(compiled.FileCount, diagnostics, Lines(error));
+    }
+
+    static IReadOnlyList<string> Lines(StringWriter writer) =>
+        [.. writer.ToString().Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)];
+}

--- a/Source/Cli/Commands/Screenplay/ScreenplayValidation.cs
+++ b/Source/Cli/Commands/Screenplay/ScreenplayValidation.cs
@@ -4,6 +4,7 @@
 using Cratis.Screenplay;
 using Cratis.Screenplay.Diagnostics;
 using Cratis.Screenplay.Files;
+using Cratis.Screenplay.Syntax;
 
 namespace Cratis.Cli.Commands.Screenplay;
 
@@ -36,7 +37,10 @@ public sealed class ScreenplayValidation(IPlayFileCompiler playFileCompiler, ISc
 
         return new(
             compilations.Length,
-            [.. compilations.SelectMany(compilation => compilation.Result.Diagnostics.Select(diagnostic => Map(compilation.File, diagnostic)))]);
+            [.. compilations.SelectMany(compilation => compilation.Result.Diagnostics.Select(diagnostic => Map(compilation.File, diagnostic)))])
+        {
+            Applications = [.. compilations.Select(compilation => compilation.Result.Value).OfType<ApplicationSyntax>()]
+        };
     }
 
     /// <summary>

--- a/Source/Cli/Commands/Screenplay/ValidatedScreenplay.cs
+++ b/Source/Cli/Commands/Screenplay/ValidatedScreenplay.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Cratis.Screenplay.Syntax;
+
 namespace Cratis.Cli.Commands.Screenplay;
 
 /// <summary>
@@ -8,4 +10,11 @@ namespace Cratis.Cli.Commands.Screenplay;
 /// </summary>
 /// <param name="FileCount">The number of <c>.play</c> files that were compiled.</param>
 /// <param name="Diagnostics">Everything the compiler reported, across every file.</param>
-public record ValidatedScreenplay(int FileCount, IReadOnlyList<ScreenplayDiagnostic> Diagnostics);
+public record ValidatedScreenplay(int FileCount, IReadOnlyList<ScreenplayDiagnostic> Diagnostics)
+{
+    /// <summary>
+    /// Gets the applications the compiler produced — one per document it could compile, and none for a document
+    /// it rejected. Validation only counts them; rendering is what needs them.
+    /// </summary>
+    public IReadOnlyList<ApplicationSyntax> Applications { get; init; } = [];
+}


### PR DESCRIPTION
## Added

- `cratis render` renders a Screenplay document, or every document beneath a folder, into a Cratis application, reporting everything the document says that the rendered application does not carry. `--target` chooses the directory, defaulting to `./out` (#62)
