### PR TITLE
Generate Screenplay from Marten and Critter Stack source

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,8 +29,20 @@ jobs:
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 
+      # Bootstrap the first source-provider packages while their new package IDs await nuget.org trusted-publisher
+      # policies. Remove this step once both 0.1.0 releases are available from nuget.org.
+      - name: Download Screenplay source-provider packages
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release download v0.1.0 --repo Cratis/Screenplay.Generation --pattern '*.nupkg' --dir ./Artifacts/Dependencies
+          gh release download v0.1.0 --repo Cratis/Screenplay.CritterStack --pattern '*.nupkg' --dir ./Artifacts/Dependencies
+
+      - name: Restore
+        run: dotnet restore --property:Configuration=Release --source ./Artifacts/Dependencies --source https://api.nuget.org/v3/index.json
+
       - name: Build
-        run: dotnet build --configuration Release
+        run: dotnet build --no-restore --configuration Release
 
       # The integration fixture starts a Chronicle container whose image is named after the Chronicle
       # package version, so a version bump always faces a cold ~400MB pull. Testcontainers times the first
@@ -45,4 +57,4 @@ jobs:
           docker pull "cratis/chronicle:$VERSION-development"
 
       - name: Test
-        run: dotnet test --configuration Release
+        run: dotnet test --no-restore --configuration Release

--- a/.github/workflows/publish-native.yml
+++ b/.github/workflows/publish-native.yml
@@ -28,8 +28,18 @@ jobs:
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 
+      - name: Download Screenplay source-provider packages
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release download v0.1.0 --repo Cratis/Screenplay.Generation --pattern '*.nupkg' --dir ./Artifacts/Dependencies
+          gh release download v0.1.0 --repo Cratis/Screenplay.CritterStack --pattern '*.nupkg' --dir ./Artifacts/Dependencies
+
+      - name: Restore
+        run: dotnet restore Source/Cli/Cli.csproj -r osx-arm64 --source ./Artifacts/Dependencies --source https://api.nuget.org/v3/index.json
+
       - name: Publish
-        run: dotnet publish Source/Cli/Cli.csproj -c Release -r osx-arm64 -p:SelfContained=true -p:PublishSingleFile=true -p:Version=${{ inputs.version }} -o ./publish/osx-arm64
+        run: dotnet publish Source/Cli/Cli.csproj --no-restore -c Release -r osx-arm64 -p:SelfContained=true -p:PublishSingleFile=true -p:Version=${{ inputs.version }} -o ./publish/osx-arm64
 
       - name: Package
         run: |
@@ -55,8 +65,18 @@ jobs:
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 
+      - name: Download Screenplay source-provider packages
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release download v0.1.0 --repo Cratis/Screenplay.Generation --pattern '*.nupkg' --dir ./Artifacts/Dependencies
+          gh release download v0.1.0 --repo Cratis/Screenplay.CritterStack --pattern '*.nupkg' --dir ./Artifacts/Dependencies
+
+      - name: Restore
+        run: dotnet restore Source/Cli/Cli.csproj -r osx-x64 --source ./Artifacts/Dependencies --source https://api.nuget.org/v3/index.json
+
       - name: Publish
-        run: dotnet publish Source/Cli/Cli.csproj -c Release -r osx-x64 -p:SelfContained=true -p:PublishSingleFile=true -p:Version=${{ inputs.version }} -o ./publish/osx-x64
+        run: dotnet publish Source/Cli/Cli.csproj --no-restore -c Release -r osx-x64 -p:SelfContained=true -p:PublishSingleFile=true -p:Version=${{ inputs.version }} -o ./publish/osx-x64
 
       - name: Package
         run: |
@@ -82,8 +102,18 @@ jobs:
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 
+      - name: Download Screenplay source-provider packages
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release download v0.1.0 --repo Cratis/Screenplay.Generation --pattern '*.nupkg' --dir ./Artifacts/Dependencies
+          gh release download v0.1.0 --repo Cratis/Screenplay.CritterStack --pattern '*.nupkg' --dir ./Artifacts/Dependencies
+
+      - name: Restore
+        run: dotnet restore Source/Cli/Cli.csproj -r linux-x64 --source ./Artifacts/Dependencies --source https://api.nuget.org/v3/index.json
+
       - name: Publish
-        run: dotnet publish Source/Cli/Cli.csproj -c Release -r linux-x64 -p:SelfContained=true -p:PublishSingleFile=true -p:Version=${{ inputs.version }} -o ./publish/linux-x64
+        run: dotnet publish Source/Cli/Cli.csproj --no-restore -c Release -r linux-x64 -p:SelfContained=true -p:PublishSingleFile=true -p:Version=${{ inputs.version }} -o ./publish/linux-x64
 
       - name: Package
         run: |
@@ -109,8 +139,18 @@ jobs:
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 
+      - name: Download Screenplay source-provider packages
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release download v0.1.0 --repo Cratis/Screenplay.Generation --pattern '*.nupkg' --dir ./Artifacts/Dependencies
+          gh release download v0.1.0 --repo Cratis/Screenplay.CritterStack --pattern '*.nupkg' --dir ./Artifacts/Dependencies
+
+      - name: Restore
+        run: dotnet restore Source/Cli/Cli.csproj -r linux-arm64 --source ./Artifacts/Dependencies --source https://api.nuget.org/v3/index.json
+
       - name: Publish
-        run: dotnet publish Source/Cli/Cli.csproj -c Release -r linux-arm64 -p:SelfContained=true -p:PublishSingleFile=true -p:Version=${{ inputs.version }} -o ./publish/linux-arm64
+        run: dotnet publish Source/Cli/Cli.csproj --no-restore -c Release -r linux-arm64 -p:SelfContained=true -p:PublishSingleFile=true -p:Version=${{ inputs.version }} -o ./publish/linux-arm64
 
       - name: Package
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -101,8 +101,19 @@ jobs:
       - name: Remove any existing artifacts
         run: rm -rf ${{ env.NUGET_OUTPUT }}
 
+      # Bootstrap until the new package IDs are available from nuget.org.
+      - name: Download Screenplay source-provider packages
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release download v0.1.0 --repo Cratis/Screenplay.Generation --pattern '*.nupkg' --dir ./Artifacts/Dependencies
+          gh release download v0.1.0 --repo Cratis/Screenplay.CritterStack --pattern '*.nupkg' --dir ./Artifacts/Dependencies
+
+      - name: Restore
+        run: dotnet restore --property:Configuration=Release --source ./Artifacts/Dependencies --source https://api.nuget.org/v3/index.json
+
       - name: Build
-        run: dotnet build --configuration Release -p:Version=${{ needs.release.outputs.version }}
+        run: dotnet build --no-restore --configuration Release -p:Version=${{ needs.release.outputs.version }}
 
       - name: Create NuGet packages
         run: dotnet pack Source/Cli/Cli.csproj --no-build --configuration Release -o ${{ env.NUGET_OUTPUT }} -p:PackageVersion=${{ needs.release.outputs.version }}

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,19 +5,22 @@
   </PropertyGroup>
   <ItemGroup>
     <!-- Cratis -->
-    <PackageVersion Include="Cratis.Arc.Screenplay" Version="21.14.2" />
+    <PackageVersion Include="Cratis.Arc.Screenplay" Version="22.0.0" />
+    <PackageVersion Include="Cratis.CritterStack.Screenplay" Version="0.1.0" />
+    <PackageVersion Include="Cratis.Screenplay.Generation.Contracts" Version="0.1.0" />
+    <PackageVersion Include="Cratis.Screenplay.Generation.DotNet" Version="0.1.0" />
     <PackageVersion Include="Cratis.Chronicle.Connections" Version="16.36.3" />
     <PackageVersion Include="Cratis.Chronicle.Contracts" Version="16.36.3" />
     <PackageVersion Include="Cratis.Fundamentals" Version="7.17.1" />
     <!-- Prologue -->
-    <PackageVersion Include="Cratis.Prologue.Configuration" Version="1.2.0" />
-    <PackageVersion Include="Cratis.Prologue.Contracts" Version="1.2.0" />
-    <PackageVersion Include="Cratis.Prologue.Interpretation" Version="1.2.0" />
-    <PackageVersion Include="Cratis.Prologue.Interpreter.Contracts" Version="1.2.0" />
-    <PackageVersion Include="Cratis.Prologue.Screenplay" Version="1.2.0" />
-    <PackageVersion Include="Cratis.Screenplay" Version="2.1.0" />
-    <PackageVersion Include="Cratis.Stage.Contracts" Version="2.4.0" />
-    <PackageVersion Include="Cratis.Stage.Rendering.Cratis" Version="2.4.0" />
+    <PackageVersion Include="Cratis.Prologue.Configuration" Version="2.0.0" />
+    <PackageVersion Include="Cratis.Prologue.Contracts" Version="2.0.0" />
+    <PackageVersion Include="Cratis.Prologue.Interpretation" Version="2.0.0" />
+    <PackageVersion Include="Cratis.Prologue.Interpreter.Contracts" Version="2.0.0" />
+    <PackageVersion Include="Cratis.Prologue.Screenplay" Version="2.0.0" />
+    <PackageVersion Include="Cratis.Screenplay" Version="4.2.1" />
+    <PackageVersion Include="Cratis.Stage.Contracts" Version="3.7.0" />
+    <PackageVersion Include="Cratis.Stage.Rendering.Cratis" Version="3.7.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.10" />
     <!-- CLI -->
     <PackageVersion Include="MongoDB.Driver" Version="3.10.0" />

