### PR TITLE
Use American English spelling in comments and descriptions

### DIFF
--- a/Source/Cli/Commands/Chronicle/EventTypes/ListEventTypesCommand.cs
+++ b/Source/Cli/Commands/Chronicle/EventTypes/ListEventTypesCommand.cs
@@ -6,7 +6,7 @@ namespace Cratis.Cli.Commands.Chronicle.EventTypes;
 /// <summary>
 /// Lists registered event types in an event store.
 /// </summary>
-[LlmDescription("Lists all registered event types in the event store. Returns type names, IDs, and generation counts. Use -o plain for large catalogues. Use to explore the domain schema.")]
+[LlmDescription("Lists all registered event types in the event store. Returns type names, IDs, and generation counts. Use -o plain for large catalogs. Use to explore the domain schema.")]
 [CliCommand("list", "List registered event types", Branch = typeof(ChronicleBranch.EventTypes))]
 [CliExample("chronicle", "event-types", "list")]
 [CliExample("chronicle", "event-types", "list", "-e", "MyStore", "-o", "plain")]

--- a/Source/Cli/Commands/Chronicle/ReadModels/ListReadModelsCommand.cs
+++ b/Source/Cli/Commands/Chronicle/ReadModels/ListReadModelsCommand.cs
@@ -6,7 +6,7 @@ namespace Cratis.Cli.Commands.Chronicle.ReadModels;
 /// <summary>
 /// Lists read model definitions in an event store.
 /// </summary>
-[LlmDescription("Lists all read model definitions registered in the namespace. Use -o plain for large catalogues. Use to discover available types before calling 'get' or 'instances'. Check the 'queryable' field: false means the model is client-owned (Owner: Client) and 'get'/'instances' will fail for it — the client application stores its state, not the Chronicle server.")]
+[LlmDescription("Lists all read model definitions registered in the namespace. Use -o plain for large catalogs. Use to discover available types before calling 'get' or 'instances'. Check the 'queryable' field: false means the model is client-owned (Owner: Client) and 'get'/'instances' will fail for it — the client application stores its state, not the Chronicle server.")]
 [CliCommand("list", "List read model definitions", Branch = typeof(ChronicleBranch.ReadModels))]
 [CliExample("chronicle", "read-models", "list")]
 [LlmOutputAdvice("plain", "plain is ~27x smaller (1.5KB vs 40KB). JSON includes full schema blobs per read model.")]

--- a/Source/Cli/Commands/Chronicle/Workbench/WorkbenchUi.cs
+++ b/Source/Cli/Commands/Chronicle/Workbench/WorkbenchUi.cs
@@ -82,7 +82,7 @@ public static class WorkbenchUi
     /// Layout (left→right): title MarkupControl · separator · action buttons · separator · filter control.
     /// Action buttons use <see cref="ColorRole.Danger"/> when the label contains "stop", "remove",
     /// "delete", or "ignore" (case-insensitive) and the action is enabled; disabled buttons always
-    /// use <see cref="ColorRole.Default"/> so they render neutral-grey.
+    /// use <see cref="ColorRole.Default"/> so they render neutral-gray.
     /// </remarks>
     /// <param name="accent">The resolved accent color snapshot used to tint the title.</param>
     /// <param name="title">The page title rendered in bold accent markup.</param>

