### PR TITLE
Support Chronicle 16.36 generated contracts

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,8 +6,8 @@
   <ItemGroup>
     <!-- Cratis -->
     <PackageVersion Include="Cratis.Arc.Screenplay" Version="21.14.2" />
-    <PackageVersion Include="Cratis.Chronicle.Connections" Version="16.30.1" />
-    <PackageVersion Include="Cratis.Chronicle.Contracts" Version="16.30.1" />
+    <PackageVersion Include="Cratis.Chronicle.Connections" Version="16.36.3" />
+    <PackageVersion Include="Cratis.Chronicle.Contracts" Version="16.36.3" />
     <PackageVersion Include="Cratis.Fundamentals" Version="7.17.1" />
     <!-- Prologue -->
     <PackageVersion Include="Cratis.Prologue.Configuration" Version="1.2.0" />
@@ -29,11 +29,11 @@
     <PackageVersion Include="Grpc.Net.Client" Version="2.80.0" />
     <PackageVersion Include="System.Text.Json" Version="10.0.10" />
     <!-- Source Generator -->
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.6.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.9.0" />
     <!-- Source reading — loading a solution or project into a Roslyn compilation for Screenplay generation. -->
     <PackageVersion Include="Microsoft.Build.Locator" Version="1.11.2" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="5.6.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.6.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="5.9.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.9.0" />
     <!-- Compile-time only: MSBuildLocator resolves the MSBuild assemblies from the installed .NET SDK at run time. -->
     <PackageVersion Include="Microsoft.Build.Framework" Version="18.9.6" />
     <PackageVersion Include="Microsoft.NET.StringTools" Version="18.9.6" />
@@ -41,16 +41,16 @@
     <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.556" NoWarn="NU5104" />
     <PackageVersion Include="Roslynator.Analyzers" Version="4.15.0" />
     <PackageVersion Include="Meziantou.Analyzer" Version="3.0.137" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="5.6.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="5.6.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="5.9.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="5.9.0" />
     <!-- Transitive dependency overrides to address known vulnerabilities -->
     <PackageVersion Include="Snappier" Version="1.3.1" />
     <!-- Integration Testing -->
-    <PackageVersion Include="Testcontainers" Version="4.13.0" />
+    <PackageVersion Include="Testcontainers" Version="4.14.0" />
     <!-- Testing -->
     <PackageVersion Include="Cratis.Specifications" Version="4.0.0" />
     <PackageVersion Include="Cratis.Specifications.XUnit" Version="4.0.0" />
-    <PackageVersion Include="Cratis.Chronicle.XUnit.Integration" Version="16.30.1" />
+    <PackageVersion Include="Cratis.Chronicle.XUnit.Integration" Version="16.36.3" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />

--- a/Integration/Chronicle/for_Diagnose/when_diagnosing_server.cs
+++ b/Integration/Chronicle/for_Diagnose/when_diagnosing_server.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using context = Cratis.Cli.Integration.Chronicle.for_Diagnose.when_diagnosing_server.context;
+
+namespace Cratis.Cli.Integration.Chronicle.for_Diagnose;
+
+[Collection(ChronicleCollection.Name)]
+public class when_diagnosing_server(context context) : CliGiven<context>(context)
+{
+    public class context : given.a_connected_cli
+    {
+        public CliCommandResult Result = null!;
+
+        async Task Because() => Result = await RunCliAsync("chronicle", "diagnose");
+    }
+
+    [Fact] void should_include_event_stores() => Context.Result.StandardOutput.ShouldContain("\"eventStores\": [");
+    [Fact] void should_include_the_system_event_store() => Context.Result.StandardOutput.ShouldContain("System");
+    [Fact] void should_have_no_errors() => Context.Result.StandardError.ShouldEqual(string.Empty);
+}

--- a/Source/Cli.Generators/Cli.Generators.csproj
+++ b/Source/Cli.Generators/Cli.Generators.csproj
@@ -24,6 +24,6 @@
         <PackageReference Remove="System.Text.Json" />
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" PrivateAssets="all" />
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" VersionOverride="5.6.0" PrivateAssets="all" />
     </ItemGroup>
 </Project>