--- a/Documentation/reference/screenplay.md
+++ b/Documentation/reference/screenplay.md
@@ -1,6 +1,6 @@
 # Screenplay
 
-`cratis screenplay` works with Cratis Screenplay (`.play`) documents. It generates one from the source code of a Cratis Arc application — so the event model your team reads is derived from the code that actually runs rather than maintained alongside it — and it compiles the documents you already have.
+`cratis screenplay` works with Cratis Screenplay (`.play`) documents. It generates one from Arc, Marten, or Marten + Wolverine application source — so the event model your team reads is derived from the code that actually runs rather than maintained alongside it — and it compiles the documents you already have.
 
 ```bash
 cratis screenplay generate [PATH]
@@ -9,11 +9,11 @@ cratis screenplay validate [PATH]
 
 **Nothing needs to be running.** This is what separates `cratis screenplay` from [`cratis arc`](../arc/index.md): every `arc` command talks to a *running* application over HTTP, while `screenplay` only ever reads files. The result is reproducible from a checkout — commit it, diff it, and run it in CI, on a machine where the application was never started.
 
-Fetching a `.play` document from a running Arc application over its introspection endpoint is a separate, complementary route: it trades the SDK requirement for the requirement that the application be running. That route does not exist yet — neither the Arc endpoint nor a CLI command for it — so generating from source is today the only way to derive a Screenplay from a Cratis Arc application.
+Fetching a `.play` document from a running application over an introspection endpoint is a separate, complementary route: it trades the SDK requirement for the requirement that the application be running. Source generation remains reproducible from a restored checkout and does not execute application startup or connect to Chronicle/PostgreSQL.
 
 ## `cratis screenplay generate [PATH]`
 
-Reads a solution or project, derives the event model from the Arc artifacts it finds — commands, events, read models, projections, reactors, constraints, and the concepts they are built from — and writes a Screenplay document.
+Reads a solution or project, selects the Arc, Marten, or Critter Stack source provider, derives the event model from the framework artifacts and conventions it finds, and writes a Screenplay document.
 
 By default the document goes to standard output, so it composes with the shell:
 
@@ -34,6 +34,7 @@ Pass `--file` to write it directly instead. The output is written as raw UTF-8, 
 | Option | Description |
 |---|---|
 | `--file <FILE>` | File to write the generated Screenplay to. Writes to standard output when not given. |
+| `--provider <PROVIDER>` | Source provider: `auto`, `arc`, `marten`, or `critter-stack`. Defaults to auto detection. |
 | `--domain <NAME>` | Name of the domain the generated document belongs to. Defaults to the assembly or root namespace of the project, and to the solution name when several projects are read. |
 | `--module <NAME>` | Name of the module every discovered feature is placed within. Defaults to the domain. |
 | `--skip-segments <COUNT>` | Number of leading namespace segments to skip when inferring features and slices. |
@@ -45,6 +46,8 @@ The output file uses `--file` rather than `-o`, because `-o/--output` is the glo
 cratis screenplay generate
 cratis screenplay generate ./MyApp.slnx --file MyApp.play
 cratis screenplay generate ./Source/MyApp/MyApp.csproj
+cratis screenplay generate ./Banking.csproj --provider marten --file Banking.play
+cratis screenplay generate ./Helpdesk.csproj --provider critter-stack --file Helpdesk.play
 cratis screenplay generate --domain Library --module Lending --file Library.play
 ```
 
@@ -76,7 +79,7 @@ A solution filter (`.slnf`) is read as the solution it filters, which is how a r
 
 A Screenplay describes one application, and an application is regularly split across several projects — an executable alongside the libraries holding its slices. Every project of a solution therefore takes part in the same document, except:
 
-- **Projects that cannot declare anything the document is made of.** Every artifact is declared with an attribute the framework ships, so a project resolving neither the Arc nor the Chronicle one — a Roslyn analyzer, a build-time tool, a code-generation project — is left out. This is asked of what the project can *see*, not of what it is called.
+- **With the Arc provider, projects that cannot declare an Arc/Chronicle artifact.** A Roslyn analyzer, build-time tool, or code-generation project resolving neither framework is left out. Marten/Wolverine contracts are frequently markerless and may live in referenced projects without a direct package reference, so Critter Stack analysis retains non-spec C# projects and lets the provider contribute only evidence it recognizes.
 - **Spec projects**, by name: the ones called, or ending in, `.Specs`, `.Specifications`, `.Tests`, `.Test`, `.IntegrationTests`, or `.Specs.AppHost`. Nothing about what a spec project can see tells it apart — it references the same framework the application does — so the name is what decides. `.Specs.AppHost` covers the host integration specs start the application in.
 
 A project that targets several frameworks is read once. The workspace opens it once per target framework and names the results `MyApp(net10.0)`, `MyApp(net9.0)`; they all hold the same application, so one of them takes part.
@@ -131,7 +134,8 @@ The project does **not** have to have been built first. Sources MSBuild generate
 | No solution or project found in `PATH` or any parent folder | Not-found error. |
 | The solution holds no project that is not specs | Validation error (`CLI0001`). |
 | A project has not been restored | Validation error (`CLI0005`) naming it; nothing is generated. |
-| No project of the solution can declare a command or an event type | Validation error (`CLI0006`). |
+| No Arc project of the solution can declare a command or event type | Validation error (`CLI0006`). |
+| `--provider` is not `auto`, `arc`, `marten`, or `critter-stack` | Validation error (`CLI0007`). |
 | A project cannot be read into a compilation | Validation error (`CLI0004`) naming it; the remaining projects are still described. |
 | Generation reports one or more errors, with `--file` | Validation error; the document is written anyway. |
 | Generation reports one or more errors, writing to standard output | Validation error; nothing is written. |
@@ -181,7 +185,7 @@ With `-o json` or `-o json-compact` the same diagnostics are written to standard
 
 Generating from source is one of three ways to arrive at a `.play` file, and they meet in the same place:
 
-- **From source** — `screenplay generate`, for an application that already exists in Cratis Arc. Needs the .NET SDK and a checkout; needs nothing running.
+- **From source** — `screenplay generate`, for an Arc, Marten, or Critter Stack application. Needs the .NET SDK and a restored checkout; needs nothing running.
 - **From a running system** — [`cratis prologue`](prologue.md) captures what a system does and interprets it into a Screenplay, for systems built without Cratis.
 - **By hand** — write the `.play` file as the design, before any code exists.
 

--- a/Source/Cli.Specs/for_CritterStackScreenplayGeneration/given/a_marten_application_built_from_source.cs
+++ b/Source/Cli.Specs/for_CritterStackScreenplayGeneration/given/a_marten_application_built_from_source.cs
@@ -1,0 +1,65 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+
+namespace Cratis.Cli.for_CritterStackScreenplayGeneration.given;
+
+public class a_marten_application_built_from_source : Specification
+{
+    protected const string ProjectName = "Banking";
+
+    static readonly string Source = string.Join(
+        '\n',
+        [
+            "namespace Marten",
+            "{",
+            "    public interface IDocumentStore;",
+            "    public class StoreOptions",
+            "    {",
+            "        public Marten.Events.Projections.ProjectionOptions Projections { get; } = new();",
+            "    }",
+            "}",
+            "namespace Marten.Events.Projections",
+            "{",
+            "    public enum SnapshotLifecycle { Inline }",
+            "    public class ProjectionOptions",
+            "    {",
+            "        public void Snapshot<T>(SnapshotLifecycle lifecycle) { }",
+            "    }",
+            "}",
+            "namespace Banking",
+            "{",
+            "    public record AccountOpened(System.Guid AccountId);",
+            "    public class Account",
+            "    {",
+            "        public System.Guid Id { get; set; }",
+            "        public void Apply(AccountOpened opened) { }",
+            "    }",
+            "    public static class Configuration",
+            "    {",
+            "        public static void Configure(Marten.StoreOptions options) =>",
+            "            options.Projections.Snapshot<Account>(Marten.Events.Projections.SnapshotLifecycle.Inline);",
+            "    }",
+            "}"
+        ]);
+
+    protected LoadedCompilation Loaded { get; private set; } = null!;
+
+    void Establish() => Loaded = new(
+        [
+            CSharpCompilation.Create(
+                ProjectName,
+                [CSharpSyntaxTree.ParseText(Source, path: "/workspace/Banking/Account.cs")],
+                References(),
+                new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary))
+        ],
+        [ProjectName],
+        []);
+
+    static IEnumerable<MetadataReference> References() =>
+        ((string)AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES")!)
+            .Split(Path.PathSeparator)
+            .Select(_ => MetadataReference.CreateFromFile(_));
+}

