### PR TITLE
Wait for an add to be visible before listing it

### DIFF
--- a/Integration/Chronicle/ReadBackTimedOut.cs
+++ b/Integration/Chronicle/ReadBackTimedOut.cs
@@ -1,0 +1,38 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Cli.Integration.Chronicle;
+
+/// <summary>
+/// Exception that gets thrown when something written through the CLI never became visible to a read that
+/// polled for it.
+/// </summary>
+/// <param name="description">Describes what was being waited for.</param>
+/// <param name="args">The arguments of the CLI command that was polled.</param>
+/// <param name="attempts">The number of times the command was run.</param>
+/// <param name="elapsed">The time spent waiting.</param>
+/// <param name="lastResult">The result of the last attempt.</param>
+public class ReadBackTimedOut(string description, IEnumerable<string> args, int attempts, TimeSpan elapsed, CliCommandResult lastResult)
+    : Exception(BuildMessage(description, args, attempts, elapsed, lastResult))
+{
+    const int MaximumReportedOutputLength = 4000;
+
+    static string BuildMessage(string description, IEnumerable<string> args, int attempts, TimeSpan elapsed, CliCommandResult lastResult) =>
+        $"{description} never showed up in the output of `cratis {string.Join(' ', args)}`. " +
+        $"Polled {attempts} time(s) over {elapsed.TotalSeconds:0.0}s.{Environment.NewLine}" +
+        $"Last exit code: {lastResult.ExitCode}{Environment.NewLine}" +
+        $"Last standard output: {Truncate(lastResult.StandardOutput)}{Environment.NewLine}" +
+        $"Last standard error: {Truncate(lastResult.StandardError)}";
+
+    static string Truncate(string value)
+    {
+        if (string.IsNullOrEmpty(value))
+        {
+            return "(empty)";
+        }
+
+        return value.Length <= MaximumReportedOutputLength
+            ? value
+            : $"{value[..MaximumReportedOutputLength]}… (truncated, {value.Length} characters in total)";
+    }
+}