--- a/Source/Cli/Commands/Chronicle/Workbench/windows/WorkbenchNavigation.cs
+++ b/Source/Cli/Commands/Chronicle/Workbench/windows/WorkbenchNavigation.cs
@@ -364,7 +364,7 @@ public class WorkbenchNavigation(
     public void OpenThemePortal(int? anchorLeft = null)
     {
         // Every registered theme, not the three the old F9/F10/F11 slots exposed — the registry is
-        // the full catalogue and the portal has room to list it.
+        // the full catalog and the portal has room to list it.
         var names = windowSystem.ThemeRegistryService.GetAvailableThemeNames();
         var active = windowSystem.ThemeStateService.CurrentTheme?.Name;
 

--- a/Source/Cli/Commands/Chronicle/Workbench/windows/WorkbenchStatusPortal.cs
+++ b/Source/Cli/Commands/Chronicle/Workbench/windows/WorkbenchStatusPortal.cs
@@ -128,7 +128,7 @@ public static class WorkbenchStatusPortal
             list.SelectedIndex = currentIndex;
         }
 
-        // Measure what renders, not what is written: the theme rows carry colour markup around
+        // Measure what renders, not what is written: the theme rows carry color markup around
         // their swatches, and counting the tags made the panel several times wider than its content.
         var widest = items.Max(i => Markup.Remove(i.Label).Length);
         var width = Math.Max(MinWidth, widest + WidthPadding);

--- a/Source/Cli/Commands/Chronicle/Workbench/windows/WorkbenchThemes.cs
+++ b/Source/Cli/Commands/Chronicle/Workbench/windows/WorkbenchThemes.cs
@@ -29,7 +29,7 @@ public record WorkbenchThemeSlot(string Label, Action Apply);
 /// <para>
 /// Theme application goes through the version-stable <c>ThemeStateService.SwitchTheme(name)</c>
 /// (present in both versions; an unknown name is a safe no-op). The three primary slots preserve the
-/// original 2.4.78 behaviour — Modern Gray / Classic / Dev Dark — and map to Modern Gray / Forest /
+/// original 2.4.78 behavior — Modern Gray / Classic / Dev Dark — and map to Modern Gray / Forest /
 /// Crimson on 2.4.79 where Classic and Dev Dark no longer exist.
 /// </para>
 /// <para>
@@ -51,7 +51,7 @@ public static class WorkbenchThemes
     {
         if (HasInstanceRegistry(windowSystem))
         {
-            // 2.4.79: Classic and Dev Dark are gone; offer dark palette themes from the catalogue.
+            // 2.4.79: Classic and Dev Dark are gone; offer dark palette themes from the catalog.
             return
             [
                 new WorkbenchThemeSlot("Modern Gray", () => Apply(windowSystem, "ModernGray")),
@@ -60,7 +60,7 @@ public static class WorkbenchThemes
             ];
         }
 
-        // 2.4.78: preserve the original behaviour — Modern Gray / Classic / Dev Dark.
+        // 2.4.78: preserve the original behavior — Modern Gray / Classic / Dev Dark.
         return
         [
             new WorkbenchThemeSlot("Modern Gray", () => Apply(windowSystem, "ModernGray")),

--- a/Source/Cli/Commands/Completions/CompletionsInstallCommand.cs
+++ b/Source/Cli/Commands/Completions/CompletionsInstallCommand.cs
@@ -6,7 +6,7 @@ namespace Cratis.Cli.Commands.Completions;
 /// <summary>
 /// Automatically installs shell completions for the current (or specified) shell.
 /// For bash and zsh, appends an eval line to the shell config so completions are always generated fresh.
-/// For fish, appends a source line to config.fish for the same dynamic behaviour.
+/// For fish, appends a source line to config.fish for the same dynamic behavior.
 /// </summary>
 [LlmDescription("Installs shell tab-completion by modifying shell configuration files. Run once after installing cratis.")]
 [CliCommand("install", "Automatically install completions for the current shell (run once after installing cratis)", Branch = typeof(CompletionsBranch))]

--- a/Source/Cli/Commands/Run/StageReadiness.cs
+++ b/Source/Cli/Commands/Run/StageReadiness.cs
@@ -30,7 +30,7 @@ public static class StageReadiness
     /// </summary>
     /// <param name="client">The <see cref="HttpClient"/> to probe with.</param>
     /// <param name="port">The host port the Stage API is published on.</param>
-    /// <param name="cancellationToken">A <see cref="CancellationToken"/> for cancelling the probe.</param>
+    /// <param name="cancellationToken">A <see cref="CancellationToken"/> for canceling the probe.</param>
     /// <returns>True when the API answered; otherwise false.</returns>
     public static async Task<bool> IsServing(HttpClient client, int port, CancellationToken cancellationToken)
     {

--- a/Source/Cli/Commands/Run/StageSession.cs
+++ b/Source/Cli/Commands/Run/StageSession.cs
@@ -96,7 +96,7 @@ public sealed class StageSession : IDisposable
     /// </summary>
     /// <param name="port">The host port the Stage API is published on.</param>
     /// <param name="onProgress">Called on every poll so the caller can report progress.</param>
-    /// <param name="cancellationToken">A <see cref="CancellationToken"/> for cancelling the wait.</param>
+    /// <param name="cancellationToken">A <see cref="CancellationToken"/> for canceling the wait.</param>
     /// <returns>True when the Stage became ready; false when the container exited before that.</returns>
     public async Task<bool> WaitUntilReady(int port, Action onProgress, CancellationToken cancellationToken)
     {
@@ -131,7 +131,7 @@ public sealed class StageSession : IDisposable
     /// <summary>
     /// Waits for the container to exit.
     /// </summary>
-    /// <param name="cancellationToken">A <see cref="CancellationToken"/> for cancelling the wait.</param>
+    /// <param name="cancellationToken">A <see cref="CancellationToken"/> for canceling the wait.</param>
     /// <returns>A task representing the asynchronous operation.</returns>
     public Task WaitForExit(CancellationToken cancellationToken) => _process.WaitForExitAsync(cancellationToken);
 

--- a/Source/Cli/Commands/Screenplay/GeneratedResourceSources.cs
+++ b/Source/Cli/Commands/Screenplay/GeneratedResourceSources.cs
@@ -13,7 +13,7 @@ namespace Cratis.Cli.Commands.Screenplay;
 /// <remarks>
 /// <see cref="DesignTimeResourceGeneration"/> makes the design-time build produce these itself, which also works for
 /// a project that has never been built. This is the safety net for when it cannot — a read-only intermediate output
-/// folder, or an MSBuild that no longer honours the hook. A previous ordinary build then still left the sources on
+/// folder, or an MSBuild that no longer honors the hook. A previous ordinary build then still left the sources on
 /// disk, and reading them back is enough to make the compilation whole. Only files the project does not already
 /// compile are added, so this does nothing at all once the design-time build does its job.
 /// </remarks>

--- a/Source/Cli/ConsoleInterrupt.cs
+++ b/Source/Cli/ConsoleInterrupt.cs
@@ -25,7 +25,7 @@ public sealed class ConsoleInterrupt : IDisposable
     public CancellationToken Token => _source.Token;
 
     /// <summary>
-    /// Starts intercepting Ctrl+C, cancelling along with the given token.
+    /// Starts intercepting Ctrl+C, canceling along with the given token.
     /// </summary>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> to link to.</param>
     /// <returns>The <see cref="ConsoleInterrupt"/>, which stops intercepting when disposed.</returns>

--- a/Source/Cli/GlobalSettings.cs
+++ b/Source/Cli/GlobalSettings.cs
@@ -95,8 +95,8 @@ public class GlobalSettings : CommandSettings
             return OutputFormats.JsonCompact;
         }
 
-        // Honour the NO_COLOR convention (https://no-color.org/): when set, fall back to plain
-        // tab-separated output rather than ANSI-coloured tables.
+        // Honor the NO_COLOR convention (https://no-color.org/): when set, fall back to plain
+        // tab-separated output rather than ANSI-colored tables.
         if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("NO_COLOR")))
         {
             return OutputFormats.Plain;

--- a/Source/Cli/GradientFigletRenderer.cs
+++ b/Source/Cli/GradientFigletRenderer.cs
@@ -13,7 +13,7 @@ public static class GradientFigletRenderer
     /// <summary>
     /// Renders an array of pre-formed ASCII art lines with a multi-stop horizontal gradient.
     /// When <paramref name="targetWidth"/> is less than the natural line width, the output is
-    /// proportionally downsampled (nearest-neighbour) so the art fits the terminal.
+    /// proportionally downsampled (nearest-neighbor) so the art fits the terminal.
     /// </summary>
     /// <param name="lines">The lines to render.</param>
     /// <param name="gradientStops">The gradient color stops (left to right).</param>


### PR DESCRIPTION
## Fixed

- `cratis llm-context` no longer describes large result sets as "catalogues" — the `event-types list` and `read-models list` descriptions now use American English like the rest of the CLI.