--- a/Source/Cli.Specs/for_CritterStackScreenplayGeneration/when_generating/and_source_does_not_compile.cs
+++ b/Source/Cli.Specs/for_CritterStackScreenplayGeneration/when_generating/and_source_does_not_compile.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.CodeAnalysis.CSharp;
+
+namespace Cratis.Cli.for_CritterStackScreenplayGeneration.when_generating;
+
+public class and_source_does_not_compile : given.a_marten_application_built_from_source
+{
+    GeneratedScreenplay _result = null!;
+
+    void Because()
+    {
+        var broken = Loaded.Compilations[0].AddSyntaxTrees(CSharpSyntaxTree.ParseText("public class Broken { MissingType Value; }"));
+        var loaded = Loaded with { Compilations = [broken] };
+        _result = CritterStackScreenplayGeneration.GenerateFrom(
+            loaded,
+            "/workspace/Banking/Banking.csproj",
+            ScreenplayGenerationOptions.Default with { Provider = ScreenplayProviders.Marten });
+    }
+
+    [Fact] void should_generate_no_source() => _result.Source.ShouldBeEmpty();
+    [Fact] void should_report_the_compilation_error() => _result.Diagnostics.Select(_ => _.Code).ShouldContainOnly(ScreenplayDiagnosticCodes.SourceDidNotCompile);
+}

--- a/Source/Cli.Specs/for_CritterStackScreenplayGeneration/when_generating/from_marten_source.cs
+++ b/Source/Cli.Specs/for_CritterStackScreenplayGeneration/when_generating/from_marten_source.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Cli.for_CritterStackScreenplayGeneration.when_generating;
+
+public class from_marten_source : given.a_marten_application_built_from_source
+{
+    GeneratedScreenplay _result = null!;
+
+    void Because() => _result = CritterStackScreenplayGeneration.GenerateFrom(
+        Loaded,
+        "/workspace/Banking/Banking.csproj",
+        ScreenplayGenerationOptions.Default with { Provider = ScreenplayProviders.Marten });
+
+    [Fact] void should_report_the_project() => _result.Projects.ShouldContainOnly(ProjectName);
+    [Fact] void should_generate_the_read_model() => _result.Source.ShouldContain("readmodel Account");
+    [Fact] void should_generate_the_event() => _result.Source.ShouldContain("event AccountOpened");
+    [Fact] void should_generate_the_reducer() => _result.Source.ShouldContain("reducer AccountSnapshot => Account");
+    [Fact] void should_report_no_diagnostics() => _result.Diagnostics.ShouldBeEmpty();
+}

--- a/Source/Cli.Specs/for_GenerateScreenplayCommand/when_generating/and_generation_options_are_given.cs
+++ b/Source/Cli.Specs/for_GenerateScreenplayCommand/when_generating/and_generation_options_are_given.cs
@@ -11,6 +11,7 @@ public class and_generation_options_are_given : given.a_generate_screenplay_comm
         _settings.Domain = "Library";
         _settings.Module = "Lending";
         _settings.SkipSegments = 2;
+        _settings.Provider = ScreenplayProviders.CritterStack;
     }
 
     async Task Because() => await Execute();
@@ -18,6 +19,11 @@ public class and_generation_options_are_given : given.a_generate_screenplay_comm
     [Fact] void should_pass_them_to_the_generation() => _generation.Received(1).Generate(
         Arg.Any<string>(),
         Arg.Is<ScreenplayGenerationOptions>(options => options.Domain == "Library" && options.Module == "Lending" && options.SegmentsToSkip == 2),
+        Arg.Any<CancellationToken>());
+
+    [Fact] void should_pass_the_provider_to_the_generation() => _generation.Received(1).Generate(
+        Arg.Any<string>(),
+        Arg.Is<ScreenplayGenerationOptions>(options => options.Provider == ScreenplayProviders.CritterStack),
         Arg.Any<CancellationToken>());
 
     [Fact] void should_leave_the_modules_named_by_one_name() => _generation.Received(1).Generate(

--- a/Source/Cli.Specs/for_ProviderScreenplayGeneration/given/provider_compilations.cs
+++ b/Source/Cli.Specs/for_ProviderScreenplayGeneration/given/provider_compilations.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+
+namespace Cratis.Cli.for_ProviderScreenplayGeneration.given;
+
+public class provider_compilations : Specification
+{
+    protected static LoadedCompilation LoadedFrom(string source) => new(
+        [CSharpCompilation.Create(
+            "Application",
+            [CSharpSyntaxTree.ParseText(source)],
+            References(),
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary))],
+        ["Application"],
+        []);
+
+    static IEnumerable<MetadataReference> References() =>
+        ((string)AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES")!)
+            .Split(Path.PathSeparator)
+            .Select(_ => MetadataReference.CreateFromFile(_));
+}

--- a/Source/Cli.Specs/for_ProviderScreenplayGeneration/when_selecting/and_a_solution_has_several_critter_stack_hosts.cs
+++ b/Source/Cli.Specs/for_ProviderScreenplayGeneration/when_selecting/and_a_solution_has_several_critter_stack_hosts.cs
@@ -1,0 +1,40 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+
+namespace Cratis.Cli.for_ProviderScreenplayGeneration.when_selecting;
+
+public class and_a_solution_has_several_critter_stack_hosts : Specification
+{
+    GeneratedScreenplay? _result;
+
+    void Because()
+    {
+        var loaded = new LoadedCompilation(
+            [Host("Api"), Host("Worker")],
+            ["Api", "Worker"],
+            []);
+        _result = ProviderScreenplayGeneration.AmbiguousHosts(
+            loaded,
+            "/workspace/Applications.slnx",
+            ScreenplayProviders.CritterStack);
+    }
+
+    [Fact] void should_report_an_outcome() => _result.ShouldNotBeNull();
+    [Fact] void should_report_both_hosts() => _result!.Diagnostics.Single().Message.ShouldContain("Api, Worker");
+    [Fact] void should_report_the_ambiguity_code() => _result!.Diagnostics.Single().Code.ShouldEqual(ScreenplayDiagnosticCodes.AmbiguousApplicationHosts);
+    [Fact] void should_generate_no_source() => _result!.Source.ShouldBeEmpty();
+
+    static CSharpCompilation Host(string name) => CSharpCompilation.Create(
+        name,
+        [CSharpSyntaxTree.ParseText("public static class Program { public static void Main() { } }")],
+        References(),
+        new CSharpCompilationOptions(OutputKind.ConsoleApplication));
+
+    static IEnumerable<MetadataReference> References() =>
+        ((string)AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES")!)
+            .Split(Path.PathSeparator)
+            .Select(_ => MetadataReference.CreateFromFile(_));
+}

--- a/Source/Cli.Specs/for_ProviderScreenplayGeneration/when_selecting/and_a_solution_has_several_critter_stack_hosts.cs
+++ b/Source/Cli.Specs/for_ProviderScreenplayGeneration/when_selecting/and_a_solution_has_several_critter_stack_hosts.cs
@@ -16,10 +16,10 @@ public class and_a_solution_has_several_critter_stack_hosts : Specification
             [Host("Api"), Host("Worker")],
             ["Api", "Worker"],
             []);
-        _result = ProviderScreenplayGeneration.AmbiguousHosts(
+        _result = new ProviderScreenplayGeneration().AmbiguousHosts(
             loaded,
             "/workspace/Applications.slnx",
-            ScreenplayProviders.CritterStack);
+            new CritterStackSourceProvider());
     }
 
     [Fact] void should_report_an_outcome() => _result.ShouldNotBeNull();

--- a/Source/Cli.Specs/for_ProviderScreenplayGeneration/when_selecting/and_arc_and_critter_stack_are_present.cs
+++ b/Source/Cli.Specs/for_ProviderScreenplayGeneration/when_selecting/and_arc_and_critter_stack_are_present.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Cli.for_ProviderScreenplayGeneration.when_selecting;
+
+public class and_arc_and_critter_stack_are_present : given.provider_compilations
+{
+    ProviderSelection _selection = null!;
+
+    void Because() => _selection = new ProviderScreenplayGeneration().Discover(
+        LoadedFrom(
+            "namespace Cratis.Arc.Commands.ModelBound { public class CommandAttribute : System.Attribute; } " +
+            "namespace Marten { public class StoreOptions; } " +
+            "namespace Wolverine { public class WolverineOptions; }"),
+        "/workspace/Application.csproj");
+
+    [Fact] void should_select_no_provider() => _selection.Provider.ShouldBeNull();
+    [Fact] void should_report_ambiguity() => _selection.Error!.Diagnostics.Single().Code.ShouldEqual(ScreenplayDiagnosticCodes.AmbiguousProviders);
+    [Fact] void should_name_both_candidates() => _selection.Error!.Diagnostics.Single().Message.ShouldContain("arc, critter-stack");
+}

--- a/Source/Cli.Specs/for_ProviderScreenplayGeneration/when_selecting/and_marten_and_wolverine_are_present.cs
+++ b/Source/Cli.Specs/for_ProviderScreenplayGeneration/when_selecting/and_marten_and_wolverine_are_present.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Cli.for_ProviderScreenplayGeneration.when_selecting;
+
+public class and_marten_and_wolverine_are_present : given.provider_compilations
+{
+    ProviderSelection _selection = null!;
+
+    void Because() => _selection = new ProviderScreenplayGeneration().Discover(
+        LoadedFrom(
+            "namespace Marten { public class StoreOptions; } " +
+            "namespace Wolverine { public class WolverineOptions; }"),
+        "/workspace/Application.csproj");
+
+    [Fact] void should_select_the_more_specific_critter_stack_provider() => _selection.Provider!.Name.ShouldEqual(ScreenplayProviders.CritterStack);
+    [Fact] void should_report_no_error() => _selection.Error.ShouldBeNull();
+}

