### PR TITLE
Move to Microsoft.Build.Framework 18.9.6 and pin StringTools

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -35,7 +35,8 @@
     <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="5.6.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.6.0" />
     <!-- Compile-time only: MSBuildLocator resolves the MSBuild assemblies from the installed .NET SDK at run time. -->
-    <PackageVersion Include="Microsoft.Build.Framework" Version="17.11.48" />
+    <PackageVersion Include="Microsoft.Build.Framework" Version="18.9.6" />
+    <PackageVersion Include="Microsoft.NET.StringTools" Version="18.9.6" />
     <!-- Analysis -->
     <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.556" NoWarn="NU5104" />
     <PackageVersion Include="Roslynator.Analyzers" Version="4.15.0" />

--- a/Source/Cli.Specs/Cli.Specs.csproj
+++ b/Source/Cli.Specs/Cli.Specs.csproj
@@ -15,6 +15,7 @@
     <ItemGroup>
         <!-- MSBuildLocator refuses to run with a copy of this beside the test host; it comes from the SDK. -->
         <PackageReference Include="Microsoft.Build.Framework" ExcludeAssets="runtime" PrivateAssets="all" />
+        <PackageReference Include="Microsoft.NET.StringTools" ExcludeAssets="runtime" PrivateAssets="all" />
         <PackageReference Include="Cratis.Specifications.XUnit" />
         <PackageReference Include="xunit" />
         <PackageReference Include="xunit.runner.visualstudio" />

--- a/Source/Cli/Cli.csproj
+++ b/Source/Cli/Cli.csproj
@@ -56,6 +56,7 @@
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" />
         <!-- MSBuild itself must come from the installed SDK that MSBuildLocator registers, never from the output folder. -->
         <PackageReference Include="Microsoft.Build.Framework" ExcludeAssets="runtime" PrivateAssets="all" />
+        <PackageReference Include="Microsoft.NET.StringTools" ExcludeAssets="runtime" PrivateAssets="all" />
         <!--
             The repository default treats Workspaces.Common as an analyzer-only dependency, and PrivateAssets="all"
             keeps Microsoft.CodeAnalysis.Workspaces.dll out of publish output while still copying it on build - so a


### PR DESCRIPTION
## Summary

- Unblocks the daily automated **Update Packages** workflow, which bumps `Microsoft.Build.Framework` from `17.11.48` to `18.9.6` and transitively pulls in `Microsoft.NET.StringTools` at the same version, causing the subsequent `dotnet build` step to fail with:
  ```
  error MSBL001: A PackageReference to the package 'Microsoft.NET.StringTools' at version '18.9.6' is present in this project without ExcludeAssets="runtime" and PrivateAssets="all" set. This can cause errors at run-time due to MSBuild assembly-loading. [Source/Cli/Cli.csproj]
  ```
- Bumps `Microsoft.Build.Framework` to `18.9.6` in `Directory.Packages.props` (latest stable per NuGet.org) and adds a matching `Microsoft.NET.StringTools` `18.9.6` `PackageVersion` entry alongside it.
- Adds a `PackageReference` for `Microsoft.NET.StringTools` with `ExcludeAssets="runtime" PrivateAssets="all"` next to the existing `Microsoft.Build.Framework` reference in `Source/Cli/Cli.csproj` and `Source/Cli.Specs/Cli.Specs.csproj`, mirroring the pattern `Microsoft.Build.Locator`'s own build target requires (both packages must come from the installed .NET SDK that `MSBuildLocator` registers, never from the output folder).

## Test plan

- [x] `dotnet build` (Debug) at repo root — succeeds, 0 warnings, 0 errors
- [x] `dotnet build --configuration Release` at repo root (matches CI) — succeeds, 0 warnings, 0 errors
- [x] `dotnet test Source/Cli.Specs/Cli.Specs.csproj --configuration Release` — 446/446 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)