--- a/Source/Cli/Commands/Chronicle/Applications/AddApplicationCommand.cs
+++ b/Source/Cli/Commands/Chronicle/Applications/AddApplicationCommand.cs
@@ -17,9 +17,9 @@ public class AddApplicationCommand : ChronicleCommand<AddApplicationSettings>
     /// <inheritdoc/>
     protected override async Task<int> ExecuteCommandAsync(IServices services, AddApplicationSettings settings, string format)
     {
-        await services.Applications.Add(new AddApplication
+        await services.Applications.AddApplication(new AddApplicationRequest
         {
-            Id = Guid.NewGuid().ToString(),
+            Id = Guid.NewGuid(),
             ClientId = settings.ClientId,
             ClientSecret = settings.ClientSecret
         });

--- a/Source/Cli/Commands/Chronicle/Applications/ListApplicationsCommand.cs
+++ b/Source/Cli/Commands/Chronicle/Applications/ListApplicationsCommand.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Reactive.Linq;
+
 namespace Cratis.Cli.Commands.Chronicle.Applications;
 
 /// <summary>
@@ -15,7 +17,8 @@ public class ListApplicationsCommand : ChronicleCommand<EventStoreSettings>
     /// <inheritdoc/>
     protected override async Task<int> ExecuteCommandAsync(IServices services, EventStoreSettings settings, string format)
     {
-        var applications = await services.Applications.GetAll();
+        var result = await services.Applications.AllApplications().FirstAsync();
+        var applications = result.Data ?? [];
 
         OutputFormatter.Write(
             format,

--- a/Source/Cli/Commands/Chronicle/Applications/RemoveApplicationCommand.cs
+++ b/Source/Cli/Commands/Chronicle/Applications/RemoveApplicationCommand.cs
@@ -22,7 +22,7 @@ public class RemoveApplicationCommand : ChronicleCommand<RemoveApplicationSettin
             return ExitCodes.Success;
         }
 
-        await services.Applications.Remove(new RemoveApplication
+        await services.Applications.RemoveApplication(new RemoveApplicationRequest
         {
             Id = settings.AppId
         });

--- a/Source/Cli/Commands/Chronicle/Diagnose/DiagnoseCommand.cs
+++ b/Source/Cli/Commands/Chronicle/Diagnose/DiagnoseCommand.cs
@@ -84,7 +84,8 @@ public partial class DiagnoseCommand : ChronicleCommand<DiagnoseSettings>
         var eventStores = new List<string>();
         try
         {
-            eventStores = [.. await services.EventStores.GetEventStores()];
+            var result = await services.EventStores.AllEventStores();
+            eventStores = [.. result.Data ?? []];
         }
         catch { }
 

--- a/Source/Cli/Commands/Chronicle/EventStoreSelector.cs
+++ b/Source/Cli/Commands/Chronicle/EventStoreSelector.cs
@@ -50,7 +50,7 @@ public static class EventStoreSelector
         string? currentEventStore = null)
     {
         // Use Task.Run to execute the async connection and gRPC call in a clean thread-pool context.
-        // Calling ConnectSync (blocking) followed by GetEventStores().GetAwaiter().GetResult() from a
+        // Calling ConnectSync (blocking) followed by AllEventStores().GetAwaiter().GetResult() from a
         // thread that itself was resumed from a blocked GetResult() call can cause deadlocks with the
         // gRPC channel's internal completion machinery. Task.Run gives us a fresh context with no
         // blocked thread in the chain.
@@ -60,7 +60,8 @@ public static class EventStoreSelector
             eventStores = Task.Run(async () =>
             {
                 using var client = await CliChronicleConnection.Connect(connectionString);
-                return (await client.Services.EventStores.GetEventStores()).ToList();
+                var result = await client.Services.EventStores.AllEventStores();
+                return (result.Data ?? []).ToList();
             }).GetAwaiter().GetResult();
         }
         catch

--- a/Source/Cli/Commands/Chronicle/EventStores/ListEventStoresCommand.cs
+++ b/Source/Cli/Commands/Chronicle/EventStores/ListEventStoresCommand.cs
@@ -15,8 +15,8 @@ public class ListEventStoresCommand : ChronicleCommand<ChronicleSettings>
     /// <inheritdoc/>
     protected override async Task<int> ExecuteCommandAsync(IServices services, ChronicleSettings settings, string format)
     {
-        var eventStores = await services.EventStores.GetEventStores();
-        var names = eventStores.ToList();
+        var eventStores = await services.EventStores.AllEventStores();
+        var names = (eventStores.Data ?? []).ToList();
 
         OutputFormatter.Write(
             format,

--- a/Source/Cli/Commands/Chronicle/Jobs/GetJobCommand.cs
+++ b/Source/Cli/Commands/Chronicle/Jobs/GetJobCommand.cs
@@ -23,14 +23,13 @@ public class GetJobCommand : ChronicleCommand<JobCommandSettings>
             return ExitCodes.ValidationError;
         }
 
-        var result = await services.Jobs.GetJob(new GetJobRequest
+        var result = await services.Jobs.AllJobs(new AllJobsRequest
         {
             EventStore = settings.ResolveEventStore(),
-            Namespace = settings.ResolveNamespace(),
-            JobId = jobId
+            Namespace = settings.ResolveNamespace()
         });
 
-        var job = result.Value0;
+        var job = result.Data?.SingleOrDefault(job => job.Id == jobId);
 
         if (job is null)
         {
@@ -65,7 +64,7 @@ public class GetJobCommand : ChronicleCommand<JobCommandSettings>
                     isCompleted = job.Progress?.IsCompleted,
                     message = job.Progress?.Message
                 },
-                steps = (steps ?? []).Select(s => new
+                steps = (steps.Data ?? []).Select(s => new
                 {
                     id = s.Id,
                     type = s.Type,

--- a/Source/Cli/Commands/Chronicle/Jobs/ListJobsCommand.cs
+++ b/Source/Cli/Commands/Chronicle/Jobs/ListJobsCommand.cs
@@ -16,13 +16,13 @@ public class ListJobsCommand : ChronicleCommand<JobsSettings>
     /// <inheritdoc/>
     protected override async Task<int> ExecuteCommandAsync(IServices services, JobsSettings settings, string format)
     {
-        var jobs = await services.Jobs.GetJobs(new GetJobsRequest
+        var jobs = await services.Jobs.AllJobs(new AllJobsRequest
         {
             EventStore = settings.ResolveEventStore(),
             Namespace = settings.ResolveNamespace()
         });
 
-        var jobList = (jobs ?? []).ToList();
+        var jobList = (jobs.Data ?? []).ToList();
 
         OutputFormatter.Write(
             format,

--- a/Source/Cli/Commands/Chronicle/Jobs/ResumeJobCommand.cs
+++ b/Source/Cli/Commands/Chronicle/Jobs/ResumeJobCommand.cs
@@ -23,7 +23,7 @@ public class ResumeJobCommand : ChronicleCommand<JobCommandSettings>
             return ExitCodes.ValidationError;
         }
 
-        await services.Jobs.Resume(new ResumeJob
+        await services.Jobs.ResumeJob(new ResumeJobRequest
         {
             EventStore = settings.ResolveEventStore(),
             Namespace = settings.ResolveNamespace(),

--- a/Source/Cli/Commands/Chronicle/Jobs/StopJobCommand.cs
+++ b/Source/Cli/Commands/Chronicle/Jobs/StopJobCommand.cs
@@ -23,7 +23,7 @@ public class StopJobCommand : ChronicleCommand<JobCommandSettings>
             return ExitCodes.ValidationError;
         }
 
-        await services.Jobs.Stop(new StopJob
+        await services.Jobs.StopJob(new StopJobRequest
         {
             EventStore = settings.ResolveEventStore(),
             Namespace = settings.ResolveNamespace(),

--- a/Source/Cli/Commands/Chronicle/Namespaces/ListNamespacesCommand.cs
+++ b/Source/Cli/Commands/Chronicle/Namespaces/ListNamespacesCommand.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Cratis.Chronicle.Contracts.Namespaces;
+
 namespace Cratis.Cli.Commands.Chronicle.Namespaces;
 
 /// <summary>
@@ -16,8 +18,8 @@ public class ListNamespacesCommand : ChronicleCommand<EventStoreSettings>
     /// <inheritdoc/>
     protected override async Task<int> ExecuteCommandAsync(IServices services, EventStoreSettings settings, string format)
     {
-        var namespaces = await services.Namespaces.GetNamespaces(new GetNamespacesRequest { EventStore = settings.ResolveEventStore() });
-        var names = namespaces.ToList();
+        var namespaces = await services.Namespaces.AllNamespaces(new AllNamespacesRequest { EventStore = settings.ResolveEventStore() });
+        var names = (namespaces.Data ?? []).ToList();
 
         OutputFormatter.Write(
             format,

--- a/Source/Cli/Commands/Chronicle/Users/AddUserCommand.cs
+++ b/Source/Cli/Commands/Chronicle/Users/AddUserCommand.cs
@@ -18,7 +18,7 @@ public class AddUserCommand : ChronicleCommand<AddUserSettings>
     /// <inheritdoc/>
     protected override async Task<int> ExecuteCommandAsync(IServices services, AddUserSettings settings, string format)
     {
-        await services.Users.Add(new AddUser
+        await services.Users.AddUser(new AddUserRequest
         {
             UserId = Guid.NewGuid(),
             Username = settings.Username,

--- a/Source/Cli/Commands/Chronicle/Users/ListUsersCommand.cs
+++ b/Source/Cli/Commands/Chronicle/Users/ListUsersCommand.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Reactive.Linq;
+
 namespace Cratis.Cli.Commands.Chronicle.Users;
 
 /// <summary>
@@ -15,7 +17,8 @@ public class ListUsersCommand : ChronicleCommand<EventStoreSettings>
     /// <inheritdoc/>
     protected override async Task<int> ExecuteCommandAsync(IServices services, EventStoreSettings settings, string format)
     {
-        var users = await services.Users.GetAll();
+        var result = await services.Users.AllUsers().FirstAsync();
+        var users = result.Data ?? [];
 
         OutputFormatter.Write(
             format,

--- a/Source/Cli/Commands/Chronicle/Users/RemoveUserCommand.cs
+++ b/Source/Cli/Commands/Chronicle/Users/RemoveUserCommand.cs
@@ -22,7 +22,7 @@ public class RemoveUserCommand : ChronicleCommand<RemoveUserSettings>
             return ExitCodes.Success;
         }
 
-        await services.Users.Remove(new RemoveUser
+        await services.Users.RemoveUser(new RemoveUserRequest
         {
             UserId = settings.UserId
         });

--- a/Source/Cli/Commands/Chronicle/Workbench/WorkbenchData.cs
+++ b/Source/Cli/Commands/Chronicle/Workbench/WorkbenchData.cs
@@ -62,7 +62,7 @@ public record WorkbenchData(
     IReadOnlyList<string> EventStoreNames,
     IReadOnlyList<ObserverInformation> Observers,
     IReadOnlyList<FailedPartition> FailedPartitions,
-    IReadOnlyList<Job> Jobs,
+    IReadOnlyList<JobSummaryResponse> Jobs,
     IReadOnlyList<Recommendation> Recommendations,
     ulong? TailSequenceNumber,
     DateTimeOffset CapturedAt,
@@ -76,8 +76,8 @@ public record WorkbenchData(
     IReadOnlyList<string> ReadModelInstances,
     int ReadModelInstancesTotalCount,
     string? ReadModelInstancesError,
-    IReadOnlyList<Application> Applications,
-    IReadOnlyList<User> Users,
+    IReadOnlyList<ApplicationResponse> Applications,
+    IReadOnlyList<UserResponse> Users,
     IReadOnlyList<Identity> Identities,
     IReadOnlyList<EventStoreSubscriptionDefinition> EventStoreSubscriptions)
 {

--- a/Source/Cli/Commands/Chronicle/Workbench/WorkbenchDataService.cs
+++ b/Source/Cli/Commands/Chronicle/Workbench/WorkbenchDataService.cs
@@ -1,9 +1,11 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Reactive.Linq;
 using System.Text.Json;
 using Cratis.Chronicle.Contracts.Identities;
 using Cratis.Chronicle.Contracts.Jobs;
+using Cratis.Chronicle.Contracts.Namespaces;
 using Cratis.Chronicle.Contracts.Observation.EventStoreSubscriptions;
 using Cratis.Cli.Commands.Chronicle.ReadModels;
 
@@ -165,7 +167,11 @@ public class WorkbenchDataService(IServices services, WorkbenchSettings settings
 
     async Task<IReadOnlyList<string>> FetchEventStoresAsync()
     {
-        try { return [.. await services.EventStores.GetEventStores().ConfigureAwait(false)]; }
+        try
+        {
+            var result = await services.EventStores.AllEventStores().ConfigureAwait(false);
+            return [.. result.Data ?? []];
+        }
         catch { return []; }
     }
 
@@ -195,15 +201,16 @@ public class WorkbenchDataService(IServices services, WorkbenchSettings settings
         catch { return []; }
     }
 
-    async Task<IReadOnlyList<Job>> FetchJobsAsync(string eventStore, string ns)
+    async Task<IReadOnlyList<JobSummaryResponse>> FetchJobsAsync(string eventStore, string ns)
     {
         try
         {
-            return [.. (await services.Jobs.GetJobs(new GetJobsRequest
+            var result = await services.Jobs.AllJobs(new AllJobsRequest
             {
                 EventStore = eventStore,
                 Namespace = ns
-            }).ConfigureAwait(false)) ?? []];
+            }).ConfigureAwait(false);
+            return [.. result.Data ?? []];
         }
         catch { return []; }
     }
@@ -309,21 +316,30 @@ public class WorkbenchDataService(IServices services, WorkbenchSettings settings
     {
         try
         {
-            return [.. await services.Namespaces.GetNamespaces(
-                new GetNamespacesRequest { EventStore = eventStore }).ConfigureAwait(false)];
+            var result = await services.Namespaces.AllNamespaces(
+                new AllNamespacesRequest { EventStore = eventStore }).ConfigureAwait(false);
+            return [.. result.Data ?? []];
         }
         catch { return []; }
     }
 
-    async Task<IReadOnlyList<Application>> FetchApplicationsAsync()
+    async Task<IReadOnlyList<ApplicationResponse>> FetchApplicationsAsync()
     {
-        try { return [.. await services.Applications.GetAll().ConfigureAwait(false) ?? []]; }
+        try
+        {
+            var result = await services.Applications.AllApplications().FirstAsync();
+            return [.. result.Data ?? []];
+        }
         catch { return []; }
     }
 
-    async Task<IReadOnlyList<User>> FetchUsersAsync()
+    async Task<IReadOnlyList<UserResponse>> FetchUsersAsync()
     {
-        try { return [.. await services.Users.GetAll().ConfigureAwait(false) ?? []]; }
+        try
+        {
+            var result = await services.Users.AllUsers().FirstAsync();
+            return [.. result.Data ?? []];
+        }
         catch { return []; }
     }
 

--- a/Source/Cli/Commands/Chronicle/Workbench/views/ApplicationsView.cs
+++ b/Source/Cli/Commands/Chronicle/Workbench/views/ApplicationsView.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Cratis.Chronicle.Contracts.Security;
 using SharpConsoleUI.Layout;
 
 namespace Cratis.Cli.Commands.Chronicle.Workbench;
@@ -9,7 +8,7 @@ namespace Cratis.Cli.Commands.Chronicle.Workbench;
 /// <summary>
 /// Applications navigation item — filterable table of registered OAuth applications with a detail pane.
 /// </summary>
-public class ApplicationsView : FilterableTableView<Application>
+public class ApplicationsView : FilterableTableView<ApplicationResponse>
 {
     /// <inheritdoc/>
     protected override IReadOnlyList<(string Name, TextJustification Justify, int? Width)> Columns =>
@@ -29,14 +28,14 @@ public class ApplicationsView : FilterableTableView<Application>
     protected override string EmptyStateMessage => "No applications registered.";
 
     /// <inheritdoc/>
-    protected override IEnumerable<Application> GetItems(WorkbenchData data) =>
+    protected override IEnumerable<ApplicationResponse> GetItems(WorkbenchData data) =>
         data.Applications.OrderBy(a => a.ClientId);
 
     /// <inheritdoc/>
-    protected override string GetKey(Application item) => item.Id.ToString();
+    protected override string GetKey(ApplicationResponse item) => item.Id.ToString();
 
     /// <inheritdoc/>
-    protected override string[] BuildRow(Application item)
+    protected override string[] BuildRow(ApplicationResponse item)
     {
         var activeColor = item.IsActive ? Theme.Success.ToMarkup() : Theme.Muted.ToMarkup();
         return
@@ -48,7 +47,7 @@ public class ApplicationsView : FilterableTableView<Application>
     }
 
     /// <inheritdoc/>
-    protected override string RenderDetail(Application? item, WorkbenchData? data)
+    protected override string RenderDetail(ApplicationResponse? item, WorkbenchData? data)
     {
         if (item is null)
         {
@@ -68,7 +67,7 @@ public class ApplicationsView : FilterableTableView<Application>
     }
 
     /// <inheritdoc/>
-    protected override bool MatchesFilter(Application item, string filter) =>
+    protected override bool MatchesFilter(ApplicationResponse item, string filter) =>
         item.ClientId.Contains(filter, StringComparison.OrdinalIgnoreCase) ||
         item.Id.ToString().Contains(filter, StringComparison.OrdinalIgnoreCase);
 }

--- a/Source/Cli/Commands/Chronicle/Workbench/views/JobsView.cs
+++ b/Source/Cli/Commands/Chronicle/Workbench/views/JobsView.cs
@@ -9,10 +9,10 @@ namespace Cratis.Cli.Commands.Chronicle.Workbench;
 /// <summary>
 /// Jobs tab — filterable table of background jobs with stop/resume actions in the detail pane.
 /// </summary>
-public class JobsView : FilterableTableView<Job>
+public class JobsView : FilterableTableView<JobSummaryResponse>
 {
     /// <summary>Gets the currently selected job, or <see langword="null"/> if none is selected.</summary>
-    public Job? SelectedJob => SelectedItem;
+    public JobSummaryResponse? SelectedJob => SelectedItem;
 
     /// <inheritdoc/>
     public override string ViewHelp =>
@@ -25,27 +25,27 @@ public class JobsView : FilterableTableView<Job>
     /// <summary>
     /// Gets or sets the callback invoked when the user requests to stop a job.
     /// </summary>
-    public Action<Job>? OnStopJob { get; set; }
+    public Action<JobSummaryResponse>? OnStopJob { get; set; }
 
     /// <summary>
     /// Gets or sets the callback invoked when the user requests to resume a job.
     /// </summary>
-    public Action<Job>? OnResumeJob { get; set; }
+    public Action<JobSummaryResponse>? OnResumeJob { get; set; }
 
     /// <summary>
     /// Gets or sets the callback invoked when the user requests a bulk stop of all checked jobs.
     /// </summary>
-    public Action<IReadOnlyList<Job>>? OnStopAll { get; set; }
+    public Action<IReadOnlyList<JobSummaryResponse>>? OnStopAll { get; set; }
 
     /// <summary>
     /// Gets or sets the callback invoked when the user requests a bulk resume of all checked jobs.
     /// </summary>
-    public Action<IReadOnlyList<Job>>? OnResumeAll { get; set; }
+    public Action<IReadOnlyList<JobSummaryResponse>>? OnResumeAll { get; set; }
 
     /// <summary>
     /// Gets all jobs that are currently checked (checkbox mode).
     /// </summary>
-    public IReadOnlyList<Job> Checked => CheckedItems;
+    public IReadOnlyList<JobSummaryResponse> Checked => CheckedItems;
 
     /// <inheritdoc/>
     protected override IReadOnlyList<(string Name, TextJustification Justify, int? Width)> Columns =>
@@ -95,14 +95,14 @@ public class JobsView : FilterableTableView<Job>
     }
 
     /// <inheritdoc/>
-    protected override IEnumerable<Job> GetItems(WorkbenchData data) =>
+    protected override IEnumerable<JobSummaryResponse> GetItems(WorkbenchData data) =>
         data.Jobs.OrderBy(j => j.Status.ToString());
 
     /// <inheritdoc/>
-    protected override string GetKey(Job item) => item.Id.ToString();
+    protected override string GetKey(JobSummaryResponse item) => item.Id.ToString();
 
     /// <inheritdoc/>
-    protected override string[] BuildRow(Job item)
+    protected override string[] BuildRow(JobSummaryResponse item)
     {
         var statusColor = GetJobStatusColor(item.Status);
         return
@@ -114,7 +114,7 @@ public class JobsView : FilterableTableView<Job>
     }
 
     /// <inheritdoc/>
-    protected override string RenderDetail(Job? item, WorkbenchData? data)
+    protected override string RenderDetail(JobSummaryResponse? item, WorkbenchData? data)
     {
         if (item is null)
         {
@@ -157,7 +157,7 @@ public class JobsView : FilterableTableView<Job>
     }
 
     /// <inheritdoc/>
-    protected override bool MatchesFilter(Job item, string filter) =>
+    protected override bool MatchesFilter(JobSummaryResponse item, string filter) =>
         (item.Type ?? string.Empty).Contains(filter, StringComparison.OrdinalIgnoreCase) ||
         item.Id.ToString().Contains(filter, StringComparison.OrdinalIgnoreCase) ||
         item.Status.ToString().Contains(filter, StringComparison.OrdinalIgnoreCase);

--- a/Source/Cli/Commands/Chronicle/Workbench/views/UsersView.cs
+++ b/Source/Cli/Commands/Chronicle/Workbench/views/UsersView.cs
@@ -8,7 +8,7 @@ namespace Cratis.Cli.Commands.Chronicle.Workbench;
 /// <summary>
 /// Users navigation item — filterable table of registered users with a detail pane.
 /// </summary>
-public class UsersView : FilterableTableView<User>
+public class UsersView : FilterableTableView<UserResponse>
 {
     /// <inheritdoc/>
     protected override IReadOnlyList<(string Name, TextJustification Justify, int? Width)> Columns =>
@@ -28,14 +28,14 @@ public class UsersView : FilterableTableView<User>
     protected override string EmptyStateMessage => "No users.";
 
     /// <inheritdoc/>
-    protected override IEnumerable<User> GetItems(WorkbenchData data) =>
+    protected override IEnumerable<UserResponse> GetItems(WorkbenchData data) =>
         data.Users.OrderBy(u => u.Username);
 
     /// <inheritdoc/>
-    protected override string GetKey(User item) => item.Id.ToString();
+    protected override string GetKey(UserResponse item) => item.Id.ToString();
 
     /// <inheritdoc/>
-    protected override string[] BuildRow(User item)
+    protected override string[] BuildRow(UserResponse item)
     {
         var activeColor = item.IsActive ? Theme.Success.ToMarkup() : Theme.Muted.ToMarkup();
         return
@@ -47,7 +47,7 @@ public class UsersView : FilterableTableView<User>
     }
 
     /// <inheritdoc/>
-    protected override string RenderDetail(User? item, WorkbenchData? data)
+    protected override string RenderDetail(UserResponse? item, WorkbenchData? data)
     {
         if (item is null)
         {
@@ -69,7 +69,7 @@ public class UsersView : FilterableTableView<User>
     }
 
     /// <inheritdoc/>
-    protected override bool MatchesFilter(User item, string filter) =>
+    protected override bool MatchesFilter(UserResponse item, string filter) =>
         item.Username.Contains(filter, StringComparison.OrdinalIgnoreCase) ||
         (item.Email ?? string.Empty).Contains(filter, StringComparison.OrdinalIgnoreCase) ||
         item.Id.ToString().Contains(filter, StringComparison.OrdinalIgnoreCase);

--- a/Source/Cli/Commands/Chronicle/Workbench/windows/MainWindow.cs
+++ b/Source/Cli/Commands/Chronicle/Workbench/windows/MainWindow.cs
@@ -2,8 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Cratis.Chronicle.Contracts.Jobs;
-using Cratis.Chronicle.Contracts.Observation;
-using Cratis.Chronicle.Contracts.Recommendations;
 using SharpConsoleUI;
 using SharpConsoleUI.Builders;
 using SharpConsoleUI.Helpers;
@@ -344,7 +342,7 @@ public class MainWindow(
         {
             jv.OnStopJob = job => _actionHandler!.ExecuteAction(
                 $"Stop job '{TruncateId(job.Type ?? job.Id.ToString())}'",
-                () => services.Jobs.Stop(new StopJob
+                () => services.Jobs.StopJob(new StopJobRequest
                 {
                     EventStore = ActiveEventStore,
                     Namespace = ActiveNamespace,
@@ -353,7 +351,7 @@ public class MainWindow(
 
             jv.OnResumeJob = job => _actionHandler!.ExecuteAction(
                 $"Resume job '{TruncateId(job.Type ?? job.Id.ToString())}'",
-                () => services.Jobs.Resume(new ResumeJob
+                () => services.Jobs.ResumeJob(new ResumeJobRequest
                 {
                     EventStore = ActiveEventStore,
                     Namespace = ActiveNamespace,
@@ -363,7 +361,7 @@ public class MainWindow(
             jv.OnStopAll = jobs => _actionHandler!.ConfirmThenExecuteAll(
                 $"Stop {jobs.Count} job{(jobs.Count == 1 ? string.Empty : "s")}",
                 jobs,
-                job => services.Jobs.Stop(new StopJob
+                job => services.Jobs.StopJob(new StopJobRequest
                 {
                     EventStore = ActiveEventStore,
                     Namespace = ActiveNamespace,
@@ -374,7 +372,7 @@ public class MainWindow(
             jv.OnResumeAll = jobs => _actionHandler!.ConfirmThenExecuteAll(
                 $"Resume {jobs.Count} job{(jobs.Count == 1 ? string.Empty : "s")}",
                 jobs,
-                job => services.Jobs.Resume(new ResumeJob
+                job => services.Jobs.ResumeJob(new ResumeJobRequest
                 {
                     EventStore = ActiveEventStore,
                     Namespace = ActiveNamespace,

--- a/Source/Cli/Commands/Completions/DynamicCompleteCommand.cs
+++ b/Source/Cli/Commands/Completions/DynamicCompleteCommand.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Reactive.Linq;
 using Cratis.Chronicle.Contracts.Jobs;
 using Cratis.Chronicle.Contracts.Observation.EventStoreSubscriptions;
 using Cratis.Cli.Commands.Chronicle;
@@ -39,12 +40,12 @@ public class DynamicCompleteCommand : ChronicleCommand<DynamicCompleteSettings>
                     break;
 
                 case "jobs":
-                    var jobs = await services.Jobs.GetJobs(new GetJobsRequest
+                    var jobs = await services.Jobs.AllJobs(new AllJobsRequest
                     {
                         EventStore = eventStore,
                         Namespace = ns
                     });
-                    foreach (var job in jobs ?? [])
+                    foreach (var job in jobs.Data ?? [])
                     {
                         Console.WriteLine(job.Id.ToString());
                     }
@@ -78,8 +79,8 @@ public class DynamicCompleteCommand : ChronicleCommand<DynamicCompleteSettings>
                     IEnumerable<string> storeNames;
                     if (eventStore == CliDefaults.DefaultEventStoreName)
                     {
-                        var allStores = await services.EventStores.GetEventStores();
-                        storeNames = allStores ?? [];
+                        var allStores = await services.EventStores.AllEventStores();
+                        storeNames = allStores.Data ?? [];
                     }
                     else
                     {
@@ -105,8 +106,8 @@ public class DynamicCompleteCommand : ChronicleCommand<DynamicCompleteSettings>
                     break;
 
                 case "event-stores":
-                    var stores = await services.EventStores.GetEventStores();
-                    foreach (var store in stores ?? [])
+                    var stores = await services.EventStores.AllEventStores();
+                    foreach (var store in stores.Data ?? [])
                     {
                         Console.WriteLine(store);
                     }
@@ -139,8 +140,8 @@ public class DynamicCompleteCommand : ChronicleCommand<DynamicCompleteSettings>
                     break;
 
                 case "users":
-                    var users = await services.Users.GetAll();
-                    foreach (var user in users ?? [])
+                    var users = await services.Users.AllUsers().FirstAsync();
+                    foreach (var user in users.Data ?? [])
                     {
                         Console.WriteLine(user.Id);
                     }
@@ -148,8 +149,8 @@ public class DynamicCompleteCommand : ChronicleCommand<DynamicCompleteSettings>
                     break;
 
                 case "applications":
-                    var apps = await services.Applications.GetAll();
-                    foreach (var app in apps ?? [])
+                    var apps = await services.Applications.AllApplications().FirstAsync();
+                    foreach (var app in apps.Data ?? [])
                     {
                         Console.WriteLine(app.Id);
                     }


### PR DESCRIPTION
# Summary

The CLI now uses the current Chronicle administration contracts and remains aligned with Chronicle 16.36.3.

## Fixed

- Chronicle diagnostics now discovers event stores instead of reporting `none found` against current servers.
- Event store, namespace, job, user, and application commands now work with Chronicle 16.36.3.