--- a/Source/Cli.Specs/for_ProviderScreenplayGeneration/when_selecting/and_no_provider_matches.cs
+++ b/Source/Cli.Specs/for_ProviderScreenplayGeneration/when_selecting/and_no_provider_matches.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Cli.for_ProviderScreenplayGeneration.when_selecting;
+
+public class and_no_provider_matches : given.provider_compilations
+{
+    ProviderSelection _selection = null!;
+
+    void Because() => _selection = new ProviderScreenplayGeneration().Discover(
+        LoadedFrom("public class Application;"),
+        "/workspace/Application.csproj");
+
+    [Fact] void should_select_no_provider() => _selection.Provider.ShouldBeNull();
+    [Fact] void should_report_no_match() => _selection.Error!.Diagnostics.Single().Code.ShouldEqual(ScreenplayDiagnosticCodes.NoMatchingProvider);
+    [Fact] void should_list_available_providers() => _selection.Error!.Diagnostics.Single().Message.ShouldContain("arc, critter-stack, marten");
+}

--- a/Source/Cli/Cli.csproj
+++ b/Source/Cli/Cli.csproj
@@ -30,6 +30,9 @@
 
     <ItemGroup>
         <PackageReference Include="Cratis.Arc.Screenplay" />
+        <PackageReference Include="Cratis.CritterStack.Screenplay" />
+        <PackageReference Include="Cratis.Screenplay.Generation.Contracts" />
+        <PackageReference Include="Cratis.Screenplay.Generation.DotNet" />
         <PackageReference Include="Cratis.Chronicle.Connections" />
         <PackageReference Include="Cratis.Chronicle.Contracts" />
         <PackageReference Include="Cratis.Fundamentals" />

--- a/Source/Cli/Commands/Screenplay/CritterStackScreenplayGeneration.cs
+++ b/Source/Cli/Commands/Screenplay/CritterStackScreenplayGeneration.cs
@@ -39,6 +39,15 @@ public sealed class CritterStackScreenplayGeneration : IScreenplayGeneration
             return new GeneratedScreenplay(string.Empty, loaded.Diagnostics);
         }
 
+        var sourceErrors = SourceErrors(loaded);
+        if (sourceErrors.Count > 0)
+        {
+            return new GeneratedScreenplay(string.Empty, [.. loaded.Diagnostics, .. sourceErrors])
+            {
+                Projects = loaded.ProjectNames
+            };
+        }
+
         var sourceRoot = Path.GetDirectoryName(targetPath);
         var projects = loaded.Compilations
             .Select((compilation, index) => new DotNetProjectCompilation
@@ -65,6 +74,18 @@ public sealed class CritterStackScreenplayGeneration : IScreenplayGeneration
             Projects = loaded.ProjectNames
         };
     }
+
+    static IReadOnlyList<ScreenplayDiagnostic> SourceErrors(LoadedCompilation loaded) =>
+    [
+        .. loaded.Compilations.SelectMany((compilation, index) => compilation.GetDiagnostics()
+            .Where(_ => _.Severity == Microsoft.CodeAnalysis.DiagnosticSeverity.Error)
+            .Take(1)
+            .Select(_ => new ScreenplayDiagnostic(
+                ScreenplayDiagnosticSeverity.Error,
+                ScreenplayDiagnosticCodes.SourceDidNotCompile,
+                $"Source project '{loaded.ProjectNames[index]}' did not compile: {_.Id} {_.GetMessage()}",
+                _.Location.GetLineSpan().Path)))
+    ];
 
     static string? DomainFrom(string targetPath, LoadedCompilation loaded) =>
         loaded.Compilations.Count > 1 ? Path.GetFileNameWithoutExtension(targetPath) : loaded.ProjectNames[0];

--- a/Source/Cli/Commands/Screenplay/CritterStackScreenplayGeneration.cs
+++ b/Source/Cli/Commands/Screenplay/CritterStackScreenplayGeneration.cs
@@ -1,0 +1,83 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.CritterStack.Screenplay;
+using Cratis.Screenplay.Generation;
+using Cratis.Screenplay.Generation.DotNet;
+
+namespace Cratis.Cli.Commands.Screenplay;
+
+/// <summary>
+/// Generates Screenplay documents from Marten and Wolverine source code.
+/// </summary>
+public sealed class CritterStackScreenplayGeneration : IScreenplayGeneration
+{
+    /// <inheritdoc/>
+    public async Task<GeneratedScreenplay> Generate(
+        string targetPath,
+        ScreenplayGenerationOptions options,
+        CancellationToken cancellationToken) =>
+        GenerateFrom(
+            await ScreenplayCompilationLoader.Load(targetPath, includeAllProjects: true, cancellationToken),
+            targetPath,
+            options);
+
+    /// <summary>
+    /// Generates from compilations that have already been loaded.
+    /// </summary>
+    /// <param name="loaded">The loaded project compilations.</param>
+    /// <param name="targetPath">The solution or project path.</param>
+    /// <param name="options">Generation options.</param>
+    /// <returns>The generated Screenplay.</returns>
+    internal static GeneratedScreenplay GenerateFrom(
+        LoadedCompilation loaded,
+        string targetPath,
+        ScreenplayGenerationOptions options)
+    {
+        if (loaded.Compilations.Count == 0)
+        {
+            return new GeneratedScreenplay(string.Empty, loaded.Diagnostics);
+        }
+
+        var sourceRoot = Path.GetDirectoryName(targetPath);
+        var projects = loaded.Compilations
+            .Select((compilation, index) => new DotNetProjectCompilation
+            {
+                Name = loaded.ProjectNames[index],
+                ProjectPath = targetPath,
+                SourceRoot = sourceRoot,
+                Compilation = compilation
+            })
+            .ToArray();
+        var result = new CritterStackScreenplayGenerator().Generate(
+            projects,
+            new CritterStackScreenplayOptions
+            {
+                Domain = options.Domain ?? DomainFrom(targetPath, loaded),
+                Module = options.Module,
+                NamespaceSegmentsToSkip = options.SegmentsToSkip ?? 0
+            });
+
+        return new GeneratedScreenplay(
+            result.Source,
+            [.. loaded.Diagnostics, .. result.Diagnostics.Select(Map)])
+        {
+            Projects = loaded.ProjectNames
+        };
+    }
+
+    static string? DomainFrom(string targetPath, LoadedCompilation loaded) =>
+        loaded.Compilations.Count > 1 ? Path.GetFileNameWithoutExtension(targetPath) : loaded.ProjectNames[0];
+
+    static ScreenplayDiagnostic Map(GenerationDiagnostic diagnostic) => new(
+        diagnostic.Severity switch
+        {
+            GenerationDiagnosticSeverity.Information => ScreenplayDiagnosticSeverity.Information,
+            GenerationDiagnosticSeverity.Warning => ScreenplayDiagnosticSeverity.Warning,
+            GenerationDiagnosticSeverity.Error => ScreenplayDiagnosticSeverity.Error,
+            _ => ScreenplayDiagnosticSeverity.Error
+        },
+        diagnostic.Code,
+        diagnostic.Message,
+        diagnostic.Source?.Path);
+}

--- a/Source/Cli/Commands/Screenplay/GenerateScreenplayCommand.cs
+++ b/Source/Cli/Commands/Screenplay/GenerateScreenplayCommand.cs
@@ -4,17 +4,18 @@
 namespace Cratis.Cli.Commands.Screenplay;
 
 /// <summary>
-/// Generates a Cratis Screenplay (<c>.play</c>) file from the source code of a Cratis Arc application — reads the
-/// solution or project with Roslyn, hands the compilation to the Screenplay generator, and writes the result.
+/// Generates a Cratis Screenplay (<c>.play</c>) file from Arc, Marten, or Critter Stack application source — reads
+/// the solution or project with Roslyn, hands the compilation to the selected generator, and writes the result.
 /// </summary>
-[LlmDescription("Generates a Cratis Screenplay (.play) file from Cratis Arc SOURCE CODE. Reads a solution or project with Roslyn — it never connects to a running application, so nothing needs to be started first. Writes the .play source to standard output unless --file is given. Diagnostics for anything that could not be expressed go to standard error, grouped by severity; the command exits with a validation error when any of them is an error.")]
-[CliCommand("generate", "Generate a Screenplay from Arc source code", Branch = typeof(ScreenplayBranch))]
+[LlmDescription("Generates a Cratis Screenplay (.play) file from Arc, Marten, or Critter Stack SOURCE CODE. Reads a solution or project with Roslyn — it never connects to a running application, so nothing needs to be started first. Writes the .play source to standard output unless --file is given. Diagnostics for anything that could not be expressed go to standard error, grouped by severity; the command exits with a validation error when any of them is an error.")]
+[CliCommand("generate", "Generate a Screenplay from application source code", Branch = typeof(ScreenplayBranch))]
 [CliExample("screenplay", "generate")]
 [CliExample("screenplay", "generate", "./MyApp.slnx", "--file", "MyApp.play")]
 [CliExample("screenplay", "generate", "./Source/MyApp/MyApp.csproj")]
 [CliExample("screenplay", "generate", "--modules-from-namespace-roots", "--skip-segments", "1")]
 [LlmOption("[PATH]", "string", "Solution (.slnx, .sln, .slnf), project (.csproj), or folder to read. Defaults to the current directory, searching upwards for a solution or project.")]
 [LlmOption("--file", "string", "File to write the generated Screenplay to. Writes to standard output when not given.")]
