### PR TITLE
Require explicit confirmation for destructive commands

### DIFF
--- a/Documentation/chronicle/jobs.md
+++ b/Documentation/chronicle/jobs.md
@@ -101,6 +101,8 @@ Resume a stopped job:
 cratis chronicle jobs resume a1b2c3d4-e5f6-7890-abcd-ef1234567890
 ```
 
+The command asks for confirmation and defaults to **No**. In automation or another non-interactive environment, pass `--yes` explicitly or the command returns a nonzero validation exit code without resuming the job.
+
 ## stop
 
 Stops a running job. The job's progress is preserved and the job can be resumed later.
@@ -129,6 +131,8 @@ Stop a running job:
 ```bash
 cratis chronicle jobs stop a1b2c3d4-e5f6-7890-abcd-ef1234567890
 ```
+
+The command asks for confirmation and defaults to **No**. In automation or another non-interactive environment, pass `--yes` explicitly or the command returns a nonzero validation exit code without stopping the job.
 
 Check the job status after stopping:
 

--- a/Documentation/context/index.md
+++ b/Documentation/context/index.md
@@ -131,6 +131,8 @@ cratis context set dev
 cratis context delete staging
 ```
 
+The command asks for confirmation and defaults to **No**. In automation or another non-interactive environment, pass `--yes` explicitly or the command returns a nonzero validation exit code without deleting the context.
+
 ---
 
 ### rename

--- a/Documentation/reference/global-options.md
+++ b/Documentation/reference/global-options.md
@@ -17,7 +17,7 @@ cratis <command> -o <FORMAT>
 | `json` | Pretty-printed JSON with indentation. |
 | `json-compact` | Compact single-line JSON. Default in AI environments. |
 
-In interactive terminals the default is `table`. In AI assistant environments (Claude Code, Cursor, Windsurf) the default is `json-compact` to minimize token consumption.
+In interactive terminals the default is `table`. In recognized agent processes such as Claude Code, Cursor, Windsurf, and Pi, the default is `json-compact` to minimize token consumption.
 
 **Example:**
 