--- a/Integration/Chronicle/for_Applications/when_adding_and_removing_application.cs
+++ b/Integration/Chronicle/for_Applications/when_adding_and_removing_application.cs
@@ -10,25 +10,32 @@ public class when_adding_and_removing_application(context context) : CliGiven<co
 {
     public class context : given.a_connected_cli
     {
+        /// <summary>
+        /// The client identifier for this run. Making it unique keeps an application left behind by an
+        /// earlier failed run from being taken for the one this run adds - the server treats adding a
+        /// client identifier it already knows as a no-op, so a leftover would make the add do nothing.
+        /// </summary>
+        public readonly string ClientId = $"integration-test-app-{Guid.NewGuid():N}";
+
         public CliCommandResult AddResult = null!;
         public CliCommandResult RemoveResult = null!;
-        public bool ApplicationAppearedInList;
+        public JsonElement ListedApplication;
 
         async Task Because()
         {
-            AddResult = await RunCliAsync("chronicle", "applications", "add", "integration-test-app", "integration-test-secret");
+            AddResult = await RunCliAsync("chronicle", "applications", "add", ClientId, "integration-test-secret");
 
-            var listResult = await RunCliAsync("chronicle", "applications", "list");
-            var apps = JsonDocument.Parse(listResult.StandardOutput).RootElement;
-            var testApp = apps.EnumerateArray()
-                .FirstOrDefault(a => a.GetProperty("clientId").GetString() == "integration-test-app");
-            ApplicationAppearedInList = testApp.ValueKind != JsonValueKind.Undefined;
+            // 'applications add' returns once the ApplicationAdded event is appended; the list is read from
+            // a store a kernel reactor projects that event into, so it catches up a moment later. Poll for it.
+            ListedApplication = await WaitForElementInList(
+                $"Application '{ClientId}'",
+                application => application.TryGetProperty("clientId", out var clientId) && clientId.GetString() == ClientId,
+                "chronicle",
+                "applications",
+                "list");
 
-            if (ApplicationAppearedInList)
-            {
-                var appId = testApp.GetProperty("id").GetString()!;
-                RemoveResult = await RunCliAsync("chronicle", "applications", "remove", appId);
-            }
+            var appId = ListedApplication.GetProperty("id").GetString()!;
+            RemoveResult = await RunCliAsync("chronicle", "applications", "remove", appId);
         }
     }
 
@@ -36,7 +43,7 @@ public class when_adding_and_removing_application(context context) : CliGiven<co
 
     [Fact] void should_contain_added_message() => Context.AddResult.StandardOutput.ShouldContain("added");
 
-    [Fact] void should_show_application_in_list() => Context.ApplicationAppearedInList.ShouldBeTrue();
+    [Fact] void should_show_application_in_list() => Context.ListedApplication.ValueKind.ShouldEqual(JsonValueKind.Object);
 
     [Fact] void should_return_success_for_remove() => Context.RemoveResult.ExitCode.ShouldEqual(ExitCodes.Success);
 

--- a/Integration/Chronicle/for_Users/when_adding_and_removing_user.cs
+++ b/Integration/Chronicle/for_Users/when_adding_and_removing_user.cs
@@ -10,25 +10,32 @@ public class when_adding_and_removing_user(context context) : CliGiven<context>(
 {
     public class context : given.a_connected_cli
     {
+        /// <summary>
+        /// The username for this run. Making it unique keeps a user left behind by an earlier failed run
+        /// from being taken for the one this run adds, which would both hide the read-after-write race and
+        /// remove the wrong user.
+        /// </summary>
+        public readonly string Username = $"integration-test-user-{Guid.NewGuid():N}";
+
         public CliCommandResult AddResult = null!;
         public CliCommandResult RemoveResult = null!;
-        public bool UserAppearedInList;
+        public JsonElement ListedUser;
 
         async Task Because()
         {
-            AddResult = await RunCliAsync("chronicle", "users", "add", "integration-test-user", "integration-test@test.com", "TestP@ss123!");
+            AddResult = await RunCliAsync("chronicle", "users", "add", Username, "integration-test@test.com", "TestP@ss123!");
 
-            var listResult = await RunCliAsync("chronicle", "users", "list");
-            var users = JsonDocument.Parse(listResult.StandardOutput).RootElement;
-            var testUser = users.EnumerateArray()
-                .FirstOrDefault(u => u.GetProperty("username").GetString() == "integration-test-user");
-            UserAppearedInList = testUser.ValueKind != JsonValueKind.Undefined;
+            // 'users add' returns once the UserAdded event is appended; the list is read from a store a
+            // kernel reactor projects that event into, so it catches up a moment later. Poll for it.
+            ListedUser = await WaitForElementInList(
+                $"User '{Username}'",
+                user => user.TryGetProperty("username", out var username) && username.GetString() == Username,
+                "chronicle",
+                "users",
+                "list");
 
-            if (UserAppearedInList)
-            {
-                var userId = testUser.GetProperty("id").GetString()!;
-                RemoveResult = await RunCliAsync("chronicle", "users", "remove", userId);
-            }
+            var userId = ListedUser.GetProperty("id").GetString()!;
+            RemoveResult = await RunCliAsync("chronicle", "users", "remove", userId);
         }
     }
 
@@ -36,7 +43,7 @@ public class when_adding_and_removing_user(context context) : CliGiven<context>(
 
     [Fact] void should_contain_added_message() => Context.AddResult.StandardOutput.ShouldContain("added");
 
-    [Fact] void should_show_user_in_list() => Context.UserAppearedInList.ShouldBeTrue();
+    [Fact] void should_show_user_in_list() => Context.ListedUser.ValueKind.ShouldEqual(JsonValueKind.Object);
 
     [Fact] void should_return_success_for_remove() => Context.RemoveResult.ExitCode.ShouldEqual(ExitCodes.Success);
 

--- a/Integration/Chronicle/given/a_connected_cli.cs
+++ b/Integration/Chronicle/given/a_connected_cli.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Diagnostics;
 using Cratis.Chronicle.Connections;
 
 namespace Cratis.Cli.Integration.Chronicle.given;
@@ -10,6 +11,21 @@ namespace Cratis.Cli.Integration.Chronicle.given;
 /// </summary>
 public class a_connected_cli : Specification
 {
+    /// <summary>
+    /// The longest a spec waits for something it wrote to become visible to a subsequent read.
+    /// </summary>
+    /// <remarks>
+    /// Chronicle is event sourced. A command such as <c>users add</c> returns as soon as its event is
+    /// appended to the event log; the kernel reactor that projects that event into the store the matching
+    /// <c>list</c> command reads from runs afterwards. Reading the list straight after the add is therefore
+    /// a read-after-write race, normally won by a few milliseconds but lost often enough on a loaded CI
+    /// runner to make the specs flaky. The wait is bounded so a write that never lands still fails, and
+    /// fails with something a reader of the log can act on.
+    /// </remarks>
+    protected static readonly TimeSpan ReadBackTimeout = TimeSpan.FromSeconds(30);
+
+    static readonly TimeSpan _readBackPollInterval = TimeSpan.FromMilliseconds(200);
+
     /// <summary>
     /// Gets the gRPC connection string for the Docker-hosted Chronicle server.
     /// </summary>
@@ -31,5 +47,74 @@ public class a_connected_cli : Specification
     {
         var allArgs = new List<string>(args) { "--server", ConnectionString, "--output", "json" };
         return CliCommandRunner.RunAsync([.. allArgs]);
+    }
+
+    /// <summary>
+    /// Runs a CLI command that outputs a JSON array repeatedly until an element matching a predicate shows up.
+    /// </summary>
+    /// <param name="description">Describes what is being waited for, used in the failure message.</param>
+    /// <param name="matches">Predicate that identifies the element being waited for.</param>
+    /// <param name="args">The command arguments (without --server and --output flags).</param>
+    /// <returns>A copy of the matching element, safe to read after this method returns.</returns>
+    /// <exception cref="ReadBackTimedOut">
+    /// Thrown when no matching element shows up within <see cref="ReadBackTimeout"/>.
+    /// </exception>
+    /// <remarks>
+    /// Polling rather than sleeping keeps the common case as fast as the server is: the first read almost
+    /// always finds the element, and only a run that actually lost the race pays for another attempt.
+    /// </remarks>
+    protected static async Task<JsonElement> WaitForElementInList(string description, Func<JsonElement, bool> matches, params string[] args)
+    {
+        var elapsed = Stopwatch.StartNew();
+        var attempts = 0;
+
+        while (true)
+        {
+            var result = await RunCliAsync(args);
+            attempts++;
+
+            if (result.ExitCode == ExitCodes.Success && TryFindElement(result.StandardOutput, matches, out var element))
+            {
+                return element;
+            }
+
+            if (elapsed.Elapsed >= ReadBackTimeout)
+            {
+                throw new ReadBackTimedOut(description, args, attempts, elapsed.Elapsed, result);
+            }
+
+            await Task.Delay(_readBackPollInterval);
+        }
+    }
+
+    static bool TryFindElement(string json, Func<JsonElement, bool> matches, out JsonElement element)
+    {
+        element = default;
+
+        try
+        {
+            using var document = JsonDocument.Parse(json);
+            if (document.RootElement.ValueKind != JsonValueKind.Array)
+            {
+                return false;
+            }
+
+            foreach (var candidate in document.RootElement.EnumerateArray())
+            {
+                if (matches(candidate))
+                {
+                    // Clone so the element stays readable once the document it was parsed from is disposed.
+                    element = candidate.Clone();
+                    return true;
+                }
+            }
+        }
+        catch (JsonException)
+        {
+            // The command did not produce JSON on this attempt. Treat it as "not there yet" and let the
+            // timeout report the output it did produce.
+        }
+
+        return false;
     }
 }


### PR DESCRIPTION
## Fixed

- The integration specs for adding and removing a user or an application no longer fail intermittently when the listing has not caught up with the add yet (#54)