+[LlmOption("--provider", "string", "Source framework provider: auto, arc, marten, or critter-stack.")]
 [LlmOption("--domain", "string", "Name of the domain the generated document belongs to.")]
 [LlmOption("--module", "string", "Name of the module every discovered feature is placed within.")]
 [LlmOption("--skip-segments", "int", "Number of leading namespace segments to skip when inferring features and slices.")]

--- a/Source/Cli/Commands/Screenplay/GenerateScreenplaySettings.cs
+++ b/Source/Cli/Commands/Screenplay/GenerateScreenplaySettings.cs
@@ -26,6 +26,13 @@ public class GenerateScreenplaySettings : GlobalSettings
     public string? File { get; set; }
 
     /// <summary>
+    /// Gets or sets the source framework provider used for generation.
+    /// </summary>
+    [CommandOption("--provider <PROVIDER>")]
+    [Description("Source framework provider: auto, arc, marten, or critter-stack. Defaults to auto detection.")]
+    public string Provider { get; set; } = ScreenplayProviders.Auto;
+
+    /// <summary>
     /// Gets or sets the domain the generated document belongs to.
     /// </summary>
     [CommandOption("--domain <NAME>")]
@@ -67,5 +74,5 @@ public class GenerateScreenplaySettings : GlobalSettings
     /// Gets the generation options these settings describe.
     /// </summary>
     /// <returns>The <see cref="ScreenplayGenerationOptions"/>.</returns>
-    public ScreenplayGenerationOptions ToGenerationOptions() => new(Domain, Module, SkipSegments, ModulesFromNamespaceRoots);
+    public ScreenplayGenerationOptions ToGenerationOptions() => new(Domain, Module, SkipSegments, ModulesFromNamespaceRoots, Provider);
 }

--- a/Source/Cli/Commands/Screenplay/IScreenplayGeneration.cs
+++ b/Source/Cli/Commands/Screenplay/IScreenplayGeneration.cs
@@ -4,12 +4,12 @@
 namespace Cratis.Cli.Commands.Screenplay;
 
 /// <summary>
-/// Defines a system that generates a Screenplay document from the source code of a Cratis Arc application.
+/// Defines a system that generates a Screenplay document from application source code.
 /// </summary>
 /// <remarks>
-/// This is the seam between the CLI and the <c>Cratis.Arc.Screenplay</c> generator. Everything the CLI does around
+/// This is the seam between the CLI and source framework generator packages. Everything the CLI does around
 /// generation — resolving the target, writing the document, reporting diagnostics — is expressed against this