@@ -51,7 +51,15 @@ Skips confirmation prompts on destructive commands such as replay, retry, and re
 cratis chronicle observers replay <ID> -y
 ```
 
-Use this flag in automation and CI pipelines where interactive confirmation is not possible. Do not use it as a habit when running commands manually — the prompt exists to prevent accidents.
+Destructive commands do not proceed in automation, redirected output, or other non-interactive environments unless this flag is supplied. Do not use it as a habit when running commands manually — the prompt exists to prevent accidents.
+
+Set `CRATIS_NONINTERACTIVE=1` when an automation host uses a terminal-like input/output stream but must never be prompted:
+
+```bash
+CRATIS_NONINTERACTIVE=1 cratis chronicle observers replay <ID> -y
+```
+
+Without `--yes`, the command fails with a nonzero validation exit code.
 
 ---
 

--- a/Integration/Chronicle/for_Applications/when_adding_and_removing_application.cs
+++ b/Integration/Chronicle/for_Applications/when_adding_and_removing_application.cs
@@ -35,7 +35,7 @@ public class when_adding_and_removing_application(context context) : CliGiven<co
                 "list");
 
             var appId = ListedApplication.GetProperty("id").GetString()!;
-            RemoveResult = await RunCliAsync("chronicle", "applications", "remove", appId);
+            RemoveResult = await RunCliAsync("chronicle", "applications", "remove", appId, "--yes");
         }
     }
 

--- a/Integration/Chronicle/for_Auth/when_logging_in.cs
+++ b/Integration/Chronicle/for_Auth/when_logging_in.cs
@@ -27,7 +27,7 @@ public class when_logging_in(context context) : CliGiven<context>(context)
             if (testUser.ValueKind != JsonValueKind.Undefined)
             {
                 var userId = testUser.GetProperty("id").GetString()!;
-                RemoveResult = await RunCliAsync("chronicle", "users", "remove", userId);
+                RemoveResult = await RunCliAsync("chronicle", "users", "remove", userId, "--yes");
             }
         }
     }

--- a/Integration/Chronicle/for_Context/when_creating_context.cs
+++ b/Integration/Chronicle/for_Context/when_creating_context.cs
@@ -21,7 +21,7 @@ public class when_creating_context : Specification
             "json");
 
         // Clean up the created context.
-        _deleteResult = await CliCommandRunner.RunAsync("context", "delete", "integration-test-ctx");
+        _deleteResult = await CliCommandRunner.RunAsync("context", "delete", "integration-test-ctx", "--yes");
     }
 
     [Fact] void should_return_success_exit_code() => _createResult.ExitCode.ShouldEqual(ExitCodes.Success);

--- a/Integration/Chronicle/for_Context/when_deleting_context.cs
+++ b/Integration/Chronicle/for_Context/when_deleting_context.cs
@@ -18,7 +18,7 @@ public class when_deleting_context : Specification
             "--server",
             "chronicle://localhost:35000/?skipTlsValidation=true");
 
-        _deleteResult = await CliCommandRunner.RunAsync("context", "delete", "integration-test-del", "--output", "json");
+        _deleteResult = await CliCommandRunner.RunAsync("context", "delete", "integration-test-del", "--output", "json", "--yes");
     }
 
     [Fact] void should_create_successfully() => _createResult.ExitCode.ShouldEqual(ExitCodes.Success);

--- a/Integration/Chronicle/for_Context/when_renaming_context.cs
+++ b/Integration/Chronicle/for_Context/when_renaming_context.cs
@@ -22,7 +22,7 @@ public class when_renaming_context : Specification
         _renameResult = await CliCommandRunner.RunAsync("context", "rename", "integration-test-ren", "integration-test-renamed", "--output", "json");
 
         // Clean up.
-        _deleteResult = await CliCommandRunner.RunAsync("context", "delete", "integration-test-renamed");
+        _deleteResult = await CliCommandRunner.RunAsync("context", "delete", "integration-test-renamed", "--yes");
     }
 
     [Fact] void should_create_successfully() => _createResult.ExitCode.ShouldEqual(ExitCodes.Success);

--- a/Integration/Chronicle/for_Context/when_renaming_context_to_same_name.cs
+++ b/Integration/Chronicle/for_Context/when_renaming_context_to_same_name.cs
@@ -21,7 +21,7 @@ public class when_renaming_context_to_same_name : Specification
         _renameResult = await CliCommandRunner.RunAsync("context", "rename", "integration-test-same-name", "integration-test-same-name", "--output", "json");
 
         // Clean up.
-        await CliCommandRunner.RunAsync("context", "delete", "integration-test-same-name");
+        await CliCommandRunner.RunAsync("context", "delete", "integration-test-same-name", "--yes");
     }
 
     [Fact] void should_create_successfully() => _createResult.ExitCode.ShouldEqual(ExitCodes.Success);

--- a/Integration/Chronicle/for_Context/when_setting_context.cs
+++ b/Integration/Chronicle/for_Context/when_setting_context.cs
@@ -23,7 +23,7 @@ public class when_setting_context : Specification
 
         // Clean up: switch back to default and delete.
         await CliCommandRunner.RunAsync("context", "set", "default");
-        _deleteResult = await CliCommandRunner.RunAsync("context", "delete", "integration-test-set");
+        _deleteResult = await CliCommandRunner.RunAsync("context", "delete", "integration-test-set", "--yes");
     }
 
     [Fact] void should_create_successfully() => _createResult.ExitCode.ShouldEqual(ExitCodes.Success);

--- a/Integration/Chronicle/for_Jobs/when_resuming_job_with_invalid_id.cs
+++ b/Integration/Chronicle/for_Jobs/when_resuming_job_with_invalid_id.cs
@@ -18,7 +18,8 @@ public class when_resuming_job_with_invalid_id(context context) : CliGiven<conte
             "resume",
             "not-a-guid",
             "--event-store",
-            "system");
+            "system",
+            "--yes");
     }
 
     [Fact] void should_return_validation_error_exit_code() => Context.Result.ExitCode.ShouldEqual(ExitCodes.ValidationError);

--- a/Integration/Chronicle/for_Jobs/when_stopping_job_with_invalid_id.cs
+++ b/Integration/Chronicle/for_Jobs/when_stopping_job_with_invalid_id.cs
@@ -18,7 +18,8 @@ public class when_stopping_job_with_invalid_id(context context) : CliGiven<conte
             "stop",
             "not-a-guid",
             "--event-store",
-            "system");
+            "system",
+            "--yes");
     }
 
     [Fact] void should_return_validation_error_exit_code() => Context.Result.ExitCode.ShouldEqual(ExitCodes.ValidationError);

--- a/Integration/Chronicle/for_Observers/when_replaying_observer.cs
+++ b/Integration/Chronicle/for_Observers/when_replaying_observer.cs
@@ -19,7 +19,7 @@ public class when_replaying_observer(context context) : CliGiven<context>(contex
             var items = JsonDocument.Parse(listResult.StandardOutput).RootElement;
             ObserverId = items.EnumerateArray().First().GetProperty("id").GetString()!;
 
-            Result = await RunCliAsync("chronicle", "observers", "replay", ObserverId, "--event-store", "system");
+            Result = await RunCliAsync("chronicle", "observers", "replay", ObserverId, "--event-store", "system", "--yes");
         }
     }
 

--- a/Integration/Chronicle/for_Observers/when_replaying_partition.cs
+++ b/Integration/Chronicle/for_Observers/when_replaying_partition.cs
@@ -19,7 +19,7 @@ public class when_replaying_partition(context context) : CliGiven<context>(conte
             var items = JsonDocument.Parse(listResult.StandardOutput).RootElement;
             ObserverId = items.EnumerateArray().First().GetProperty("id").GetString()!;
 
-            Result = await RunCliAsync("chronicle", "observers", "replay-partition", ObserverId, "test-partition-key", "--event-store", "system");
+            Result = await RunCliAsync("chronicle", "observers", "replay-partition", ObserverId, "test-partition-key", "--event-store", "system", "--yes");
         }
     }
 

--- a/Integration/Chronicle/for_Observers/when_retrying_partition.cs
+++ b/Integration/Chronicle/for_Observers/when_retrying_partition.cs
@@ -19,7 +19,7 @@ public class when_retrying_partition(context context) : CliGiven<context>(contex
             var items = JsonDocument.Parse(listResult.StandardOutput).RootElement;
             ObserverId = items.EnumerateArray().First().GetProperty("id").GetString()!;
 
-            Result = await RunCliAsync("chronicle", "observers", "retry-partition", ObserverId, "test-partition-key", "--event-store", "system");
+            Result = await RunCliAsync("chronicle", "observers", "retry-partition", ObserverId, "test-partition-key", "--event-store", "system", "--yes");
         }
     }
 

--- a/Integration/Chronicle/for_Recommendations/when_ignoring_nonexistent_recommendation.cs
+++ b/Integration/Chronicle/for_Recommendations/when_ignoring_nonexistent_recommendation.cs
@@ -12,7 +12,7 @@ public class when_ignoring_nonexistent_recommendation(context context) : CliGive
     {
         public CliCommandResult Result = null!;
 
-        async Task Because() => Result = await RunCliAsync("chronicle", "recommendations", "ignore", "00000000-0000-0000-0000-000000000099", "--event-store", "system");
+        async Task Because() => Result = await RunCliAsync("chronicle", "recommendations", "ignore", "00000000-0000-0000-0000-000000000099", "--event-store", "system", "--yes");
     }
 
     [Fact] void should_return_server_error_exit_code() => Context.Result.ExitCode.ShouldEqual(ExitCodes.ServerError);

--- a/Integration/Chronicle/for_Recommendations/when_performing_nonexistent_recommendation.cs
+++ b/Integration/Chronicle/for_Recommendations/when_performing_nonexistent_recommendation.cs
@@ -12,7 +12,7 @@ public class when_performing_nonexistent_recommendation(context context) : CliGi
     {
         public CliCommandResult Result = null!;
 
-        async Task Because() => Result = await RunCliAsync("chronicle", "recommendations", "perform", "00000000-0000-0000-0000-000000000099", "--event-store", "system");
+        async Task Because() => Result = await RunCliAsync("chronicle", "recommendations", "perform", "00000000-0000-0000-0000-000000000099", "--event-store", "system", "--yes");
     }
 
     [Fact] void should_return_server_error_exit_code() => Context.Result.ExitCode.ShouldEqual(ExitCodes.ServerError);

--- a/Integration/Chronicle/for_Users/when_adding_and_removing_user.cs
+++ b/Integration/Chronicle/for_Users/when_adding_and_removing_user.cs
@@ -35,7 +35,7 @@ public class when_adding_and_removing_user(context context) : CliGiven<context>(
                 "list");
 
             var userId = ListedUser.GetProperty("id").GetString()!;
-            RemoveResult = await RunCliAsync("chronicle", "users", "remove", userId);
+            RemoveResult = await RunCliAsync("chronicle", "users", "remove", userId, "--yes");
         }
     }
 

--- a/Source/Cli.Specs/for_AiAgentEnvironment/when_checking_if_non_interactive_is_requested.cs
+++ b/Source/Cli.Specs/for_AiAgentEnvironment/when_checking_if_non_interactive_is_requested.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Cli.for_AiAgentEnvironment;
+
+public class when_checking_if_non_interactive_is_requested : Specification
+{
+    [Fact] void should_be_requested_for_a_non_empty_value() =>
+        AiAgentEnvironment.IsNonInteractiveRequested(name => name == AiAgentEnvironment.NonInteractiveEnvironmentVariable ? "1" : null).ShouldBeTrue();
+
+    [Fact] void should_not_be_requested_for_an_empty_value() =>
+        AiAgentEnvironment.IsNonInteractiveRequested(name => name == AiAgentEnvironment.NonInteractiveEnvironmentVariable ? string.Empty : null).ShouldBeFalse();
+}

--- a/Source/Cli.Specs/for_AiAgentEnvironment/when_detecting_supported_hosts.cs
+++ b/Source/Cli.Specs/for_AiAgentEnvironment/when_detecting_supported_hosts.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Cli.for_AiAgentEnvironment;
+
+public class when_detecting_supported_hosts : Specification
+{
+    [Fact] void should_detect_claude_code() => Detect("CLAUDECODE", "1").ShouldBeTrue();
+    [Fact] void should_not_assume_a_vscode_terminal_is_an_agent_process() => Detect("VSCODE_PID", "123").ShouldBeFalse();
+    [Fact] void should_detect_cursor() => Detect("TERM_PROGRAM", "cursor").ShouldBeTrue();
+    [Fact] void should_detect_windsurf() => Detect("WINDSURF_SESSION_ID", "session").ShouldBeTrue();
+    [Fact] void should_detect_pi() => Detect("PI_CODING_AGENT", "1").ShouldBeTrue();
+    [Fact] void should_not_detect_an_unknown_host() => Detect("UNKNOWN_AGENT", "1").ShouldBeFalse();
+
+    static bool Detect(string variable, string value) =>
+        AiAgentEnvironment.IsDetected(name => name == variable ? value : null);
+}

--- a/Source/Cli.Specs/for_ChronicleCommand/when_confirmation_is_required_before_connecting.cs
+++ b/Source/Cli.Specs/for_ChronicleCommand/when_confirmation_is_required_before_connecting.cs
@@ -1,0 +1,50 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Contracts;
+
+namespace Cratis.Cli.for_ChronicleCommand;
+
+[Collection(CliSpecsCollection.Name)]
+public class when_confirmation_is_required_before_connecting : Specification
+{
+    string? _previousNonInteractive;
+    ConfirmationCommand _command;
+    int _result;
+
+    void Establish()
+    {
+        _previousNonInteractive = Environment.GetEnvironmentVariable(AiAgentEnvironment.NonInteractiveEnvironmentVariable);
+        Environment.SetEnvironmentVariable(AiAgentEnvironment.NonInteractiveEnvironmentVariable, "1");
+        _command = new ConfirmationCommand();
+    }
+
+    async Task Because() =>
+        _result = await _command.Execute(new ChronicleSettings
+        {
+            Output = OutputFormats.JsonCompact,
+            Server = "chronicle://127.0.0.1:1"
+        });
+
+    void Destroy() =>
+        Environment.SetEnvironmentVariable(AiAgentEnvironment.NonInteractiveEnvironmentVariable, _previousNonInteractive);
+
+    [Fact] void should_return_a_validation_error() => _result.ShouldEqual(ExitCodes.ValidationError);
+    [Fact] void should_not_invoke_the_connected_command() => _command.CommandWasExecuted.ShouldBeFalse();
+
+    sealed class ConfirmationCommand : ChronicleCommand<ChronicleSettings>
+    {
+        public bool CommandWasExecuted { get; private set; }
+
+        public Task<int> Execute(ChronicleSettings settings) =>
+            ExecuteAsync(null!, settings, CancellationToken.None);
+
+        protected override string GetConfirmationPrompt(ChronicleSettings settings) => "Confirm destructive operation?";
+
+        protected override Task<int> ExecuteCommandAsync(IServices services, ChronicleSettings settings, string format)
+        {
+            CommandWasExecuted = true;
+            return Task.FromResult(ExitCodes.Success);
+        }
+    }
+}

--- a/Source/Cli.Specs/for_ConfirmationHelper/given/a_confirmation_request.cs
+++ b/Source/Cli.Specs/for_ConfirmationHelper/given/a_confirmation_request.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Cli.for_ConfirmationHelper.given;
+
+public class a_confirmation_request : Specification
+{
+    protected GlobalSettings _settings;
+    protected bool _isInteractiveEnvironment;
+    protected bool? _confirmationAnswer;
+    protected bool _confirmationWasRequested;
+    protected bool _defaultConfirmation;
+    protected ConfirmationOutcome _result;
+
+    void Establish()
+    {
+        _settings = new GlobalSettings();
+        _isInteractiveEnvironment = true;
+        _confirmationAnswer = null;
+    }
+
+    protected bool Confirm(bool defaultValue)
+    {
+        _confirmationWasRequested = true;
+        _defaultConfirmation = defaultValue;
+
+        return _confirmationAnswer ?? defaultValue;
+    }
+
+    protected void Decide() =>
+        _result = ConfirmationHelper.Confirm(_settings, _isInteractiveEnvironment, Confirm);
+}

--- a/Source/Cli.Specs/for_ConfirmationHelper/when_deciding_whether_to_proceed/and_an_interactive_user_answers_no.cs
+++ b/Source/Cli.Specs/for_ConfirmationHelper/when_deciding_whether_to_proceed/and_an_interactive_user_answers_no.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Cli.for_ConfirmationHelper.when_deciding_whether_to_proceed;
+
+[Collection(CliSpecsCollection.Name)]
+public class and_an_interactive_user_answers_no : given.a_confirmation_request
+{
+    void Establish() => _confirmationAnswer = false;
+
+    void Because() => Decide();
+
+    [Fact] void should_be_declined() => _result.ShouldEqual(ConfirmationOutcome.Declined);
+    [Fact] void should_request_confirmation() => _confirmationWasRequested.ShouldBeTrue();
+}

--- a/Source/Cli.Specs/for_ConfirmationHelper/when_deciding_whether_to_proceed/and_an_interactive_user_answers_yes.cs
+++ b/Source/Cli.Specs/for_ConfirmationHelper/when_deciding_whether_to_proceed/and_an_interactive_user_answers_yes.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Cli.for_ConfirmationHelper.when_deciding_whether_to_proceed;
+
+[Collection(CliSpecsCollection.Name)]
+public class and_an_interactive_user_answers_yes : given.a_confirmation_request
+{
+    void Establish() => _confirmationAnswer = true;
+
+    void Because() => Decide();
+
+    [Fact] void should_be_confirmed() => _result.ShouldEqual(ConfirmationOutcome.Confirmed);
+    [Fact] void should_request_confirmation() => _confirmationWasRequested.ShouldBeTrue();
+}

--- a/Source/Cli.Specs/for_ConfirmationHelper/when_deciding_whether_to_proceed/and_the_environment_is_not_interactive.cs
+++ b/Source/Cli.Specs/for_ConfirmationHelper/when_deciding_whether_to_proceed/and_the_environment_is_not_interactive.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Cli.for_ConfirmationHelper.when_deciding_whether_to_proceed;
+
+[Collection(CliSpecsCollection.Name)]
+public class and_the_environment_is_not_interactive : given.a_confirmation_request
+{
+    void Establish() => _isInteractiveEnvironment = false;
+
+    void Because() => Decide();
+
+    [Fact] void should_require_confirmation() => _result.ShouldEqual(ConfirmationOutcome.ConfirmationRequired);
+    [Fact] void should_not_request_confirmation() => _confirmationWasRequested.ShouldBeFalse();
+}

--- a/Source/Cli.Specs/for_ConfirmationHelper/when_deciding_whether_to_proceed/and_the_interactive_user_does_not_answer.cs
+++ b/Source/Cli.Specs/for_ConfirmationHelper/when_deciding_whether_to_proceed/and_the_interactive_user_does_not_answer.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Cli.for_ConfirmationHelper.when_deciding_whether_to_proceed;
+
+[Collection(CliSpecsCollection.Name)]
+public class and_the_interactive_user_does_not_answer : given.a_confirmation_request
+{
+    void Because() => Decide();
+
+    [Fact] void should_be_declined_using_the_interactive_default() => _result.ShouldEqual(ConfirmationOutcome.Declined);
+    [Fact] void should_request_confirmation() => _confirmationWasRequested.ShouldBeTrue();
+    [Fact] void should_default_to_declining() => _defaultConfirmation.ShouldBeFalse();
+}

--- a/Source/Cli.Specs/for_ConfirmationHelper/when_deciding_whether_to_proceed/and_yes_flag_is_set.cs
+++ b/Source/Cli.Specs/for_ConfirmationHelper/when_deciding_whether_to_proceed/and_yes_flag_is_set.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Cli.for_ConfirmationHelper.when_deciding_whether_to_proceed;
+
+[Collection(CliSpecsCollection.Name)]
+public class and_yes_flag_is_set : given.a_confirmation_request
+{
+    void Establish()
+    {
+        _settings.Yes = true;
+        _isInteractiveEnvironment = false;
+    }
+
+    void Because() => Decide();
+
+    [Fact] void should_be_confirmed() => _result.ShouldEqual(ConfirmationOutcome.Confirmed);
+    [Fact] void should_not_request_confirmation() => _confirmationWasRequested.ShouldBeFalse();
+}

--- a/Source/Cli.Specs/for_ConfirmationHelper/when_resolving_exit_code/and_an_interactive_user_declined.cs
+++ b/Source/Cli.Specs/for_ConfirmationHelper/when_resolving_exit_code/and_an_interactive_user_declined.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Cli.for_ConfirmationHelper.when_resolving_exit_code;
+
+[Collection(CliSpecsCollection.Name)]
+public class and_an_interactive_user_declined : Specification
+{
+    int? _result;
+
+    void Because() => _result = ConfirmationHelper.ExitCodeFor(ConfirmationOutcome.Declined, OutputFormats.Plain);
+
+    [Fact] void should_return_success() => _result.ShouldEqual(ExitCodes.Success);
+}

--- a/Source/Cli.Specs/for_ConfirmationHelper/when_resolving_exit_code/and_non_interactive_confirmation_is_required.cs
+++ b/Source/Cli.Specs/for_ConfirmationHelper/when_resolving_exit_code/and_non_interactive_confirmation_is_required.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Cli.for_ConfirmationHelper.when_resolving_exit_code;
+
+[Collection(CliSpecsCollection.Name)]
+public class and_non_interactive_confirmation_is_required : Specification
+{
+    TextWriter _previousError;
+    string _output;
+    int? _result;
+
+    void Because()
+    {
+        _previousError = Console.Error;
+        var writer = new StringWriter();
+        Console.SetError(writer);
+
+        _result = ConfirmationHelper.ExitCodeFor(ConfirmationOutcome.ConfirmationRequired, OutputFormats.JsonCompact);
+
+        _output = writer.ToString();
+        Console.SetError(_previousError);
+    }
+
+    [Fact] void should_return_a_validation_error() => _result.ShouldEqual(ExitCodes.ValidationError);
+    [Fact] void should_write_the_validation_error_to_stderr() => _output.ShouldContain("\"error\":\"validation_error\"");
+    [Fact] void should_include_the_yes_hint() => _output.ShouldContain("--yes");
+    [Fact] void should_write_valid_json() => System.Text.Json.JsonDocument.Parse(_output).ShouldNotBeNull();
+}

--- a/Source/Cli.Specs/for_ConfirmationHelper/when_resolving_exit_code/and_the_operation_was_confirmed.cs
+++ b/Source/Cli.Specs/for_ConfirmationHelper/when_resolving_exit_code/and_the_operation_was_confirmed.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Cli.for_ConfirmationHelper.when_resolving_exit_code;
+
+[Collection(CliSpecsCollection.Name)]
+public class and_the_operation_was_confirmed : Specification
+{
+    int? _result;
+
+    void Because() => _result = ConfirmationHelper.ExitCodeFor(ConfirmationOutcome.Confirmed, OutputFormats.Plain);
+
+    [Fact] void should_not_return_an_exit_code() => _result.ShouldBeNull();
+}

--- a/Source/Cli.Specs/for_DeleteContextCommand/when_confirmation_is_unavailable.cs
+++ b/Source/Cli.Specs/for_DeleteContextCommand/when_confirmation_is_unavailable.cs
@@ -1,0 +1,61 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Cli.Commands.Context;
+
+namespace Cratis.Cli.for_DeleteContextCommand;
+
+[Collection(CliSpecsCollection.Name)]
+public class when_confirmation_is_unavailable : given.a_temp_config_directory
+{
+    string? _previousNonInteractive;
+    TextWriter _previousError;
+    string _configBefore;
+    int _result;
+
+    void Establish()
+    {
+        _previousNonInteractive = Environment.GetEnvironmentVariable(AiAgentEnvironment.NonInteractiveEnvironmentVariable);
+        Environment.SetEnvironmentVariable(AiAgentEnvironment.NonInteractiveEnvironmentVariable, "1");
+
+        var config = new CliConfiguration
+        {
+            ActiveContext = "keep",
+            Contexts = new Dictionary<string, CliContext>
+            {
+                ["keep"] = new(),
+                ["remove-me"] = new()
+            }
+        };
+        config.Save();
+        _configBefore = File.ReadAllText(CliConfiguration.GetConfigPath());
+    }
+
+    async Task Because()
+    {
+        _previousError = Console.Error;
+        Console.SetError(new StringWriter());
+        _result = await new TestDeleteContextCommand().Execute(new ContextNameSettings
+        {
+            Name = "remove-me",
+            Output = OutputFormats.JsonCompact
+        });
+        Console.SetError(_previousError);
+    }
+
+    protected override void CleanUp()
+    {
+        Environment.SetEnvironmentVariable(AiAgentEnvironment.NonInteractiveEnvironmentVariable, _previousNonInteractive);
+        base.CleanUp();
+    }
+
+    [Fact] void should_return_a_validation_error() => _result.ShouldEqual(ExitCodes.ValidationError);
+    [Fact] void should_leave_the_configuration_unchanged() => File.ReadAllText(CliConfiguration.GetConfigPath()).ShouldEqual(_configBefore);
+    [Fact] void should_not_delete_the_context() => CliConfiguration.Load().Contexts.ContainsKey("remove-me").ShouldBeTrue();
+
+    sealed class TestDeleteContextCommand : DeleteContextCommand
+    {
+        public Task<int> Execute(ContextNameSettings settings) =>
+            ExecuteAsync(null!, settings, CancellationToken.None);
+    }
+}

--- a/Source/Cli.Specs/for_GlobalSettings/when_checking_if_environment_is_interactive/all_combinations.cs
+++ b/Source/Cli.Specs/for_GlobalSettings/when_checking_if_environment_is_interactive/all_combinations.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Cli.for_GlobalSettings.when_checking_if_environment_is_interactive;
+
+public class all_combinations : Specification
+{
+    [Fact] void should_not_be_interactive_when_nothing_supports_interaction() => Result(false, false, false, false).ShouldBeFalse();
+    [Fact] void should_not_be_interactive_when_only_non_interactive_is_requested() => Result(false, false, false, true).ShouldBeFalse();
+    [Fact] void should_not_be_interactive_when_only_an_ai_agent_is_detected() => Result(false, false, true, false).ShouldBeFalse();
+    [Fact] void should_not_be_interactive_when_an_ai_agent_is_detected_and_non_interactive_is_requested() => Result(false, false, true, true).ShouldBeFalse();
+    [Fact] void should_not_be_interactive_when_only_output_is_a_terminal() => Result(false, true, false, false).ShouldBeFalse();
+    [Fact] void should_not_be_interactive_when_output_is_a_terminal_and_non_interactive_is_requested() => Result(false, true, false, true).ShouldBeFalse();
+    [Fact] void should_not_be_interactive_when_output_is_a_terminal_and_an_ai_agent_is_detected() => Result(false, true, true, false).ShouldBeFalse();
+    [Fact] void should_not_be_interactive_when_output_is_a_terminal_and_both_non_interactive_signals_are_present() => Result(false, true, true, true).ShouldBeFalse();
+    [Fact] void should_not_be_interactive_when_only_interaction_is_supported() => Result(true, false, false, false).ShouldBeFalse();
+    [Fact] void should_not_be_interactive_when_interaction_is_supported_and_non_interactive_is_requested() => Result(true, false, false, true).ShouldBeFalse();
+    [Fact] void should_not_be_interactive_when_interaction_is_supported_and_an_ai_agent_is_detected() => Result(true, false, true, false).ShouldBeFalse();
+    [Fact] void should_not_be_interactive_when_interaction_is_supported_and_both_non_interactive_signals_are_present() => Result(true, false, true, true).ShouldBeFalse();
+    [Fact] void should_be_interactive_when_interaction_and_terminal_output_are_available() => Result(true, true, false, false).ShouldBeTrue();
+    [Fact] void should_not_be_interactive_when_everything_is_available_but_non_interactive_is_requested() => Result(true, true, false, true).ShouldBeFalse();
+    [Fact] void should_not_be_interactive_when_everything_is_available_but_an_ai_agent_is_detected() => Result(true, true, true, false).ShouldBeFalse();
+    [Fact] void should_not_be_interactive_when_everything_is_available_and_both_non_interactive_signals_are_present() => Result(true, true, true, true).ShouldBeFalse();
+
+    static bool Result(bool interactionSupported, bool outputIsTerminal, bool aiAgentDetected, bool nonInteractiveRequested) =>
+        GlobalSettings.IsInteractiveEnvironment(interactionSupported, outputIsTerminal, aiAgentDetected, nonInteractiveRequested);
+}

--- a/Source/Cli.Specs/for_GlobalSettings/when_checking_if_environment_is_interactive/and_an_ai_agent_environment_is_detected.cs
+++ b/Source/Cli.Specs/for_GlobalSettings/when_checking_if_environment_is_interactive/and_an_ai_agent_environment_is_detected.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Cli.for_GlobalSettings.when_checking_if_environment_is_interactive;
+
+[Collection(CliSpecsCollection.Name)]
+public class and_an_ai_agent_environment_is_detected : Specification
+{
+    string? _originalValue;
+    bool _result;
+
+    void Establish()
+    {
+        _originalValue = Environment.GetEnvironmentVariable("CLAUDECODE");
+        Environment.SetEnvironmentVariable("CLAUDECODE", "1");
+    }
+
+    void Because() => _result = GlobalSettings.IsInteractiveEnvironment(true, true);
+
+    void Destroy() => Environment.SetEnvironmentVariable("CLAUDECODE", _originalValue);
+
+    [Fact] void should_not_be_interactive() => _result.ShouldBeFalse();
+}

--- a/Source/Cli.Specs/for_GlobalSettings/when_resolving_output_format/and_no_color_is_set.cs
+++ b/Source/Cli.Specs/for_GlobalSettings/when_resolving_output_format/and_no_color_is_set.cs
@@ -6,7 +6,7 @@ namespace Cratis.Cli.for_GlobalSettings.when_resolving_output_format;
 [Collection(CliSpecsCollection.Name)]
 public sealed class and_no_color_is_set : Specification, IDisposable
 {
-    static readonly string[] _aiAgentEnvVars = ["CLAUDECODE", "CLAUDE_CODE_ENTRYPOINT", "CURSOR_TRACE_DIR", "WINDSURF_SESSION_ID", "TERM_PROGRAM"];
+    static readonly string[] _aiAgentEnvVars = ["CLAUDECODE", "CLAUDE_CODE_ENTRYPOINT", "VSCODE_PID", "CURSOR_TRACE_DIR", "WINDSURF_SESSION_ID", "PI_CODING_AGENT", "PI_SESSION_ID", "TERM_PROGRAM"];
     readonly Dictionary<string, string?> _savedEnvVars = [];
 
     string _previousNoColor;

--- a/Source/Cli.Specs/for_GlobalSettings/when_resolving_output_format/and_output_is_redirected.cs
+++ b/Source/Cli.Specs/for_GlobalSettings/when_resolving_output_format/and_output_is_redirected.cs
@@ -6,7 +6,7 @@ namespace Cratis.Cli.for_GlobalSettings.when_resolving_output_format;
 [Collection(CliSpecsCollection.Name)]
 public sealed class and_output_is_redirected : Specification, IDisposable
 {
-    static readonly string[] _aiAgentEnvVars = ["CLAUDECODE", "CLAUDE_CODE_ENTRYPOINT", "CURSOR_TRACE_DIR", "WINDSURF_SESSION_ID", "TERM_PROGRAM"];
+    static readonly string[] _aiAgentEnvVars = ["CLAUDECODE", "CLAUDE_CODE_ENTRYPOINT", "VSCODE_PID", "CURSOR_TRACE_DIR", "WINDSURF_SESSION_ID", "PI_CODING_AGENT", "PI_SESSION_ID", "TERM_PROGRAM"];
     readonly Dictionary<string, string?> _savedEnvVars = [];
 
     string _previousNoColor;

--- a/Source/Cli.Specs/for_JobCommands/and_stopping_a_job_when_confirmation_is_unavailable.cs
+++ b/Source/Cli.Specs/for_JobCommands/and_stopping_a_job_when_confirmation_is_unavailable.cs
@@ -1,0 +1,44 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Cli.Commands.Chronicle.Jobs;
+
+namespace Cratis.Cli.for_JobCommands;
+
+[Collection(CliSpecsCollection.Name)]
+public class and_stopping_a_job_when_confirmation_is_unavailable : Specification
+{
+    string? _previousNonInteractive;
+    TextWriter _previousError;
+    int _result;
+
+    void Establish()
+    {
+        _previousNonInteractive = Environment.GetEnvironmentVariable(AiAgentEnvironment.NonInteractiveEnvironmentVariable);
+        Environment.SetEnvironmentVariable(AiAgentEnvironment.NonInteractiveEnvironmentVariable, "1");
+    }
+
+    async Task Because()
+    {
+        _previousError = Console.Error;
+        Console.SetError(new StringWriter());
+        _result = await new TestStopJobCommand().Execute(new JobCommandSettings
+        {
+            JobId = Guid.Empty.ToString(),
+            Output = OutputFormats.JsonCompact,
+            Server = "chronicle://127.0.0.1:1"
+        });
+        Console.SetError(_previousError);
+    }
+
+    void Destroy() =>
+        Environment.SetEnvironmentVariable(AiAgentEnvironment.NonInteractiveEnvironmentVariable, _previousNonInteractive);
+
+    [Fact] void should_return_a_validation_error_before_connecting() => _result.ShouldEqual(ExitCodes.ValidationError);
+
+    sealed class TestStopJobCommand : StopJobCommand
+    {
+        public Task<int> Execute(JobCommandSettings settings) =>
+            ExecuteAsync(null!, settings, CancellationToken.None);
+    }
+}

--- a/Source/Cli.Specs/for_JobCommands/when_confirmation_is_unavailable.cs
+++ b/Source/Cli.Specs/for_JobCommands/when_confirmation_is_unavailable.cs
@@ -1,0 +1,44 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Cli.Commands.Chronicle.Jobs;
+
+namespace Cratis.Cli.for_JobCommands;
+
+[Collection(CliSpecsCollection.Name)]
+public class and_resuming_a_job_when_confirmation_is_unavailable : Specification
+{
+    string? _previousNonInteractive;
+    TextWriter _previousError;
+    int _result;
+
+    void Establish()
+    {
+        _previousNonInteractive = Environment.GetEnvironmentVariable(AiAgentEnvironment.NonInteractiveEnvironmentVariable);
+        Environment.SetEnvironmentVariable(AiAgentEnvironment.NonInteractiveEnvironmentVariable, "1");
+    }
+
+    async Task Because()
+    {
+        _previousError = Console.Error;
+        Console.SetError(new StringWriter());
+        _result = await new TestResumeJobCommand().Execute(new JobCommandSettings
+        {
+            JobId = Guid.Empty.ToString(),
+            Output = OutputFormats.JsonCompact,
+            Server = "chronicle://127.0.0.1:1"
+        });
+        Console.SetError(_previousError);
+    }
+
+    void Destroy() =>
+        Environment.SetEnvironmentVariable(AiAgentEnvironment.NonInteractiveEnvironmentVariable, _previousNonInteractive);
+
+    [Fact] void should_return_a_validation_error_before_connecting() => _result.ShouldEqual(ExitCodes.ValidationError);
+
+    sealed class TestResumeJobCommand : ResumeJobCommand
+    {
+        public Task<int> Execute(JobCommandSettings settings) =>
+            ExecuteAsync(null!, settings, CancellationToken.None);
+    }
+}

--- a/Source/Cli.Specs/for_OutputFormatter/when_writing_error/and_format_is_json_quiet.cs
+++ b/Source/Cli.Specs/for_OutputFormatter/when_writing_error/and_format_is_json_quiet.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Cli.for_OutputFormatter.when_writing_error;
+
+[Collection(CliSpecsCollection.Name)]
+public class and_format_is_json_quiet : Specification
+{
+    string _output;
+
+    void Because()
+    {
+        var writer = new StringWriter();
+        Console.SetError(writer);
+
+        OutputFormatter.WriteError(
+            OutputFormats.JsonQuiet,
+            "Confirmation is required",
+            "Re-run with --yes",
+            ExitCodes.ValidationErrorCode);
+
+        _output = writer.ToString();
+        Console.SetError(new StreamWriter(Console.OpenStandardError()) { AutoFlush = true });
+    }
+
+    [Fact] void should_contain_the_error_code() => _output.ShouldContain("\"error\":\"validation_error\"");
+    [Fact] void should_contain_the_yes_hint() => _output.ShouldContain("--yes");
+    [Fact] void should_be_valid_json() => System.Text.Json.JsonDocument.Parse(_output).ShouldNotBeNull();
+}

--- a/Source/Cli.Specs/for_OutputFormatter/when_writing_message/and_format_is_json_quiet.cs
+++ b/Source/Cli.Specs/for_OutputFormatter/when_writing_message/and_format_is_json_quiet.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Cli.for_OutputFormatter.when_writing_message;
+
+[Collection(CliSpecsCollection.Name)]
+public class and_format_is_json_quiet : Specification
+{
+    string _output;
+
+    void Because()
+    {
+        var writer = new StringWriter();
+        Console.SetOut(writer);
+
+        OutputFormatter.WriteMessage(OutputFormats.JsonQuiet, "Aborted.");
+
+        _output = writer.ToString();
+        Console.SetOut(new StreamWriter(Console.OpenStandardOutput()) { AutoFlush = true });
+    }
+
+    [Fact] void should_contain_the_message() => _output.ShouldContain("Aborted.");
+    [Fact] void should_be_compact_json() => _output.Trim().ShouldEqual("{\"message\":\"Aborted.\"}");
+}

--- a/Source/Cli/AiAgentEnvironment.cs
+++ b/Source/Cli/AiAgentEnvironment.cs
@@ -1,0 +1,62 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Cli;
+
+/// <summary>
+/// Centralizes runtime detection for supported AI coding agents and explicit non-interactive execution.
+/// </summary>
+public static class AiAgentEnvironment
+{
+    /// <summary>
+    /// The environment variable that explicitly marks a process as non-interactive.
+    /// </summary>
+    public const string NonInteractiveEnvironmentVariable = "CRATIS_NONINTERACTIVE";
+
+    /// <summary>
+    /// Determines whether the process is running inside a supported AI coding agent.
+    /// </summary>
+    /// <returns>True when a supported AI coding agent is detected.</returns>
+    public static bool IsDetected() => IsDetected(Environment.GetEnvironmentVariable);
+
+    /// <summary>
+    /// Determines whether non-interactive execution was explicitly requested.
+    /// </summary>
+    /// <returns>True when <c>CRATIS_NONINTERACTIVE</c> has a non-empty value.</returns>
+    public static bool IsNonInteractiveRequested() =>
+        IsNonInteractiveRequested(Environment.GetEnvironmentVariable);
+
+    internal static bool IsNonInteractiveRequested(Func<string, string?> getEnvironmentVariable) =>
+        HasValue(getEnvironmentVariable(NonInteractiveEnvironmentVariable));
+
+    internal static bool IsDetected(Func<string, string?> getEnvironmentVariable) =>
+        IsClaudeCode(getEnvironmentVariable) ||
+        IsCursor(getEnvironmentVariable) ||
+        IsWindsurf(getEnvironmentVariable) ||
+        IsPi(getEnvironmentVariable);
+
+    internal static bool IsClaudeCode(Func<string, string?> getEnvironmentVariable) =>
+        HasValue(getEnvironmentVariable("CLAUDECODE")) ||
+        HasValue(getEnvironmentVariable("CLAUDE_CODE_ENTRYPOINT"));
+
+    internal static bool IsGitHubCopilot(Func<string, string?> getEnvironmentVariable) =>
+        HasValue(getEnvironmentVariable("VSCODE_PID")) ||
+        EqualsValue(getEnvironmentVariable("TERM_PROGRAM"), "vscode");
+
+    internal static bool IsCursor(Func<string, string?> getEnvironmentVariable) =>
+        HasValue(getEnvironmentVariable("CURSOR_TRACE_DIR")) ||
+        EqualsValue(getEnvironmentVariable("TERM_PROGRAM"), "cursor");
+
+    internal static bool IsWindsurf(Func<string, string?> getEnvironmentVariable) =>
+        HasValue(getEnvironmentVariable("WINDSURF_SESSION_ID")) ||
+        EqualsValue(getEnvironmentVariable("TERM_PROGRAM"), "windsurf");
+
+    internal static bool IsPi(Func<string, string?> getEnvironmentVariable) =>
+        HasValue(getEnvironmentVariable("PI_CODING_AGENT")) ||
+        HasValue(getEnvironmentVariable("PI_SESSION_ID"));
+
+    static bool HasValue(string? value) => !string.IsNullOrEmpty(value);
+
+    static bool EqualsValue(string? value, string expected) =>
+        string.Equals(value, expected, StringComparison.OrdinalIgnoreCase);
+}

--- a/Source/Cli/Commands/Chronicle/Applications/RemoveApplicationCommand.cs
+++ b/Source/Cli/Commands/Chronicle/Applications/RemoveApplicationCommand.cs
@@ -14,14 +14,12 @@ namespace Cratis.Cli.Commands.Chronicle.Applications;
 public class RemoveApplicationCommand : ChronicleCommand<RemoveApplicationSettings>
 {
     /// <inheritdoc/>
+    protected override string GetConfirmationPrompt(RemoveApplicationSettings settings) =>
+        $"Are you sure you want to remove application '{settings.AppId}'?";
+
+    /// <inheritdoc/>
     protected override async Task<int> ExecuteCommandAsync(IServices services, RemoveApplicationSettings settings, string format)
     {
-        if (!ConfirmationHelper.ShouldProceed(settings, $"Are you sure you want to remove application '{settings.AppId}'?"))
-        {
-            OutputFormatter.WriteMessage(format, "Aborted.");
-            return ExitCodes.Success;
-        }
-
         await services.Applications.RemoveApplication(new RemoveApplicationRequest
         {
             Id = settings.AppId

--- a/Source/Cli/Commands/Chronicle/ChronicleCommand.cs
+++ b/Source/Cli/Commands/Chronicle/ChronicleCommand.cs
@@ -24,10 +24,23 @@ public abstract partial class ChronicleCommand<TSettings> : AsyncCommand<TSettin
     [GeneratedRegex("://(?<user>[^:@/]+):[^@/]+@", RegexOptions.None, matchTimeoutMilliseconds: 1000)]
     static partial Regex ConnectionStringCredentialsRegex { get; }
 
+    /// <summary>
+    /// Gets the destructive-operation confirmation prompt, or <see langword="null"/> when the command does not require confirmation.
+    /// Confirmation is evaluated before connection setup so a declined or unavailable prompt cannot contact Chronicle or load connection credentials.
+    /// </summary>
+    /// <param name="settings">The command settings.</param>
+    /// <returns>The confirmation prompt, or <see langword="null"/>.</returns>
+    protected virtual string? GetConfirmationPrompt(TSettings settings) => null;
+
     /// <inheritdoc/>
     protected sealed override async Task<int> ExecuteAsync(CommandContext context, TSettings settings, CancellationToken cancellationToken)
     {
         var format = settings.ResolveOutputFormat();
+        if (GetConfirmationPrompt(settings) is { } confirmationPrompt &&
+            ConfirmationHelper.ConfirmOrExit(settings, confirmationPrompt, format) is { } confirmationExitCode)
+        {
+            return confirmationExitCode;
+        }
 
         if (settings.Debug)
         {

--- a/Source/Cli/Commands/Chronicle/EventStoreInterceptor.cs
+++ b/Source/Cli/Commands/Chronicle/EventStoreInterceptor.cs
@@ -25,13 +25,8 @@ public class EventStoreInterceptor : ICommandInterceptor
             return;
         }
 
-        // Skip prompting when --yes flag is set or in non-interactive terminals.
-        if (settings is GlobalSettings { Yes: true })
-        {
-            return;
-        }
-
-        if (!AnsiConsole.Profile.Out.IsTerminal)
+        // Skip prompting when --yes is set or a person cannot safely answer the prompt.
+        if (settings is GlobalSettings { Yes: true } || !GlobalSettings.IsInteractiveEnvironment())
         {
             return;
         }

--- a/Source/Cli/Commands/Chronicle/EventStoreSubscriptions/RemoveEventStoreSubscriptionCommand.cs
+++ b/Source/Cli/Commands/Chronicle/EventStoreSubscriptions/RemoveEventStoreSubscriptionCommand.cs
@@ -16,14 +16,12 @@ namespace Cratis.Cli.Commands.Chronicle.EventStoreSubscriptions;
 public class RemoveEventStoreSubscriptionCommand : ChronicleCommand<RemoveEventStoreSubscriptionSettings>
 {
     /// <inheritdoc/>
+    protected override string GetConfirmationPrompt(RemoveEventStoreSubscriptionSettings settings) =>
+        $"Are you sure you want to remove event store subscription '{settings.SubscriptionId}'?";
+
+    /// <inheritdoc/>
     protected override async Task<int> ExecuteCommandAsync(IServices services, RemoveEventStoreSubscriptionSettings settings, string format)
     {
-        if (!ConfirmationHelper.ShouldProceed(settings, $"Are you sure you want to remove event store subscription '{settings.SubscriptionId}'?"))
-        {
-            OutputFormatter.WriteMessage(format, "Aborted.");
-            return ExitCodes.Success;
-        }
-
         await services.EventStoreSubscriptions.Remove(new RemoveEventStoreSubscriptions
         {
             TargetEventStore = settings.ResolveEventStore(),

--- a/Source/Cli/Commands/Chronicle/Jobs/ResumeJobCommand.cs
+++ b/Source/Cli/Commands/Chronicle/Jobs/ResumeJobCommand.cs
@@ -15,6 +15,10 @@ namespace Cratis.Cli.Commands.Chronicle.Jobs;
 public class ResumeJobCommand : ChronicleCommand<JobCommandSettings>
 {
     /// <inheritdoc/>
+    protected override string GetConfirmationPrompt(JobCommandSettings settings) =>
+        $"Are you sure you want to resume job '{settings.JobId}'?";
+
+    /// <inheritdoc/>
     protected override async Task<int> ExecuteCommandAsync(IServices services, JobCommandSettings settings, string format)
     {
         if (!Guid.TryParse(settings.JobId, out var jobId))

--- a/Source/Cli/Commands/Chronicle/Jobs/StopJobCommand.cs
+++ b/Source/Cli/Commands/Chronicle/Jobs/StopJobCommand.cs
@@ -15,6 +15,10 @@ namespace Cratis.Cli.Commands.Chronicle.Jobs;
 public class StopJobCommand : ChronicleCommand<JobCommandSettings>
 {
     /// <inheritdoc/>
+    protected override string GetConfirmationPrompt(JobCommandSettings settings) =>
+        $"Are you sure you want to stop job '{settings.JobId}'?";
+
+    /// <inheritdoc/>
     protected override async Task<int> ExecuteCommandAsync(IServices services, JobCommandSettings settings, string format)
     {
         if (!Guid.TryParse(settings.JobId, out var jobId))

--- a/Source/Cli/Commands/Chronicle/Observers/ClearObserverQuarantineCommand.cs
+++ b/Source/Cli/Commands/Chronicle/Observers/ClearObserverQuarantineCommand.cs
@@ -13,14 +13,12 @@ namespace Cratis.Cli.Commands.Chronicle.Observers;
 public class ClearObserverQuarantineCommand : ChronicleCommand<ObserverCommandSettings>
 {
     /// <inheritdoc/>
+    protected override string GetConfirmationPrompt(ObserverCommandSettings settings) =>
+        $"Are you sure you want to clear quarantine for observer '{settings.ObserverId}'?";
+
+    /// <inheritdoc/>
     protected override async Task<int> ExecuteCommandAsync(IServices services, ObserverCommandSettings settings, string format)
     {
-        if (!ConfirmationHelper.ShouldProceed(settings, $"Are you sure you want to clear quarantine for observer '{settings.ObserverId}'?"))
-        {
-            OutputFormatter.WriteMessage(format, "Aborted.");
-            return ExitCodes.Success;
-        }
-
         var cleared = await ClearObserverQuarantineInvoker.TryClear(
             services.Observers,
             settings.ResolveEventStore(),

--- a/Source/Cli/Commands/Chronicle/Observers/ListObserversCommand.cs
+++ b/Source/Cli/Commands/Chronicle/Observers/ListObserversCommand.cs
@@ -29,9 +29,10 @@ public class ListObserversCommand : ChronicleCommand<ListObserversSettings>
             return observers;
         }
 
-        // Validation already passed in IsValidType, so TryParse is guaranteed to succeed.
-        Enum.TryParse<ObserverType>(type, ignoreCase: true, out var parsed);
-        return observers.Where(o => o.Type == parsed);
+        // Validation normally passes before filtering, but keep this helper safe for direct callers.
+        return Enum.TryParse<ObserverType>(type, ignoreCase: true, out var parsed)
+            ? observers.Where(o => o.Type == parsed)
+            : [];
     }
 
     /// <summary>

--- a/Source/Cli/Commands/Chronicle/Observers/ReplayObserverCommand.cs
+++ b/Source/Cli/Commands/Chronicle/Observers/ReplayObserverCommand.cs
@@ -13,14 +13,12 @@ namespace Cratis.Cli.Commands.Chronicle.Observers;
 public class ReplayObserverCommand : ChronicleCommand<ObserverCommandSettings>
 {
     /// <inheritdoc/>
+    protected override string GetConfirmationPrompt(ObserverCommandSettings settings) =>
+        $"Are you sure you want to replay observer '{settings.ObserverId}'?";
+
+    /// <inheritdoc/>
     protected override async Task<int> ExecuteCommandAsync(IServices services, ObserverCommandSettings settings, string format)
     {
-        if (!ConfirmationHelper.ShouldProceed(settings, $"Are you sure you want to replay observer '{settings.ObserverId}'?"))
-        {
-            OutputFormatter.WriteMessage(format, "Aborted.");
-            return ExitCodes.Success;
-        }
-
         await services.Observers.Replay(new Replay
         {
             EventStore = settings.ResolveEventStore(),

--- a/Source/Cli/Commands/Chronicle/Observers/ReplayPartitionCommand.cs
+++ b/Source/Cli/Commands/Chronicle/Observers/ReplayPartitionCommand.cs
@@ -16,14 +16,12 @@ namespace Cratis.Cli.Commands.Chronicle.Observers;
 public class ReplayPartitionCommand : ChronicleCommand<PartitionCommandSettings>
 {
     /// <inheritdoc/>
+    protected override string GetConfirmationPrompt(PartitionCommandSettings settings) =>
+        $"Are you sure you want to replay partition '{settings.Partition}' of observer '{settings.ObserverId}'?";
+
+    /// <inheritdoc/>
     protected override async Task<int> ExecuteCommandAsync(IServices services, PartitionCommandSettings settings, string format)
     {
-        if (!ConfirmationHelper.ShouldProceed(settings, $"Are you sure you want to replay partition '{settings.Partition}' of observer '{settings.ObserverId}'?"))
-        {
-            OutputFormatter.WriteMessage(format, "Aborted.");
-            return ExitCodes.Success;
-        }
-
         await services.Observers.ReplayPartition(new ReplayPartitionContract
         {
             EventStore = settings.ResolveEventStore(),

--- a/Source/Cli/Commands/Chronicle/Observers/RetryPartitionCommand.cs
+++ b/Source/Cli/Commands/Chronicle/Observers/RetryPartitionCommand.cs
@@ -16,14 +16,12 @@ namespace Cratis.Cli.Commands.Chronicle.Observers;
 public class RetryPartitionCommand : ChronicleCommand<PartitionCommandSettings>
 {
     /// <inheritdoc/>
+    protected override string GetConfirmationPrompt(PartitionCommandSettings settings) =>
+        $"Are you sure you want to retry partition '{settings.Partition}' of observer '{settings.ObserverId}'?";
+
+    /// <inheritdoc/>
     protected override async Task<int> ExecuteCommandAsync(IServices services, PartitionCommandSettings settings, string format)
     {
-        if (!ConfirmationHelper.ShouldProceed(settings, $"Are you sure you want to retry partition '{settings.Partition}' of observer '{settings.ObserverId}'?"))
-        {
-            OutputFormatter.WriteMessage(format, "Aborted.");
-            return ExitCodes.Success;
-        }
-
         await services.Observers.RetryPartition(new RetryPartitionContract
         {
             EventStore = settings.ResolveEventStore(),

--- a/Source/Cli/Commands/Chronicle/Recommendations/IgnoreRecommendationCommand.cs
+++ b/Source/Cli/Commands/Chronicle/Recommendations/IgnoreRecommendationCommand.cs
@@ -13,14 +13,12 @@ namespace Cratis.Cli.Commands.Chronicle.Recommendations;
 public class IgnoreRecommendationCommand : ChronicleCommand<RecommendationActionSettings>
 {
     /// <inheritdoc/>
+    protected override string GetConfirmationPrompt(RecommendationActionSettings settings) =>
+        $"Are you sure you want to ignore recommendation '{settings.RecommendationId}'?";
+
+    /// <inheritdoc/>
     protected override async Task<int> ExecuteCommandAsync(IServices services, RecommendationActionSettings settings, string format)
     {
-        if (!ConfirmationHelper.ShouldProceed(settings, $"Are you sure you want to ignore recommendation '{settings.RecommendationId}'?"))
-        {
-            OutputFormatter.WriteMessage(format, "Aborted.");
-            return ExitCodes.Success;
-        }
-
         // The Ignore RPC reuses the Perform request message type per the protobuf contract.
         await services.Recommendations.Ignore(new Perform
         {

--- a/Source/Cli/Commands/Chronicle/Recommendations/PerformRecommendationCommand.cs
+++ b/Source/Cli/Commands/Chronicle/Recommendations/PerformRecommendationCommand.cs
@@ -13,14 +13,12 @@ namespace Cratis.Cli.Commands.Chronicle.Recommendations;
 public class PerformRecommendationCommand : ChronicleCommand<RecommendationActionSettings>
 {
     /// <inheritdoc/>
+    protected override string GetConfirmationPrompt(RecommendationActionSettings settings) =>
+        $"Are you sure you want to perform recommendation '{settings.RecommendationId}'?";
+
+    /// <inheritdoc/>
     protected override async Task<int> ExecuteCommandAsync(IServices services, RecommendationActionSettings settings, string format)
     {
-        if (!ConfirmationHelper.ShouldProceed(settings, $"Are you sure you want to perform recommendation '{settings.RecommendationId}'?"))
-        {
-            OutputFormatter.WriteMessage(format, "Aborted.");
-            return ExitCodes.Success;
-        }
-
         await services.Recommendations.Perform(new Perform
         {
             EventStore = settings.ResolveEventStore(),

--- a/Source/Cli/Commands/Chronicle/Users/RemoveUserCommand.cs
+++ b/Source/Cli/Commands/Chronicle/Users/RemoveUserCommand.cs
@@ -14,14 +14,12 @@ namespace Cratis.Cli.Commands.Chronicle.Users;
 public class RemoveUserCommand : ChronicleCommand<RemoveUserSettings>
 {
     /// <inheritdoc/>
+    protected override string GetConfirmationPrompt(RemoveUserSettings settings) =>
+        $"Are you sure you want to remove user '{settings.UserId}'?";
+
+    /// <inheritdoc/>
     protected override async Task<int> ExecuteCommandAsync(IServices services, RemoveUserSettings settings, string format)
     {
-        if (!ConfirmationHelper.ShouldProceed(settings, $"Are you sure you want to remove user '{settings.UserId}'?"))
-        {
-            OutputFormatter.WriteMessage(format, "Aborted.");
-            return ExitCodes.Success;
-        }
-
         await services.Users.RemoveUser(new RemoveUserRequest
         {
             UserId = settings.UserId

--- a/Source/Cli/Commands/Context/DeleteContextCommand.cs
+++ b/Source/Cli/Commands/Context/DeleteContextCommand.cs
@@ -37,6 +37,11 @@ public class DeleteContextCommand : AsyncCommand<ContextNameSettings>
             return Task.FromResult(ExitCodes.ValidationError);
         }
 
+        if (ConfirmationHelper.ConfirmOrExit(settings, $"Are you sure you want to delete context '{settings.Name}'?", format) is { } confirmationExitCode)
+        {
+            return Task.FromResult(confirmationExitCode);
+        }
+
         config.Contexts.Remove(settings.Name);
         config.Save();
 

--- a/Source/Cli/Commands/Init/AiToolDetector.cs
+++ b/Source/Cli/Commands/Init/AiToolDetector.cs
@@ -100,41 +100,27 @@ public static class AiToolDetector
     /// <param name="tools">The set to add detected tools to.</param>
     static void DetectFromEnvironment(HashSet<AiTool> tools)
     {
-        // Claude Code sets CLAUDECODE=1 and/or CLAUDE_CODE_ENTRYPOINT when spawning terminals.
-        if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("CLAUDECODE")) ||
-            !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("CLAUDE_CODE_ENTRYPOINT")))
+        if (AiAgentEnvironment.IsClaudeCode(Environment.GetEnvironmentVariable))
         {
             tools.Add(AiTool.Claude);
         }
 
-        // VS Code sets VSCODE_PID and TERM_PROGRAM=vscode. Copilot is the primary AI tool in VS Code.
-        var termProgram = Environment.GetEnvironmentVariable("TERM_PROGRAM") ?? string.Empty;
-
-        if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("VSCODE_PID")) ||
-            termProgram.Equals("vscode", StringComparison.OrdinalIgnoreCase))
+        if (AiAgentEnvironment.IsGitHubCopilot(Environment.GetEnvironmentVariable))
         {
             tools.Add(AiTool.Copilot);
         }
 
-        // Cursor sets TERM_PROGRAM=cursor or CURSOR_TRACE_DIR when spawning terminals.
-        if (termProgram.Equals("cursor", StringComparison.OrdinalIgnoreCase) ||
-            !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("CURSOR_TRACE_DIR")))
+        if (AiAgentEnvironment.IsCursor(Environment.GetEnvironmentVariable))
         {
             tools.Add(AiTool.Cursor);
         }
 
-        // Windsurf (Codeium) sets TERM_PROGRAM=windsurf or WINDSURF_* env vars.
-        if (termProgram.Equals("windsurf", StringComparison.OrdinalIgnoreCase) ||
-            !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("WINDSURF_SESSION_ID")))
+        if (AiAgentEnvironment.IsWindsurf(Environment.GetEnvironmentVariable))
         {
             tools.Add(AiTool.Windsurf);
         }
 
-        // Pi exports PI_* variables into every command it runs. PI_CODING_AGENT identifies the harness
-        // itself, where PI_SESSION_ID and friends only say a session is in flight - so it stays the
-        // signal even if the session variables are ever narrowed.
-        if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("PI_CODING_AGENT")) ||
-            !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("PI_SESSION_ID")))
+        if (AiAgentEnvironment.IsPi(Environment.GetEnvironmentVariable))
         {
             tools.Add(AiTool.Pi);
         }

--- a/Source/Cli/Commands/Llm/ClearLlmCommand.cs
+++ b/Source/Cli/Commands/Llm/ClearLlmCommand.cs
@@ -25,10 +25,9 @@ public class ClearLlmCommand : AsyncCommand<GlobalSettings>
             return Task.FromResult(ExitCodes.Success);
         }
 
-        if (!ConfirmationHelper.ShouldProceed(settings, "Are you sure you want to remove the language model configuration?"))
+        if (ConfirmationHelper.ConfirmOrExit(settings, "Are you sure you want to remove the language model configuration?", format) is { } confirmationExitCode)
         {
-            OutputFormatter.WriteMessage(format, "Aborted.");
-            return Task.FromResult(ExitCodes.Success);
+            return Task.FromResult(confirmationExitCode);
         }
 
         config.Llm = null;

--- a/Source/Cli/ConfirmationHelper.cs
+++ b/Source/Cli/ConfirmationHelper.cs
@@ -9,24 +9,60 @@ namespace Cratis.Cli;
 public static class ConfirmationHelper
 {
     /// <summary>
-    /// Determines whether the operation should proceed by checking the --yes flag,
-    /// terminal interactivity, or prompting the user.
+    /// Determines the confirmation outcome by checking the --yes flag or prompting an interactive user.
     /// </summary>
     /// <param name="settings">The global settings containing the Yes flag.</param>
     /// <param name="prompt">The confirmation prompt to display.</param>
-    /// <returns>True if the operation should proceed; false if the user declined.</returns>
-    public static bool ShouldProceed(GlobalSettings settings, string prompt)
+    /// <returns>The typed confirmation outcome.</returns>
+    public static ConfirmationOutcome Confirm(GlobalSettings settings, string prompt) =>
+        Confirm(
+            settings,
+            GlobalSettings.IsInteractiveEnvironment(),
+            defaultValue => AnsiConsole.Confirm(prompt, defaultValue));
+
+    /// <summary>
+    /// Confirms an operation and centralizes command output and exit-code behavior for non-confirmed outcomes.
+    /// </summary>
+    /// <param name="settings">The global settings containing the Yes flag.</param>
+    /// <param name="prompt">The confirmation prompt to display.</param>
+    /// <param name="format">The resolved output format.</param>
+    /// <returns>Null when the operation was confirmed; otherwise the command exit code to return.</returns>
+    public static int? ConfirmOrExit(GlobalSettings settings, string prompt, string format) =>
+        ExitCodeFor(Confirm(settings, prompt), format);
+
+    internal static ConfirmationOutcome Confirm(GlobalSettings settings, bool isInteractiveEnvironment, Func<bool, bool> confirm)
     {
         if (settings.Yes)
         {
-            return true;
+            return ConfirmationOutcome.Confirmed;
         }
 
-        if (!AnsiConsole.Profile.Out.IsTerminal)
+        if (!isInteractiveEnvironment)
         {
-            return true;
+            return ConfirmationOutcome.ConfirmationRequired;
         }
 
-        return AnsiConsole.Confirm(prompt);
+        return confirm(false) ? ConfirmationOutcome.Confirmed : ConfirmationOutcome.Declined;
+    }
+
+    internal static int? ExitCodeFor(ConfirmationOutcome outcome, string format)
+    {
+        if (outcome is ConfirmationOutcome.Confirmed)
+        {
+            return null;
+        }
+
+        if (outcome is ConfirmationOutcome.Declined)
+        {
+            OutputFormatter.WriteMessage(format, "Aborted.");
+            return ExitCodes.Success;
+        }
+
+        OutputFormatter.WriteError(
+            format,
+            "Confirmation is required for this destructive command in a non-interactive environment",
+            "Re-run the command with --yes to confirm the operation",
+            ExitCodes.ValidationErrorCode);
+        return ExitCodes.ValidationError;
     }
 }

--- a/Source/Cli/ConfirmationOutcome.cs
+++ b/Source/Cli/ConfirmationOutcome.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Cli;
+
+/// <summary>
+/// Describes the outcome of a destructive-operation confirmation request.
+/// </summary>
+public enum ConfirmationOutcome
+{
+    /// <summary>
+    /// The operation was explicitly confirmed.
+    /// </summary>
+    Confirmed = 0,
+
+    /// <summary>
+    /// An interactive user declined the operation.
+    /// </summary>
+    Declined = 1,
+
+    /// <summary>
+    /// The operation requires explicit confirmation because no interactive user is available.
+    /// </summary>
+    ConfirmationRequired = 2
+}

--- a/Source/Cli/GlobalSettings.cs
+++ b/Source/Cli/GlobalSettings.cs
@@ -30,9 +30,10 @@ public class GlobalSettings : CommandSettings
 
     /// <summary>
     /// Gets or sets a value indicating whether confirmation prompts should be skipped.
+    /// Required for destructive commands in non-interactive environments.
     /// </summary>
     [CommandOption("-y|--yes")]
-    [Description("Skip confirmation prompts (assume yes)")]
+    [Description("Skip confirmation prompts (assume yes); required for non-interactive destructive commands")]
     [DefaultValue(false)]
     public bool Yes { get; set; }
 
@@ -46,17 +47,18 @@ public class GlobalSettings : CommandSettings
     public bool Debug { get; set; }
 
     /// <summary>
-    /// Returns true when the process is running inside a known AI agent environment (Claude Code, Cursor, Windsurf).
+    /// Returns true when the process is running inside a supported AI agent environment.
     /// Used to tune default output formats — compact JSON rather than indented JSON.
     /// </summary>
     /// <returns>True if an AI agent environment is detected.</returns>
-    public static bool IsAiAgentEnvironment() =>
-        !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("CLAUDECODE")) ||
-        !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("CLAUDE_CODE_ENTRYPOINT")) ||
-        !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("CURSOR_TRACE_DIR")) ||
-        !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("WINDSURF_SESSION_ID")) ||
-        string.Equals(Environment.GetEnvironmentVariable("TERM_PROGRAM"), "cursor", StringComparison.OrdinalIgnoreCase) ||
-        string.Equals(Environment.GetEnvironmentVariable("TERM_PROGRAM"), "windsurf", StringComparison.OrdinalIgnoreCase);
+    public static bool IsAiAgentEnvironment() => AiAgentEnvironment.IsDetected();
+
+    /// <summary>
+    /// Returns true when the process can safely prompt a person for input.
+    /// </summary>
+    /// <returns>True when input and output are interactive and no AI agent environment is detected.</returns>
+    public static bool IsInteractiveEnvironment() =>
+        IsInteractiveEnvironment(AnsiConsole.Profile.Capabilities.Interactive, AnsiConsole.Profile.Out.IsTerminal);
 
     /// <summary>
     /// Resolves the effective output format, using auto-detection when set to "auto".
@@ -104,4 +106,14 @@ public class GlobalSettings : CommandSettings
 
         return Console.IsOutputRedirected ? OutputFormats.Json : OutputFormats.Table;
     }
+
+    internal static bool IsInteractiveEnvironment(bool interactionSupported, bool outputIsTerminal) =>
+        IsInteractiveEnvironment(
+            interactionSupported,
+            outputIsTerminal,
+            IsAiAgentEnvironment(),
+            AiAgentEnvironment.IsNonInteractiveRequested());
+
+    internal static bool IsInteractiveEnvironment(bool interactionSupported, bool outputIsTerminal, bool aiAgentDetected, bool nonInteractiveRequested) =>
+        interactionSupported && outputIsTerminal && !aiAgentDetected && !nonInteractiveRequested;
 }

--- a/Source/Cli/OutputFormatter.cs
+++ b/Source/Cli/OutputFormatter.cs
@@ -141,7 +141,9 @@ public static class OutputFormatter
             return;
         }
 
-        if (string.Equals(format, OutputFormats.Json, StringComparison.Ordinal) || string.Equals(format, OutputFormats.JsonCompact, StringComparison.Ordinal))
+        if (string.Equals(format, OutputFormats.Json, StringComparison.Ordinal) ||
+            string.Equals(format, OutputFormats.JsonCompact, StringComparison.Ordinal) ||
+            string.Equals(format, OutputFormats.JsonQuiet, StringComparison.Ordinal))
         {
             var json = JsonSerializer.Serialize(new { message }, OptionsFor(format));
             Console.WriteLine(json);
@@ -161,7 +163,10 @@ public static class OutputFormatter
     /// <param name="errorCode">An optional machine-readable error code included in JSON output.</param>
     public static void WriteError(string format, string error, string? suggestion = null, string? errorCode = null)
     {
-        if (string.Equals(format, OutputFormats.Json, StringComparison.Ordinal) || string.Equals(format, OutputFormats.JsonCompact, StringComparison.Ordinal) || string.Equals(format, OutputFormats.Quiet, StringComparison.Ordinal))
+        if (string.Equals(format, OutputFormats.Json, StringComparison.Ordinal) ||
+            string.Equals(format, OutputFormats.JsonCompact, StringComparison.Ordinal) ||
+            string.Equals(format, OutputFormats.JsonQuiet, StringComparison.Ordinal) ||
+            string.Equals(format, OutputFormats.Quiet, StringComparison.Ordinal))
         {
             var errorObj = new Dictionary<string, string>();
             if (errorCode is not null)


### PR DESCRIPTION
## Changed

- Default destructive confirmation prompts to No and require `--yes` in noninteractive environments.
- Honor `CRATIS_NONINTERACTIVE` and recognized agent hosts without treating ordinary VS Code terminals as agent processes.

## Fixed

- Validate destructive confirmation before connecting to Chronicle or loading connection credentials.
- Keep declined and missing-confirmation output machine-readable across JSON and quiet JSON formats.