-/// interface so that it stays independent of how a compilation is obtained.
+/// interface so that it stays independent of how framework semantics are recovered.
 /// </remarks>
 public interface IScreenplayGeneration
 {

--- a/Source/Cli/Commands/Screenplay/IScreenplaySourceProvider.cs
+++ b/Source/Cli/Commands/Screenplay/IScreenplaySourceProvider.cs
@@ -1,0 +1,44 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Cli.Commands.Screenplay;
+
+/// <summary>
+/// Defines one bundled source-framework provider for Screenplay generation.
+/// </summary>
+interface IScreenplaySourceProvider
+{
+    /// <summary>
+    /// Gets the stable provider name used by <c>--provider</c>.
+    /// </summary>
+    string Name { get; }
+
+    /// <summary>
+    /// Gets provider names this more-specific provider replaces when both match.
+    /// </summary>
+    IReadOnlyList<string> Supersedes { get; }
+
+    /// <summary>
+    /// Gets whether a solution with several deployable hosts is ambiguous for this provider.
+    /// </summary>
+    bool RequiresSingleHost { get; }
+
+    /// <summary>
+    /// Gets whether source evidence in the loaded compilations matches this provider.
+    /// </summary>
+    /// <param name="loaded">The loaded source compilations.</param>
+    /// <returns><see langword="true"/> when the provider matches.</returns>
+    bool Matches(LoadedCompilation loaded);
+
+    /// <summary>
+    /// Generates the Screenplay from already loaded source.
+    /// </summary>
+    /// <param name="loaded">The loaded source compilations.</param>
+    /// <param name="targetPath">The source target path.</param>
+    /// <param name="options">Generation options.</param>
+    /// <returns>The generated Screenplay.</returns>
+    GeneratedScreenplay GenerateFrom(
+        LoadedCompilation loaded,
+        string targetPath,
+        ScreenplayGenerationOptions options);
+}

--- a/Source/Cli/Commands/Screenplay/ProviderScreenplayGeneration.cs
+++ b/Source/Cli/Commands/Screenplay/ProviderScreenplayGeneration.cs
@@ -4,10 +4,25 @@
 namespace Cratis.Cli.Commands.Screenplay;
 
 /// <summary>
-/// Loads application source once and delegates generation to the selected framework provider.
+/// Loads application source once, discovers bundled provider capabilities, and delegates generation.
 /// </summary>
 public sealed class ProviderScreenplayGeneration : IScreenplayGeneration
 {
+    readonly IReadOnlyList<IScreenplaySourceProvider> _providers;
+
+    /// <summary>
+    /// Initializes generation with every allowlisted provider bundled into this CLI build.
+    /// </summary>
+    public ProviderScreenplayGeneration()
+        : this(ScreenplaySourceProviders.Default)
+    {
+    }
+
+    internal ProviderScreenplayGeneration(IReadOnlyList<IScreenplaySourceProvider> providers)
+    {
+        _providers = providers;
+    }
+
     /// <inheritdoc/>
     public async Task<GeneratedScreenplay> Generate(
         string targetPath,
@@ -15,34 +30,51 @@ public sealed class ProviderScreenplayGeneration : IScreenplayGeneration
         CancellationToken cancellationToken)
     {
         var requested = options.Provider.ToLowerInvariant();
-        if (!ScreenplayProviders.IsKnown(requested))
+        var explicitProvider = string.Equals(requested, ScreenplayProviders.Auto, StringComparison.Ordinal)
+            ? null
+            : _providers.FirstOrDefault(_ => string.Equals(_.Name, requested, StringComparison.Ordinal));
+        if (requested != ScreenplayProviders.Auto && explicitProvider is null)
         {
             return InvalidProvider(requested, targetPath);
         }
 
-        var loaded = await ScreenplayCompilationLoader.Load(
-            targetPath,
-            includeAllProjects: !string.Equals(requested, ScreenplayProviders.Arc, StringComparison.Ordinal),
-            cancellationToken);
-        var provider = string.Equals(requested, ScreenplayProviders.Auto, StringComparison.Ordinal)
-            ? Detect(loaded)
-            : requested;
-        return AmbiguousHosts(loaded, targetPath, provider) ?? provider switch
+        var loaded = await ScreenplayCompilationLoader.Load(targetPath, includeAllProjects: true, cancellationToken);
+        var selection = explicitProvider is null ? Discover(loaded, targetPath) : new ProviderSelection(explicitProvider, null);
+        if (selection.Error is not null)
         {
-            ScreenplayProviders.Arc => ArcScreenplayGeneration.GenerateFrom(NarrowToArc(loaded), targetPath, options),
-            ScreenplayProviders.Marten or ScreenplayProviders.CritterStack =>
-                CritterStackScreenplayGeneration.GenerateFrom(loaded, targetPath, options),
-            _ => InvalidProvider(provider, targetPath)
+            return selection.Error;
+        }
+
+        var provider = selection.Provider!;
+        return AmbiguousHosts(loaded, targetPath, provider) ?? provider.GenerateFrom(loaded, targetPath, options);
+    }
+
+    internal ProviderSelection Discover(LoadedCompilation loaded, string targetPath)
+    {
+        var matches = _providers.Where(_ => _.Matches(loaded)).ToArray();
+        var superseded = matches.SelectMany(_ => _.Supersedes).ToHashSet(StringComparer.Ordinal);
+        matches = [.. matches.Where(_ => !superseded.Contains(_.Name))];
+
+        return matches.Length switch
+        {
+            1 => new(matches[0], null),
+            0 => new(null, ProviderError(
+                ScreenplayDiagnosticCodes.NoMatchingProvider,
+                $"No bundled Screenplay provider recognizes the loaded source. Available providers: {ProviderNames()}",
+                targetPath)),
+            _ => new(null, ProviderError(
+                ScreenplayDiagnosticCodes.AmbiguousProviders,
+                $"Several Screenplay providers recognize the loaded source: {string.Join(", ", matches.Select(_ => _.Name).Order(StringComparer.Ordinal))}. Select one with --provider",
+                targetPath))
         };
     }
 
-    internal static GeneratedScreenplay? AmbiguousHosts(
+    internal GeneratedScreenplay? AmbiguousHosts(
         LoadedCompilation loaded,
         string targetPath,
-        string provider)
+        IScreenplaySourceProvider provider)
     {
-        if (!ScreenplayTargetResolver.IsSolution(targetPath) ||
-            (provider != ScreenplayProviders.Marten && provider != ScreenplayProviders.CritterStack))
+        if (!provider.RequiresSingleHost || !ScreenplayTargetResolver.IsSolution(targetPath))
         {
             return null;
         }
@@ -55,56 +87,24 @@ public sealed class ProviderScreenplayGeneration : IScreenplayGeneration
             .ToArray();
         return hosts.Length <= 1
             ? null
-            : new GeneratedScreenplay(
-                string.Empty,
-                [
-                    new ScreenplayDiagnostic(
-                        ScreenplayDiagnosticSeverity.Error,
-                        ScreenplayDiagnosticCodes.AmbiguousApplicationHosts,
-                        $"Solution contains several deployable application hosts: {string.Join(", ", hosts)}. Target one .csproj explicitly",
-                        targetPath)
-                ]);
+            : ProviderError(
+                ScreenplayDiagnosticCodes.AmbiguousApplicationHosts,
+                $"Solution contains several deployable application hosts: {string.Join(", ", hosts)}. Target one .csproj explicitly",
+                targetPath);
     }
 
-    static string Detect(LoadedCompilation loaded) => loaded.Compilations.Any(IsCritterStack)
-        ? ScreenplayProviders.CritterStack
-        : ScreenplayProviders.Arc;
+    string ProviderNames() => string.Join(", ", _providers.Select(_ => _.Name).Order(StringComparer.Ordinal));
 
-    static bool IsCritterStack(Microsoft.CodeAnalysis.Compilation compilation) =>
-        compilation.GetTypeByMetadataName("Marten.StoreOptions") is not null ||
-        compilation.GetTypeByMetadataName("Marten.IDocumentStore") is not null ||
-        compilation.GetTypeByMetadataName("Wolverine.WolverineOptions") is not null;
+    GeneratedScreenplay InvalidProvider(string provider, string targetPath) => ProviderError(
+        ScreenplayDiagnosticCodes.InvalidProvider,
+        $"Unknown Screenplay provider '{provider}'. Available providers: {ProviderNames()}",
+        targetPath);
 
-    static LoadedCompilation NarrowToArc(LoadedCompilation loaded)
-    {
-        var selected = loaded.Compilations
-            .Select((compilation, index) => new { Compilation = compilation, Name = loaded.ProjectNames[index] })
-            .Where(_ => ScreenplayProjectSelection.CanDeclareAnArtifact(_.Compilation))
-            .ToArray();
-        if (selected.Length == 0 && loaded.Compilations.Count > 0)
-        {
-            return LoadedCompilation.Failed(
-                ScreenplayDiagnosticCodes.NoArtifacts,
-                "No loaded project declares Arc commands or Chronicle events, so there is nothing for the Arc Screenplay provider to generate",
-                null,
-                loaded.Diagnostics);
-        }
-
-        return selected.Length == loaded.Compilations.Count
-            ? loaded
-            : new LoadedCompilation(
-                [.. selected.Select(_ => _.Compilation)],
-                [.. selected.Select(_ => _.Name)],
-                loaded.Diagnostics);
-    }
-
-    static GeneratedScreenplay InvalidProvider(string provider, string targetPath) => new(
+    GeneratedScreenplay ProviderError(string code, string message, string targetPath) => new(
         string.Empty,
-        [
-            new ScreenplayDiagnostic(
-                ScreenplayDiagnosticSeverity.Error,
-                ScreenplayDiagnosticCodes.InvalidProvider,
-                $"Unknown Screenplay provider '{provider}'. Use auto, arc, marten, or critter-stack",
-                targetPath)
-        ]);
+        [new ScreenplayDiagnostic(ScreenplayDiagnosticSeverity.Error, code, message, targetPath)]);
 }
+
+internal sealed record ProviderSelection(
+    IScreenplaySourceProvider? Provider,
+    GeneratedScreenplay? Error);

--- a/Source/Cli/Commands/Screenplay/ProviderScreenplayGeneration.cs
+++ b/Source/Cli/Commands/Screenplay/ProviderScreenplayGeneration.cs
@@ -1,0 +1,72 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Cli.Commands.Screenplay;
+
+/// <summary>
+/// Loads application source once and delegates generation to the selected framework provider.
+/// </summary>
+public sealed class ProviderScreenplayGeneration : IScreenplayGeneration
+{
+    /// <inheritdoc/>
+    public async Task<GeneratedScreenplay> Generate(
+        string targetPath,
+        ScreenplayGenerationOptions options,
+        CancellationToken cancellationToken)
+    {
+        var requested = options.Provider.ToLowerInvariant();
+        if (!ScreenplayProviders.IsKnown(requested))
+        {
+            return InvalidProvider(requested, targetPath);
+        }
+
+        var loaded = await ScreenplayCompilationLoader.Load(
+            targetPath,
+            includeAllProjects: !string.Equals(requested, ScreenplayProviders.Arc, StringComparison.Ordinal),
+            cancellationToken);
+        var provider = string.Equals(requested, ScreenplayProviders.Auto, StringComparison.Ordinal)
+            ? Detect(loaded)
+            : requested;
+
+        return provider switch
+        {
+            ScreenplayProviders.Arc => ArcScreenplayGeneration.GenerateFrom(NarrowToArc(loaded), targetPath, options),
+            ScreenplayProviders.Marten or ScreenplayProviders.CritterStack =>
+                CritterStackScreenplayGeneration.GenerateFrom(loaded, targetPath, options),
+            _ => InvalidProvider(provider, targetPath)
+        };
+    }
+
+    static string Detect(LoadedCompilation loaded) => loaded.Compilations.Any(IsCritterStack)
+        ? ScreenplayProviders.CritterStack
+        : ScreenplayProviders.Arc;
+
+    static bool IsCritterStack(Microsoft.CodeAnalysis.Compilation compilation) =>
+        compilation.GetTypeByMetadataName("Marten.StoreOptions") is not null ||
+        compilation.GetTypeByMetadataName("Marten.IDocumentStore") is not null ||
+        compilation.GetTypeByMetadataName("Wolverine.WolverineOptions") is not null;
+
+    static LoadedCompilation NarrowToArc(LoadedCompilation loaded)
+    {
+        var selected = loaded.Compilations
+            .Select((compilation, index) => new { Compilation = compilation, Name = loaded.ProjectNames[index] })
+            .Where(_ => ScreenplayProjectSelection.CanDeclareAnArtifact(_.Compilation))
+            .ToArray();
+        return selected.Length == loaded.Compilations.Count
+            ? loaded
+            : new LoadedCompilation(
+                [.. selected.Select(_ => _.Compilation)],
+                [.. selected.Select(_ => _.Name)],
+                loaded.Diagnostics);
+    }
+
+    static GeneratedScreenplay InvalidProvider(string provider, string targetPath) => new(
+        string.Empty,
+        [
+            new ScreenplayDiagnostic(
+                ScreenplayDiagnosticSeverity.Error,
+                ScreenplayDiagnosticCodes.InvalidProvider,
+                $"Unknown Screenplay provider '{provider}'. Use auto, arc, marten, or critter-stack",
+                targetPath)
+        ]);
+}

--- a/Source/Cli/Commands/Screenplay/ProviderScreenplayGeneration.cs
+++ b/Source/Cli/Commands/Screenplay/ProviderScreenplayGeneration.cs
@@ -27,14 +27,43 @@ public sealed class ProviderScreenplayGeneration : IScreenplayGeneration
         var provider = string.Equals(requested, ScreenplayProviders.Auto, StringComparison.Ordinal)
             ? Detect(loaded)
             : requested;
-
-        return provider switch
+        return AmbiguousHosts(loaded, targetPath, provider) ?? provider switch
         {
             ScreenplayProviders.Arc => ArcScreenplayGeneration.GenerateFrom(NarrowToArc(loaded), targetPath, options),
             ScreenplayProviders.Marten or ScreenplayProviders.CritterStack =>
                 CritterStackScreenplayGeneration.GenerateFrom(loaded, targetPath, options),
             _ => InvalidProvider(provider, targetPath)
         };
+    }
+
+    internal static GeneratedScreenplay? AmbiguousHosts(
+        LoadedCompilation loaded,
+        string targetPath,
+        string provider)
+    {
+        if (!ScreenplayTargetResolver.IsSolution(targetPath) ||
+            (provider != ScreenplayProviders.Marten && provider != ScreenplayProviders.CritterStack))
+        {
+            return null;
+        }
+
+        var hosts = loaded.Compilations
+            .Select((compilation, index) => new { EntryPoint = compilation.GetEntryPoint(CancellationToken.None), Name = loaded.ProjectNames[index] })
+            .Where(_ => _.EntryPoint is not null)
+            .Select(_ => _.Name)
+            .Order(StringComparer.Ordinal)
+            .ToArray();
+        return hosts.Length <= 1
+            ? null
+            : new GeneratedScreenplay(
+                string.Empty,
+                [
+                    new ScreenplayDiagnostic(
+                        ScreenplayDiagnosticSeverity.Error,
+                        ScreenplayDiagnosticCodes.AmbiguousApplicationHosts,
+                        $"Solution contains several deployable application hosts: {string.Join(", ", hosts)}. Target one .csproj explicitly",
+                        targetPath)
+                ]);
     }
 
     static string Detect(LoadedCompilation loaded) => loaded.Compilations.Any(IsCritterStack)

--- a/Source/Cli/Commands/Screenplay/ProviderScreenplayGeneration.cs
+++ b/Source/Cli/Commands/Screenplay/ProviderScreenplayGeneration.cs
@@ -52,6 +52,15 @@ public sealed class ProviderScreenplayGeneration : IScreenplayGeneration
             .Select((compilation, index) => new { Compilation = compilation, Name = loaded.ProjectNames[index] })
             .Where(_ => ScreenplayProjectSelection.CanDeclareAnArtifact(_.Compilation))
             .ToArray();
+        if (selected.Length == 0 && loaded.Compilations.Count > 0)
+        {
+            return LoadedCompilation.Failed(
+                ScreenplayDiagnosticCodes.NoArtifacts,
+                "No loaded project declares Arc commands or Chronicle events, so there is nothing for the Arc Screenplay provider to generate",
+                null,
+                loaded.Diagnostics);
+        }
+
         return selected.Length == loaded.Compilations.Count
             ? loaded
             : new LoadedCompilation(

--- a/Source/Cli/Commands/Screenplay/ScreenplayCompilationLoader.cs
+++ b/Source/Cli/Commands/Screenplay/ScreenplayCompilationLoader.cs
@@ -180,6 +180,8 @@ public static class ScreenplayCompilationLoader
                 continue;
             }
 
+            compilation = ScreenplayFrameworkReferences.AddMissingTo(project, compilation);
+
             if (isSolution && !includeAllProjects && !ScreenplayProjectSelection.CanDeclareAnArtifact(compilation))
             {
                 continue;

--- a/Source/Cli/Commands/Screenplay/ScreenplayCompilationLoader.cs
+++ b/Source/Cli/Commands/Screenplay/ScreenplayCompilationLoader.cs
@@ -46,14 +46,31 @@ public static class ScreenplayCompilationLoader
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The <see cref="LoadedCompilation"/> describing the outcome.</returns>
     [MethodImpl(MethodImplOptions.NoInlining)]
-    public static async Task<LoadedCompilation> Load(string targetPath, CancellationToken cancellationToken)
+    public static Task<LoadedCompilation> Load(string targetPath, CancellationToken cancellationToken) =>
+        Load(targetPath, includeAllProjects: false, cancellationToken);
+
+    /// <summary>
+    /// Loads the given solution or project and optionally retains every non-spec C# project for provider analysis.
+    /// </summary>
+    /// <param name="targetPath">The full path of the solution or project file.</param>
+    /// <param name="includeAllProjects">Whether solution projects should bypass Arc-specific artifact filtering.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The <see cref="LoadedCompilation"/> describing the outcome.</returns>
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static async Task<LoadedCompilation> Load(
+        string targetPath,
+        bool includeAllProjects,
+        CancellationToken cancellationToken)
     {
         RegisterMSBuild();
-        return await LoadWithWorkspace(targetPath, cancellationToken);
+        return await LoadWithWorkspace(targetPath, includeAllProjects, cancellationToken);
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
-    static async Task<LoadedCompilation> LoadWithWorkspace(string targetPath, CancellationToken cancellationToken)
+    static async Task<LoadedCompilation> LoadWithWorkspace(
+        string targetPath,
+        bool includeAllProjects,
+        CancellationToken cancellationToken)
     {
         var failures = new List<ScreenplayDiagnostic>();
         var failureLock = new Lock();
@@ -112,7 +129,7 @@ public static class ScreenplayCompilationLoader
                 failures);
         }
 
-        return await CompilationsOf(selected, isSolution, targetPath, failures, cancellationToken);
+        return await CompilationsOf(selected, isSolution, includeAllProjects, targetPath, failures, cancellationToken);
     }
 
     /// <summary>
@@ -120,6 +137,7 @@ public static class ScreenplayCompilationLoader
     /// </summary>
     /// <param name="selected">The projects that take part, ordered by name.</param>
     /// <param name="isSolution">Whether a solution was opened rather than a single project.</param>
+    /// <param name="includeAllProjects">Whether all selected projects should bypass Arc-specific artifact filtering.</param>
     /// <param name="targetPath">The full path of the solution or project file.</param>
     /// <param name="failures">Everything the workspace reported while loading.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
@@ -134,6 +152,7 @@ public static class ScreenplayCompilationLoader
     static async Task<LoadedCompilation> CompilationsOf(
         IReadOnlyList<Project> selected,
         bool isSolution,
+        bool includeAllProjects,
         string targetPath,
         IReadOnlyList<ScreenplayDiagnostic> failures,
         CancellationToken cancellationToken)
@@ -161,7 +180,7 @@ public static class ScreenplayCompilationLoader
                 continue;
             }
 
-            if (isSolution && !ScreenplayProjectSelection.CanDeclareAnArtifact(compilation))
+            if (isSolution && !includeAllProjects && !ScreenplayProjectSelection.CanDeclareAnArtifact(compilation))
             {
                 continue;
             }

--- a/Source/Cli/Commands/Screenplay/ScreenplayDiagnosticCodes.cs
+++ b/Source/Cli/Commands/Screenplay/ScreenplayDiagnosticCodes.cs
@@ -40,4 +40,9 @@ public static class ScreenplayDiagnosticCodes
     /// Every project loaded, and none of them can declare anything a Screenplay document is made of.
     /// </summary>
     public const string NoArtifacts = "CLI0006";
+
+    /// <summary>
+    /// The requested source framework provider is not recognized.
+    /// </summary>
+    public const string InvalidProvider = "CLI0007";
 }

--- a/Source/Cli/Commands/Screenplay/ScreenplayDiagnosticCodes.cs
+++ b/Source/Cli/Commands/Screenplay/ScreenplayDiagnosticCodes.cs
@@ -45,4 +45,14 @@ public static class ScreenplayDiagnosticCodes
     /// The requested source framework provider is not recognized.
     /// </summary>
     public const string InvalidProvider = "CLI0007";
+
+    /// <summary>
+    /// Source compilation errors make the recovered semantic model untrustworthy.
+    /// </summary>
+    public const string SourceDidNotCompile = "CLI0008";
+
+    /// <summary>
+    /// A solution contains several deployable hosts and therefore does not identify one application.
+    /// </summary>
+    public const string AmbiguousApplicationHosts = "CLI0009";
 }

--- a/Source/Cli/Commands/Screenplay/ScreenplayDiagnosticCodes.cs
+++ b/Source/Cli/Commands/Screenplay/ScreenplayDiagnosticCodes.cs
@@ -55,4 +55,14 @@ public static class ScreenplayDiagnosticCodes
     /// A solution contains several deployable hosts and therefore does not identify one application.
     /// </summary>
     public const string AmbiguousApplicationHosts = "CLI0009";
+
+    /// <summary>
+    /// No bundled source provider recognizes the loaded application.
+    /// </summary>
+    public const string NoMatchingProvider = "CLI0010";
+
+    /// <summary>
+    /// More than one unrelated source provider recognizes the loaded application.
+    /// </summary>
+    public const string AmbiguousProviders = "CLI0011";
 }

--- a/Source/Cli/Commands/Screenplay/ScreenplayFrameworkReferences.cs
+++ b/Source/Cli/Commands/Screenplay/ScreenplayFrameworkReferences.cs
@@ -1,0 +1,90 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Runtime.InteropServices;
+using Microsoft.CodeAnalysis;
+
+namespace Cratis.Cli.Commands.Screenplay;
+
+/// <summary>
+/// Restores target-framework reference assemblies that an MSBuild workspace can omit for projects targeting an
+/// earlier installed .NET version than the CLI process.
+/// </summary>
+static class ScreenplayFrameworkReferences
+{
+    static readonly string[] _packs = ["Microsoft.NETCore.App.Ref", "Microsoft.AspNetCore.App.Ref"];
+
+    /// <summary>
+    /// Adds missing target-framework references to a project compilation.
+    /// </summary>
+    /// <param name="project">The workspace project.</param>
+    /// <param name="compilation">The compilation produced by the workspace.</param>
+    /// <returns>The original compilation when its framework is complete; otherwise, a compilation with references.</returns>
+    public static Compilation AddMissingTo(Project project, Compilation compilation)
+    {
+        if (compilation.GetSpecialType(SpecialType.System_Object).TypeKind != TypeKind.Error)
+        {
+            return compilation;
+        }
+
+        var targetFramework = TargetFrameworkOf(project);
+        if (targetFramework is null)
+        {
+            return compilation;
+        }
+
+        var existing = compilation.References
+            .Select(_ => Path.GetFileNameWithoutExtension(_.Display))
+            .Where(_ => !string.IsNullOrEmpty(_))
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+        var references = PackRoots()
+            .SelectMany(root => _packs.Select(pack => Path.Combine(root, pack)))
+            .Where(Directory.Exists)
+            .Select(pack => ReferenceDirectory(pack, targetFramework))
+            .Where(_ => _ is not null)
+            .SelectMany(_ => Directory.EnumerateFiles(_!, "*.dll", SearchOption.TopDirectoryOnly))
+            .Where(_ => existing.Add(Path.GetFileNameWithoutExtension(_)))
+            .Select(_ => MetadataReference.CreateFromFile(_))
+            .ToArray();
+
+        return references.Length == 0 ? compilation : compilation.AddReferences(references);
+    }
+
+    static string? TargetFrameworkOf(Project project)
+    {
+        var assemblyPath = project.CompilationOutputInfo.AssemblyPath;
+        if (!string.IsNullOrWhiteSpace(assemblyPath))
+        {
+            var framework = new DirectoryInfo(Path.GetDirectoryName(assemblyPath)!).Name;
+            if (framework.StartsWith("net", StringComparison.OrdinalIgnoreCase))
+            {
+                return framework;
+            }
+        }
+
+        var start = project.Name.LastIndexOf('(');
+        return start > 0 && project.Name.EndsWith(')') ? project.Name[(start + 1)..^1] : null;
+    }
+
+    static IEnumerable<string> PackRoots()
+    {
+        var runtime = new DirectoryInfo(RuntimeEnvironment.GetRuntimeDirectory());
+        var dotnetRoot = runtime.Parent?.Parent?.Parent;
+        if (dotnetRoot is not null)
+        {
+            yield return Path.Combine(dotnetRoot.FullName, "packs");
+        }
+
+        var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        if (!string.IsNullOrWhiteSpace(home))
+        {
+            yield return Path.Combine(home, ".nuget", "packages");
+        }
+    }
+
+    static string? ReferenceDirectory(string pack, string targetFramework) => Directory.EnumerateDirectories(pack)
+        .Select(version => Path.Combine(version, "ref", targetFramework))
+        .Where(Directory.Exists)
+        .OrderDescending(StringComparer.OrdinalIgnoreCase)
+        .FirstOrDefault();
+}

--- a/Source/Cli/Commands/Screenplay/ScreenplayGenerationOptions.cs
+++ b/Source/Cli/Commands/Screenplay/ScreenplayGenerationOptions.cs
@@ -10,10 +10,16 @@ namespace Cratis.Cli.Commands.Screenplay;
 /// <param name="Module">The module every discovered feature is placed within; <see langword="null"/> falls back to the domain.</param>
 /// <param name="SegmentsToSkip">The number of leading namespace segments to skip when inferring features and slices; <see langword="null"/> uses the generator default.</param>
 /// <param name="ModulesFromNamespaceRoots">Whether each feature is placed in a module named after the outermost segment of its namespace rather than all of them in one module.</param>
-public record ScreenplayGenerationOptions(string? Domain, string? Module, int? SegmentsToSkip, bool ModulesFromNamespaceRoots = false)
+/// <param name="Provider">The source framework provider to use or auto-detect.</param>
+public record ScreenplayGenerationOptions(
+    string? Domain,
+    string? Module,
+    int? SegmentsToSkip,
+    bool ModulesFromNamespaceRoots = false,
+    string Provider = ScreenplayProviders.Auto)
 {
     /// <summary>
     /// Gets the options that leave every choice to the generator.
     /// </summary>
-    public static ScreenplayGenerationOptions Default { get; } = new(null, null, null);
+    public static ScreenplayGenerationOptions Default { get; } = new(null, null, null, Provider: ScreenplayProviders.Auto);
 }

--- a/Source/Cli/Commands/Screenplay/ScreenplayGenerations.cs
+++ b/Source/Cli/Commands/Screenplay/ScreenplayGenerations.cs
@@ -12,5 +12,5 @@ public static class ScreenplayGenerations
     /// Creates the generation to use.
     /// </summary>
     /// <returns>The <see cref="IScreenplayGeneration"/> to generate with.</returns>
-    public static IScreenplayGeneration Create() => new ArcScreenplayGeneration();
+    public static IScreenplayGeneration Create() => new ProviderScreenplayGeneration();
 }

--- a/Source/Cli/Commands/Screenplay/ScreenplayProviders.cs
+++ b/Source/Cli/Commands/Screenplay/ScreenplayProviders.cs
@@ -1,0 +1,39 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Cli.Commands.Screenplay;
+
+/// <summary>
+/// Defines the source-framework providers available for Screenplay generation.
+/// </summary>
+public static class ScreenplayProviders
+{
+    /// <summary>
+    /// Detect the provider from loaded project compilations.
+    /// </summary>
+    public const string Auto = "auto";
+
+    /// <summary>
+    /// Generate from Arc and Chronicle conventions.
+    /// </summary>
+    public const string Arc = "arc";
+
+    /// <summary>
+    /// Generate from Marten conventions without requiring Wolverine.
+    /// </summary>
+    public const string Marten = "marten";
+
+    /// <summary>
+    /// Generate from combined Marten and Wolverine conventions.
+    /// </summary>
+    public const string CritterStack = "critter-stack";
+
+    static readonly HashSet<string> _known = [Auto, Arc, Marten, CritterStack];
+
+    /// <summary>
+    /// Gets whether a provider name is recognized.
+    /// </summary>
+    /// <param name="provider">The provider name.</param>
+    /// <returns><see langword="true"/> when recognized; otherwise, <see langword="false"/>.</returns>
+    public static bool IsKnown(string provider) => _known.Contains(provider);
+}

--- a/Source/Cli/Commands/Screenplay/ScreenplaySourceProviders.cs
+++ b/Source/Cli/Commands/Screenplay/ScreenplaySourceProviders.cs
@@ -1,0 +1,72 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Cli.Commands.Screenplay;
+
+/// <summary>
+/// Provides the allowlisted source-framework providers bundled with this CLI build.
+/// </summary>
+static class ScreenplaySourceProviders
+{
+    public static readonly IReadOnlyList<IScreenplaySourceProvider> Default =
+    [
+        new ArcSourceProvider(),
+        new MartenSourceProvider(),
+        new CritterStackSourceProvider()
+    ];
+}
+
+static class ProviderEvidence
+{
+    public static bool HasMarten(Microsoft.CodeAnalysis.Compilation compilation) =>
+        compilation.GetTypeByMetadataName("Marten.StoreOptions") is not null ||
+        compilation.GetTypeByMetadataName("Marten.IDocumentStore") is not null;
+
+    public static bool HasWolverine(Microsoft.CodeAnalysis.Compilation compilation) =>
+        compilation.GetTypeByMetadataName("Wolverine.WolverineOptions") is not null;
+}
+
+sealed class ArcSourceProvider : IScreenplaySourceProvider
+{
+    public string Name => ScreenplayProviders.Arc;
+    public IReadOnlyList<string> Supersedes => [];
+    public bool RequiresSingleHost => false;
+    public bool Matches(LoadedCompilation loaded) => loaded.Compilations.Any(ScreenplayProjectSelection.CanDeclareAnArtifact);
+    public GeneratedScreenplay GenerateFrom(LoadedCompilation loaded, string targetPath, ScreenplayGenerationOptions options) =>
+        ArcScreenplayGeneration.GenerateFrom(Narrow(loaded), targetPath, options);
+
+    static LoadedCompilation Narrow(LoadedCompilation loaded)
+    {
+        var selected = loaded.Compilations
+            .Select((compilation, index) => new { Compilation = compilation, Name = loaded.ProjectNames[index] })
+            .Where(_ => ScreenplayProjectSelection.CanDeclareAnArtifact(_.Compilation))
+            .ToArray();
+        return selected.Length == loaded.Compilations.Count
+            ? loaded
+            : new LoadedCompilation(
+                [.. selected.Select(_ => _.Compilation)],
+                [.. selected.Select(_ => _.Name)],
+                loaded.Diagnostics);
+    }
+}
+
+sealed class MartenSourceProvider : IScreenplaySourceProvider
+{
+    public string Name => ScreenplayProviders.Marten;
+    public IReadOnlyList<string> Supersedes => [];
+    public bool RequiresSingleHost => true;
+    public bool Matches(LoadedCompilation loaded) => loaded.Compilations.Any(ProviderEvidence.HasMarten);
+    public GeneratedScreenplay GenerateFrom(LoadedCompilation loaded, string targetPath, ScreenplayGenerationOptions options) =>
+        CritterStackScreenplayGeneration.GenerateFrom(loaded, targetPath, options);
+}
+
+sealed class CritterStackSourceProvider : IScreenplaySourceProvider
+{
+    public string Name => ScreenplayProviders.CritterStack;
+    public IReadOnlyList<string> Supersedes => [ScreenplayProviders.Marten];
+    public bool RequiresSingleHost => true;
+    public bool Matches(LoadedCompilation loaded) => loaded.Compilations.Any(_ =>
+        ProviderEvidence.HasMarten(_) && ProviderEvidence.HasWolverine(_));
+    public GeneratedScreenplay GenerateFrom(LoadedCompilation loaded, string targetPath, ScreenplayGenerationOptions options) =>
+        CritterStackScreenplayGeneration.GenerateFrom(loaded, targetPath, options);
+}


### PR DESCRIPTION
# Summary

Extends `cratis screenplay generate` from Arc-only source analysis to built-in Arc, Marten, and Marten + Wolverine providers while preserving source-only, reproducible generation.

## Added

- Add `--provider auto|arc|marten|critter-stack` with conservative source-framework detection.
- Generate verified Screenplay definitions from Marten and Critter Stack projects through the new official adapter package.
- Add a real package compatibility spec and end-to-end validation for Arc, BankAccountES, and canonical IncidentService source.

## Changed

- Align Arc Screenplay, Screenplay, Stage, and Prologue packages on the current Screenplay 4 generation.
- Retain markerless non-spec projects for Critter Stack analysis while preserving Arc-specific project filtering.