### PR TITLE
Report Screenplay package provenance and support tiers

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -2,11 +2,13 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <CratisArcScreenplayVersion>22.0.0</CratisArcScreenplayVersion>
+    <CratisCritterStackScreenplayVersion>0.1.0</CratisCritterStackScreenplayVersion>
   </PropertyGroup>
   <ItemGroup>
     <!-- Cratis -->
-    <PackageVersion Include="Cratis.Arc.Screenplay" Version="22.0.0" />
-    <PackageVersion Include="Cratis.CritterStack.Screenplay" Version="0.1.0" />
+    <PackageVersion Include="Cratis.Arc.Screenplay" Version="$(CratisArcScreenplayVersion)" />
+    <PackageVersion Include="Cratis.CritterStack.Screenplay" Version="$(CratisCritterStackScreenplayVersion)" />
     <PackageVersion Include="Cratis.Screenplay.Generation.Contracts" Version="0.1.0" />
     <PackageVersion Include="Cratis.Screenplay.Generation.DotNet" Version="0.1.0" />
     <PackageVersion Include="Cratis.Chronicle.Connections" Version="16.37.0" />

--- a/Documentation/reference/screenplay.md
+++ b/Documentation/reference/screenplay.md
@@ -40,7 +40,7 @@ Pass `--file` to write it directly instead. The output is written as raw UTF-8, 
 | `--domain <NAME>` | Name of the domain the generated document belongs to. Defaults to the assembly or root namespace of the project, and to the solution name when several projects are read. |
 | `--module <NAME>` | Name of the module every discovered feature is placed within. Defaults to the domain. |
 | `--skip-segments <COUNT>` | Number of leading namespace segments to skip when inferring features and slices. |
-| `--modules-from-namespace-roots` | Name the module of each feature after the outermost segment of its namespace, instead of placing every feature in one module. |
+| `--modules-from-namespace-roots` | With the Arc provider, name each feature's module after the outermost namespace segment. Marten/Critter Stack currently report `CLI0014` and leave this option unapplied. |
 
 The output file uses `--file` rather than `-o`, because `-o/--output` is the global output *format* flag — see [Global Options](global-options.md).
 
@@ -69,7 +69,7 @@ module Inventory
 module Lending
 ```
 
-Naming a module with `--module` still collapses the document into that one, whichever of these is passed.
+Naming a module with `--module` still collapses the document into that one, whichever of these is passed. Namespace-root module inference currently belongs to the Arc provider. Marten and Critter Stack generation reports `CLI0014` rather than silently pretending to apply it.
 
 ### Finding the solution or project
 
@@ -84,7 +84,7 @@ A Screenplay describes one application, and an application is regularly split ac
 - **With the Arc provider, projects that cannot declare an Arc/Chronicle artifact.** A Roslyn analyzer, build-time tool, or code-generation project resolving neither framework is left out. Marten/Wolverine contracts are frequently markerless and may live in referenced projects without a direct package reference, so Critter Stack analysis retains non-spec C# projects and lets the provider contribute only evidence it recognizes.
 - **Spec projects**, by name: the ones called, or ending in, `.Specs`, `.Specifications`, `.Tests`, `.Test`, `.IntegrationTests`, or `.Specs.AppHost`. Nothing about what a spec project can see tells it apart — it references the same framework the application does — so the name is what decides. `.Specs.AppHost` covers the host integration specs start the application in.
 
-A project that targets several frameworks is read once. The workspace opens it once per target framework and names the results `MyApp(net10.0)`, `MyApp(net9.0)`; they all hold the same application, so one of them takes part.
+A project that targets several frameworks is read once. The workspace opens it once per target framework and names the results `MyApp(net10.0)`, `MyApp(net9.0)`; the CLI selects one deterministically and the provenance report names the selected target. Package admission, capabilities, and the support tier apply only to that reported target framework — they make no claim about the project's other targets.
 
 Pass a `.csproj` instead of the solution to describe a single project — pointing at a project is the instruction to read it, so it is read whatever it can see.
 
@@ -109,15 +109,51 @@ warnings (2):
   warning SP0141: [Library.Authors.Registration] validator rule Must() cannot be expressed
 ```
 
-With `-o json` or `-o json-compact` the same diagnostics are written to standard error as a JSON object instead.
+With `-o json` or `-o json-compact`, standard error is one JSON object containing both source provenance and diagnostics.
 
 **Warnings and information do not fail the command** — the document is still written. **An error does**: nothing is written and the command exits with a validation error, because a document that does not describe the source faithfully is worse than no document.
+
+### Source and compatibility provenance
+
+Every successful provider selection reports provenance on standard error, separately from the `.play` document on standard output. The report names:
+
+- the selected provider and bundled provider package version;
+- every selected project and target framework;
+- resolved Marten/Wolverine NuGet package IDs and versions from that target's `project.assets.json`;
+- referenced framework assembly identities and versions as corroboration;
+- exact metadata capability fingerprints found by Roslyn.
+
+For Marten and Critter Stack, it also reports four independent compatibility dimensions:
+
+- **Support tier** — `Canonical`, `SourceReviewed`, `RecognizedWithLoss`, `Unknown`, or `Unsupported` package/API evidence.
+- **Recognition status** — whether the provider recognized the framework generation.
+- **Semantic conformance** — whether static interpretation completed and still requires human review, found contradictory evidence, or was not evaluated.
+- **Lowering fidelity** — whether no loss was reported, loss was reported, lowering failed, or lowering was not evaluated.
+
+These values deliberately do not imply one another. A canonical package set can still use behavior outside its fixture assertions, require human review, and report lowering loss. An assembly version corroborates a NuGet version but never replaces it.
+
+```text
+source compatibility:
+  provider: critter-stack 0.1.0
+  project: Helpdesk.Api (net9.0)
+    packages: Marten 9.23.0, WolverineFx 6.29.1, WolverineFx.Marten 6.29.1
+    assemblies: Marten 9.23.0.0, Wolverine 6.29.1.0
+    capabilities: marten.event-projection, wolverine.handler-attribute
+  support tier: SourceReviewed
+  recognition: Recognized
+  semantic conformance: RequiresHumanReview
+  lowering fidelity: LossReported
+```
+
+`Canonical` means the bundled provider version passes the exact pinned package set and its fixture assertions — not that every API in that package combination is implemented. A package set that is canonical for a newer adapter remains `SourceReviewed` when the CLI bundles an older provider. `SourceReviewed` otherwise means the major-generation source and metadata were reviewed, but the exact provider/package combination is not canonical. `RecognizedWithLoss` means the API is identified but its source semantics cannot be interpreted exactly. `Unknown` and `Unsupported` fail closed before source interpretation. A newer Marten or Wolverine major remains unsupported until source review and canonical evidence exist.
+
+Arc reports provider, target-framework, package, assembly, and capability provenance but continues to use its existing adapter compatibility contract rather than the Critter Stack support-tier matrix.
 
 ### Marten and Critter Stack preview
 
 Marten and Critter Stack source generation is a **preview**. It covers representative current and legacy applications, including aggregate event returns, snapshots and reducers, HTTP/message handlers, direct document operations, queries, response wrappers, and outgoing or delayed messages. Generated documents are compiled and checked for stable print/compile/print output before they are returned.
 
-The preview does not claim complete reconstruction of every compiled query, `EventProjection`, multi-stream grouper, tenancy topology, saga, middleware chain, broker option, alias, or upcast. Recognized behavior that cannot be represented is reported with a stable `MARTEN`, `WOLVERINE`, or `GEN` diagnostic instead of being silently invented or omitted. Review warnings before using generated output as a migration specification.
+The preview does not claim complete reconstruction of every compiled query, `EventProjection`, multi-stream grouper, tenancy topology, saga, middleware chain, broker option, alias, or upcast. Recognized behavior that cannot be represented is reported with a stable `MARTEN`, `WOLVERINE`, or `GEN` diagnostic instead of being silently invented or omitted. The compatibility report identifies the exact package evidence used for admission and keeps package support separate from semantic review and lowering loss. Review both before using generated output as a migration specification.
 
 Source analysis does not start the target host or connect to PostgreSQL or Chronicle. MSBuild still evaluates the targeted project, so generate only from source you trust.
 
@@ -150,6 +186,9 @@ The project does **not** have to have been built first. Sources MSBuild generate
 | A solution contains several deployable hosts for a provider that requires one application | Validation error (`CLI0009`) listing the hosts; target one `.csproj` explicitly. |
 | No bundled provider recognizes the loaded source | Validation error (`CLI0010`) listing the available providers. |
 | Several unrelated providers recognize the loaded source | Validation error (`CLI0011`) listing the candidates; select one with `--provider`. |
+| Resolved Marten/Wolverine package provenance is absent, divergent, or cannot be classified | Validation error (`CLI0012`); compatibility is `Unknown` and source interpretation does not start. |
+| A resolved Marten/Wolverine major is newer than the highest source-reviewed generation | Validation error (`CLI0013`); compatibility is `Unsupported` and source interpretation does not start. |
+| `--modules-from-namespace-roots` is used with Marten or Critter Stack | Warning (`CLI0014`); generation continues without applying the option and lowering fidelity reports loss. |
 | A project cannot be read into a compilation | Validation error (`CLI0004`) naming it; the remaining projects are still described. |
 | Generation reports one or more errors, with `--file` | Validation error; the document is written anyway. |
 | Generation reports one or more errors, writing to standard output | Validation error; nothing is written. |

--- a/Source/Cli.Specs/for_CritterStackScreenplayGeneration/when_generating/and_namespace_root_modules_are_requested.cs
+++ b/Source/Cli.Specs/for_CritterStackScreenplayGeneration/when_generating/and_namespace_root_modules_are_requested.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Cli.for_CritterStackScreenplayGeneration.when_generating;
+
+public class and_namespace_root_modules_are_requested : given.a_marten_application_built_from_source
+{
+    GeneratedScreenplay _result;
+
+    void Because() => _result = CritterStackScreenplayGeneration.GenerateFrom(
+        Loaded,
+        "/workspace/Banking/Banking.csproj",
+        ScreenplayGenerationOptions.Default with
+        {
+            Provider = ScreenplayProviders.Marten,
+            ModulesFromNamespaceRoots = true
+        });
+
+    [Fact] void should_report_that_the_option_was_not_applied() => _result.Diagnostics.Select(_ => _.Code).ShouldContain(ScreenplayDiagnosticCodes.UnsupportedGenerationOption);
+}

--- a/Source/Cli.Specs/for_GenerateScreenplayCommand/when_generating/and_generation_reports_an_error/and_machine_output_is_requested.cs
+++ b/Source/Cli.Specs/for_GenerateScreenplayCommand/when_generating/and_generation_reports_an_error/and_machine_output_is_requested.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text.Json;
+
+namespace Cratis.Cli.for_GenerateScreenplayCommand.when_generating.and_generation_reports_an_error;
+
+[Collection(CliSpecsCollection.Name)]
+public class and_machine_output_is_requested : given.a_generation_reporting_an_error
+{
+    TextWriter _previousError;
+    StringWriter _capturedError;
+    string _result;
+
+    void Establish()
+    {
+        _previousError = Console.Error;
+        _capturedError = new StringWriter();
+        Console.SetError(_capturedError);
+    }
+
+    async Task Because()
+    {
+        await Execute();
+        _result = _capturedError.ToString();
+    }
+
+    [Fact] void should_write_one_json_payload() => JsonDocument.Parse(_result).RootElement.GetProperty("diagnostics").GetArrayLength().ShouldEqual(2);
+
+    void Destroy()
+    {
+        Console.SetError(_previousError);
+        _capturedError.Dispose();
+    }
+}

--- a/Source/Cli.Specs/for_GenerateScreenplayCommand/when_generating/and_provenance_is_available.cs
+++ b/Source/Cli.Specs/for_GenerateScreenplayCommand/when_generating/and_provenance_is_available.cs
@@ -1,0 +1,48 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text;
+
+namespace Cratis.Cli.for_GenerateScreenplayCommand.when_generating;
+
+[Collection(CliSpecsCollection.Name)]
+public class and_provenance_is_available : given.a_generate_screenplay_command
+{
+    TextWriter _previousError;
+    StringWriter _capturedError;
+    int _result;
+
+    void Establish()
+    {
+        _previousError = Console.Error;
+        _capturedError = new StringWriter();
+        Console.SetError(_capturedError);
+        _generation
+            .Generate(Arg.Any<string>(), Arg.Any<ScreenplayGenerationOptions>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new GeneratedScreenplay(GeneratedSource, [])
+            {
+                Provenance = new ScreenplayGenerationProvenance(
+                    ScreenplayProviders.Marten,
+                    "0.3.0",
+                    [],
+                    new ScreenplayCompatibilityReport(
+                        ScreenplaySupportTier.Canonical,
+                        ScreenplayRecognitionStatus.Recognized,
+                        ScreenplaySemanticConformance.RequiresHumanReview,
+                        ScreenplayLoweringFidelity.NoReportedLoss,
+                        "canonical fixture evidence"))
+            }));
+    }
+
+    async Task Because() => _result = await Execute();
+
+    [Fact] void should_succeed() => _result.ShouldEqual(ExitCodes.Success);
+    [Fact] void should_report_compatibility_to_standard_error() => _capturedError.ToString().ShouldContain("\"supportTier\":\"Canonical\"");
+    [Fact] void should_keep_the_screenplay_clean_on_standard_output() => Encoding.UTF8.GetString(_standardOutput.ToArray()).ShouldEqual(GeneratedSource);
+
+    void Destroy()
+    {
+        Console.SetError(_previousError);
+        _capturedError.Dispose();
+    }
+}

--- a/Source/Cli.Specs/for_ProjectRestoreState/when_finding_the_assets_file/and_the_intermediate_output_folder_was_moved.cs
+++ b/Source/Cli.Specs/for_ProjectRestoreState/when_finding_the_assets_file/and_the_intermediate_output_folder_was_moved.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Cli.for_ProjectRestoreState.when_finding_the_assets_file;
+
+public class and_the_intermediate_output_folder_was_moved : given.a_project_folder
+{
+    string _assets;
+    string _result;
+
+    void Establish()
+    {
+        Restore(Path.Combine(_folder, "obj"));
+        var intermediate = Path.Combine(_folder, "artifacts", "obj", "MyApp");
+        _assets = Restore(intermediate);
+        _result = Path.Combine(intermediate, "Debug", "net9.0", "MyApp.dll");
+    }
+
+    void Because() => _result = ProjectRestoreState.AssetsFileFor(_project, _result)!;
+
+    [Fact] void should_find_the_assets_file_from_the_intermediate_assembly() => _result.ShouldEqual(_assets);
+}

--- a/Source/Cli.Specs/for_ProviderScreenplayGeneration/given/provider_compilations.cs
+++ b/Source/Cli.Specs/for_ProviderScreenplayGeneration/given/provider_compilations.cs
@@ -17,7 +17,7 @@ public class provider_compilations : Specification
         ["Application"],
         []);
 
-    static IEnumerable<MetadataReference> References() =>
+    protected static IEnumerable<MetadataReference> References() =>
         ((string)AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES")!)
             .Split(Path.PathSeparator)
             .Select(_ => MetadataReference.CreateFromFile(_));

--- a/Source/Cli.Specs/for_ProviderScreenplayGeneration/when_selecting/and_arc_excludes_non_artifact_provenance.cs
+++ b/Source/Cli.Specs/for_ProviderScreenplayGeneration/when_selecting/and_arc_excludes_non_artifact_provenance.cs
@@ -1,0 +1,40 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.CodeAnalysis.CSharp;
+
+namespace Cratis.Cli.for_ProviderScreenplayGeneration.when_selecting;
+
+public class and_arc_excludes_non_artifact_provenance : given.provider_compilations
+{
+    LoadedCompilation _result;
+
+    void Because()
+    {
+        var loaded = new LoadedCompilation(
+            [
+                CSharpCompilation.Create(
+                    "Application",
+                    [CSharpSyntaxTree.ParseText("namespace Cratis.Arc.Commands.ModelBound { public class CommandAttribute : System.Attribute; }")],
+                    References()),
+                CSharpCompilation.Create(
+                    "Tooling",
+                    [CSharpSyntaxTree.ParseText("public class Tooling;")],
+                    References())
+            ],
+            ["Application", "Tooling"],
+            [])
+        {
+            ProjectProvenance =
+            [
+                new ScreenplayProjectProvenance("Application", "net9.0", [], [], []),
+                new ScreenplayProjectProvenance("Tooling", "net9.0", [], [], [])
+            ]
+        };
+
+        _result = new ArcSourceProvider().SelectFrom(loaded);
+    }
+
+    [Fact] void should_keep_only_the_project_arc_will_interpret() => _result.ProjectNames.ShouldContainOnly(["Application"]);
+    [Fact] void should_keep_only_the_matching_project_provenance() => _result.ProjectProvenance.Select(_ => _.Project).ShouldContainOnly(["Application"]);
+}

--- a/Source/Cli.Specs/for_ScreenplayCompatibility/given/compatibility_evidence.cs
+++ b/Source/Cli.Specs/for_ScreenplayCompatibility/given/compatibility_evidence.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Cli.for_ScreenplayCompatibility.given;
+
+public class compatibility_evidence : Specification
+{
+    protected sealed class a_provider(string name, string version) : IScreenplaySourceProvider
+    {
+        public string Name => name;
+        public string Version => version;
+        public IReadOnlyList<string> Supersedes => [];
+        public bool RequiresSingleHost => true;
+        public bool Matches(LoadedCompilation loaded) => false;
+        public LoadedCompilation SelectFrom(LoadedCompilation loaded) => loaded;
+        public GeneratedScreenplay GenerateFrom(LoadedCompilation loaded, string targetPath, ScreenplayGenerationOptions options) =>
+            GeneratedScreenplay.Failed("SPEC", "Not used by compatibility specs");
+    }
+
+    protected static LoadedCompilation LoadedWith(params ResolvedScreenplayPackage[] packages) =>
+        new([], [], [])
+        {
+            ProjectProvenance =
+            [
+                new ScreenplayProjectProvenance(
+                    "Application",
+                    "net9.0",
+                    packages,
+                    [new ScreenplayAssemblyIdentity("Marten", "9.0.0.0")],
+                    ["marten.event-projection"])
+            ]
+        };
+}

--- a/Source/Cli.Specs/for_ScreenplayCompatibility/when_assessing/and_bundled_provider_predates_canonical_baseline.cs
+++ b/Source/Cli.Specs/for_ScreenplayCompatibility/when_assessing/and_bundled_provider_predates_canonical_baseline.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Cli.for_ScreenplayCompatibility.when_assessing;
+
+public class and_bundled_provider_predates_canonical_baseline : given.compatibility_evidence
+{
+    ScreenplayCompatibilityEvaluation _result;
+
+    void Because() => _result = ScreenplayCompatibility.Evaluate(
+        new a_provider(ScreenplayProviders.CritterStack, "0.1.0"),
+        LoadedWith(
+            new ResolvedScreenplayPackage("Marten", "9.23.0"),
+            new ResolvedScreenplayPackage("WolverineFx", "6.29.1"),
+            new ResolvedScreenplayPackage("WolverineFx.Marten", "6.29.1")));
+
+    [Fact] void should_not_claim_canonical_support() => _result.Provenance.Compatibility!.SupportTier.ShouldEqual(ScreenplaySupportTier.SourceReviewed);
+    [Fact] void should_explain_the_required_provider_baseline() => _result.Provenance.Compatibility!.Explanation.ShouldContain("provider 0.3.0 or newer");
+}

--- a/Source/Cli.Specs/for_ScreenplayCompatibility/when_assessing/and_marten_has_an_unreviewed_major.cs
+++ b/Source/Cli.Specs/for_ScreenplayCompatibility/when_assessing/and_marten_has_an_unreviewed_major.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Cli.for_ScreenplayCompatibility.when_assessing;
+
+public class and_marten_has_an_unreviewed_major : given.compatibility_evidence
+{
+    ScreenplayCompatibilityEvaluation _result;
+
+    void Because() => _result = ScreenplayCompatibility.Evaluate(
+        new MartenSourceProvider(),
+        LoadedWith(new ResolvedScreenplayPackage("Marten", "8.12.0")));
+
+    [Fact] void should_fail_closed() => _result.BlockingDiagnostic.ShouldNotBeNull();
+    [Fact] void should_report_unknown_version_evidence() => _result.BlockingDiagnostic!.Code.ShouldEqual(ScreenplayDiagnosticCodes.UnknownFrameworkVersion);
+    [Fact] void should_not_call_the_unreviewed_major_unsupported() => _result.Provenance.Compatibility!.SupportTier.ShouldEqual(ScreenplaySupportTier.Unknown);
+}

--- a/Source/Cli.Specs/for_ScreenplayCompatibility/when_assessing/and_marten_is_a_newer_major.cs
+++ b/Source/Cli.Specs/for_ScreenplayCompatibility/when_assessing/and_marten_is_a_newer_major.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Cli.for_ScreenplayCompatibility.when_assessing;
+
+public class and_marten_is_a_newer_major : given.compatibility_evidence
+{
+    ScreenplayCompatibilityEvaluation _result;
+
+    void Because() => _result = ScreenplayCompatibility.Evaluate(
+        new MartenSourceProvider(),
+        LoadedWith(new ResolvedScreenplayPackage("Marten", "10.0.0")));
+
+    [Fact] void should_fail_closed() => _result.BlockingDiagnostic.ShouldNotBeNull();
+    [Fact] void should_report_the_unsupported_version_code() => _result.BlockingDiagnostic!.Code.ShouldEqual(ScreenplayDiagnosticCodes.UnsupportedFrameworkVersion);
+    [Fact] void should_report_unsupported_support() => _result.Provenance.Compatibility!.SupportTier.ShouldEqual(ScreenplaySupportTier.Unsupported);
+    [Fact] void should_not_evaluate_lowering() => _result.Provenance.Compatibility!.LoweringFidelity.ShouldEqual(ScreenplayLoweringFidelity.NotEvaluated);
+}

--- a/Source/Cli.Specs/for_ScreenplayCompatibility/when_assessing/and_resolved_package_provenance_is_missing.cs
+++ b/Source/Cli.Specs/for_ScreenplayCompatibility/when_assessing/and_resolved_package_provenance_is_missing.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Cli.for_ScreenplayCompatibility.when_assessing;
+
+public class and_resolved_package_provenance_is_missing : given.compatibility_evidence
+{
+    ScreenplayCompatibilityEvaluation _result;
+
+    void Because() => _result = ScreenplayCompatibility.Evaluate(
+        new MartenSourceProvider(),
+        LoadedWith());
+
+    [Fact] void should_fail_closed() => _result.BlockingDiagnostic.ShouldNotBeNull();
+    [Fact] void should_report_unknown_provenance() => _result.BlockingDiagnostic!.Code.ShouldEqual(ScreenplayDiagnosticCodes.UnknownFrameworkVersion);
+    [Fact] void should_keep_unknown_distinct_from_unsupported() => _result.Provenance.Compatibility!.SupportTier.ShouldEqual(ScreenplaySupportTier.Unknown);
+    [Fact] void should_not_evaluate_semantic_conformance() => _result.Provenance.Compatibility!.SemanticConformance.ShouldEqual(ScreenplaySemanticConformance.NotEvaluated);
+}

--- a/Source/Cli.Specs/for_ScreenplayCompatibility/when_assessing/and_the_critter_stack_package_set_is_canonical.cs
+++ b/Source/Cli.Specs/for_ScreenplayCompatibility/when_assessing/and_the_critter_stack_package_set_is_canonical.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Cli.for_ScreenplayCompatibility.when_assessing;
+
+public class and_the_critter_stack_package_set_is_canonical : given.compatibility_evidence
+{
+    ScreenplayCompatibilityEvaluation _result;
+
+    void Because() => _result = ScreenplayCompatibility.Evaluate(
+        new a_provider(ScreenplayProviders.CritterStack, "0.3.0"),
+        LoadedWith(
+            new ResolvedScreenplayPackage("Marten", "9.23.0"),
+            new ResolvedScreenplayPackage("WolverineFx", "6.29.1"),
+            new ResolvedScreenplayPackage("WolverineFx.Marten", "6.29.1")));
+
+    [Fact] void should_admit_generation() => _result.BlockingDiagnostic.ShouldBeNull();
+    [Fact] void should_report_canonical_support() => _result.Provenance.Compatibility!.SupportTier.ShouldEqual(ScreenplaySupportTier.Canonical);
+    [Fact] void should_keep_recognition_separate() => _result.Provenance.Compatibility!.RecognitionStatus.ShouldEqual(ScreenplayRecognitionStatus.Recognized);
+    [Fact] void should_require_semantic_review() => _result.Provenance.Compatibility!.SemanticConformance.ShouldEqual(ScreenplaySemanticConformance.RequiresHumanReview);
+    [Fact] void should_not_claim_lowering_before_generation() => _result.Provenance.Compatibility!.LoweringFidelity.ShouldEqual(ScreenplayLoweringFidelity.NotEvaluated);
+}

--- a/Source/Cli.Specs/for_ScreenplayCompatibility/when_assessing/and_the_marten_integration_version_diverges.cs
+++ b/Source/Cli.Specs/for_ScreenplayCompatibility/when_assessing/and_the_marten_integration_version_diverges.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Cli.for_ScreenplayCompatibility.when_assessing;
+
+public class and_the_marten_integration_version_diverges : given.compatibility_evidence
+{
+    ScreenplayCompatibilityEvaluation _result;
+
+    void Because() => _result = ScreenplayCompatibility.Evaluate(
+        new CritterStackSourceProvider(),
+        LoadedWith(
+            new ResolvedScreenplayPackage("Marten", "9.23.0"),
+            new ResolvedScreenplayPackage("WolverineFx", "6.29.1"),
+            new ResolvedScreenplayPackage("WolverineFx.Marten", "6.28.0")));
+
+    [Fact] void should_fail_closed_as_unknown() => _result.Provenance.Compatibility!.SupportTier.ShouldEqual(ScreenplaySupportTier.Unknown);
+    [Fact] void should_name_both_versions() => _result.BlockingDiagnostic!.Message.ShouldContain("6.28.0 does not match WolverineFx 6.29.1");
+}

--- a/Source/Cli.Specs/for_ScreenplayCompatibility/when_assessing/and_the_marten_version_is_malformed.cs
+++ b/Source/Cli.Specs/for_ScreenplayCompatibility/when_assessing/and_the_marten_version_is_malformed.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Cli.for_ScreenplayCompatibility.when_assessing;
+
+public class and_the_marten_version_is_malformed : given.compatibility_evidence
+{
+    ScreenplayCompatibilityEvaluation _result;
+
+    void Because() => _result = ScreenplayCompatibility.Evaluate(
+        new MartenSourceProvider(),
+        LoadedWith(new ResolvedScreenplayPackage("Marten", "9.not-a-version")));
+
+    [Fact] void should_fail_closed_as_unknown() => _result.Provenance.Compatibility!.SupportTier.ShouldEqual(ScreenplaySupportTier.Unknown);
+    [Fact] void should_report_unknown_version_evidence() => _result.BlockingDiagnostic!.Code.ShouldEqual(ScreenplayDiagnosticCodes.UnknownFrameworkVersion);
+}

--- a/Source/Cli.Specs/for_ScreenplayCompatibility/when_assessing/and_the_package_set_is_source_reviewed.cs
+++ b/Source/Cli.Specs/for_ScreenplayCompatibility/when_assessing/and_the_package_set_is_source_reviewed.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Cli.for_ScreenplayCompatibility.when_assessing;
+
+public class and_the_package_set_is_source_reviewed : given.compatibility_evidence
+{
+    ScreenplayCompatibilityEvaluation _result;
+
+    void Because() => _result = ScreenplayCompatibility.Evaluate(
+        new CritterStackSourceProvider(),
+        LoadedWith(
+            new ResolvedScreenplayPackage("Marten", "9.29.0"),
+            new ResolvedScreenplayPackage("WolverineFx", "6.29.2")));
+
+    [Fact] void should_admit_generation() => _result.BlockingDiagnostic.ShouldBeNull();
+    [Fact] void should_not_promote_it_to_canonical() => _result.Provenance.Compatibility!.SupportTier.ShouldEqual(ScreenplaySupportTier.SourceReviewed);
+    [Fact] void should_explain_that_the_exact_set_is_not_canonical() => _result.Provenance.Compatibility!.Explanation.ShouldContain("not an exact canonical package set");
+}

--- a/Source/Cli.Specs/for_ScreenplayCompatibility/when_completing/and_lowering_reports_loss.cs
+++ b/Source/Cli.Specs/for_ScreenplayCompatibility/when_completing/and_lowering_reports_loss.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Cli.for_ScreenplayCompatibility.when_completing;
+
+public class and_lowering_reports_loss : given.compatibility_evidence
+{
+    ScreenplayGenerationProvenance _result;
+
+    void Because()
+    {
+        var evaluation = ScreenplayCompatibility.Evaluate(
+            new a_provider(ScreenplayProviders.Marten, "0.3.0"),
+            LoadedWith(new ResolvedScreenplayPackage("Marten", "9.20.1")));
+        _result = evaluation.Complete(
+            [new ScreenplayDiagnostic(ScreenplayDiagnosticSeverity.Warning, "MARTEN0004", "lifecycle omitted", null)]);
+    }
+
+    [Fact] void should_retain_the_canonical_support_tier() => _result.Compatibility!.SupportTier.ShouldEqual(ScreenplaySupportTier.Canonical);
+    [Fact] void should_report_lowering_loss_separately() => _result.Compatibility!.LoweringFidelity.ShouldEqual(ScreenplayLoweringFidelity.LossReported);
+    [Fact] void should_still_require_semantic_review() => _result.Compatibility!.SemanticConformance.ShouldEqual(ScreenplaySemanticConformance.RequiresHumanReview);
+}

--- a/Source/Cli.Specs/for_ScreenplayDiagnosticsWriter/when_writing_json/and_provenance_is_available.cs
+++ b/Source/Cli.Specs/for_ScreenplayDiagnosticsWriter/when_writing_json/and_provenance_is_available.cs
@@ -1,0 +1,44 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text.Json;
+
+namespace Cratis.Cli.for_ScreenplayDiagnosticsWriter.when_writing_json;
+
+public class and_provenance_is_available : Specification
+{
+    JsonElement _result;
+
+    void Because()
+    {
+        var json = ScreenplayDiagnosticsWriter.JsonFor(
+            OutputFormats.JsonCompact,
+            [],
+            new ScreenplayGenerationProvenance(
+                ScreenplayProviders.CritterStack,
+                "0.3.0",
+                [
+                    new ScreenplayProjectProvenance(
+                        "Application",
+                        "net9.0",
+                        [new ResolvedScreenplayPackage("Marten", "9.23.0")],
+                        [new ScreenplayAssemblyIdentity("Marten", "9.0.0.0")],
+                        ["marten.event-projection"])
+                ],
+                new ScreenplayCompatibilityReport(
+                    ScreenplaySupportTier.Canonical,
+                    ScreenplayRecognitionStatus.Recognized,
+                    ScreenplaySemanticConformance.RequiresHumanReview,
+                    ScreenplayLoweringFidelity.NoReportedLoss,
+                    "canonical fixture evidence")));
+        _result = JsonDocument.Parse(json).RootElement.Clone();
+    }
+
+    [Fact] void should_report_the_provider_version() => _result.GetProperty("provenance").GetProperty("providerVersion").GetString().ShouldEqual("0.3.0");
+    [Fact] void should_report_the_selected_target_framework() => _result.GetProperty("provenance").GetProperty("projects")[0].GetProperty("targetFramework").GetString().ShouldEqual("net9.0");
+    [Fact] void should_report_the_resolved_package_version() => _result.GetProperty("provenance").GetProperty("projects")[0].GetProperty("packages")[0].GetProperty("version").GetString().ShouldEqual("9.23.0");
+    [Fact] void should_report_the_assembly_version_separately() => _result.GetProperty("provenance").GetProperty("projects")[0].GetProperty("assemblies")[0].GetProperty("version").GetString().ShouldEqual("9.0.0.0");
+    [Fact] void should_report_the_support_tier() => _result.GetProperty("provenance").GetProperty("compatibility").GetProperty("supportTier").GetString().ShouldEqual("Canonical");
+    [Fact] void should_report_semantic_conformance_separately() => _result.GetProperty("provenance").GetProperty("compatibility").GetProperty("semanticConformance").GetString().ShouldEqual("RequiresHumanReview");
+    [Fact] void should_report_lowering_fidelity_separately() => _result.GetProperty("provenance").GetProperty("compatibility").GetProperty("loweringFidelity").GetString().ShouldEqual("NoReportedLoss");
+}

--- a/Source/Cli.Specs/for_ScreenplayFrameworkCapabilities/when_fingerprinting/and_current_and_legacy_apis_are_present.cs
+++ b/Source/Cli.Specs/for_ScreenplayFrameworkCapabilities/when_fingerprinting/and_current_and_legacy_apis_are_present.cs
@@ -1,0 +1,55 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.CodeAnalysis.CSharp;
+
+namespace Cratis.Cli.for_ScreenplayFrameworkCapabilities.when_fingerprinting;
+
+public class and_current_and_legacy_apis_are_present : Specification
+{
+    IReadOnlyList<string> _result;
+
+    void Because()
+    {
+        var compilation = CSharpCompilation.Create(
+            "Application",
+            [CSharpSyntaxTree.ParseText(
+                string.Join('\n',
+                [
+                    "namespace Marten.Events.Aggregation",
+                    "{",
+                    "    public class SingleStreamProjection<T, TId>;",
+                    "}",
+                    "namespace JasperFx.Events.Projections",
+                    "{",
+                    "    public enum ProjectionLifecycle { Inline, Async, Live }",
+                    "}",
+                    "namespace Marten.Subscriptions",
+                    "{",
+                    "    public interface ISubscription;",
+                    "}",
+                    "namespace Wolverine.Attributes",
+                    "{",
+                    "    public class WolverineHandlerAttribute : System.Attribute;",
+                    "}",
+                    "namespace Wolverine.Persistence.EventSourcing",
+                    "{",
+                    "    public class DeciderFunctionAttribute : System.Attribute;",
+                    "    public class EventsToAppend;",
+                    "}",
+                    "namespace Wolverine.Marten",
+                    "{",
+                    "    public class AggregateHandlerAttribute : System.Attribute;",
+                    "}"
+                ]))]);
+
+        _result = ScreenplayFrameworkCapabilities.From(compilation);
+    }
+
+    [Fact] void should_recognize_the_current_projection_shape() => _result.ShouldContain("marten.single-stream-projection.two-identities");
+    [Fact] void should_recognize_the_current_lifecycle_namespace() => _result.ShouldContain("marten.projection-lifecycle.jasperfx");
+    [Fact] void should_recognize_subscriptions() => _result.ShouldContain("marten.subscription");
+    [Fact] void should_recognize_current_handler_metadata() => _result.ShouldContain("wolverine.handler-attribute");
+    [Fact] void should_recognize_store_agnostic_event_capture() => _result.ShouldContain("wolverine.events-to-append");
+    [Fact] void should_recognize_legacy_aggregate_metadata_separately() => _result.ShouldContain("wolverine.legacy-marten-aggregate");
+}

--- a/Source/Cli.Specs/for_ScreenplayPackageProvenance/when_reading_packages/and_the_assets_file_has_several_targets.cs
+++ b/Source/Cli.Specs/for_ScreenplayPackageProvenance/when_reading_packages/and_the_assets_file_has_several_targets.cs
@@ -1,0 +1,48 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Cli.for_ScreenplayPackageProvenance.when_reading_packages;
+
+public class and_the_assets_file_has_several_targets : Specification
+{
+    string _folder;
+    IReadOnlyList<ResolvedScreenplayPackage> _result;
+
+    void Establish()
+    {
+        _folder = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString())).FullName;
+        File.WriteAllText(
+            Path.Combine(_folder, ProjectRestoreState.AssetsFileName),
+            string.Join('\n',
+            [
+                "{",
+                "  \"targets\": {",
+                "    \"net8.0\": {",
+                "      \"Marten/8.0.0\": { \"type\": \"package\" }",
+                "    },",
+                "    \"net9.0\": {",
+                "      \"WolverineFx.Marten/6.23.1\": { \"type\": \"package\" },",
+                "      \"Unrelated/1.0.0\": { \"type\": \"package\" },",
+                "      \"Marten/9.20.0\": { \"type\": \"package\" },",
+                "      \"WolverineFx/6.23.1\": { \"type\": \"package\" }",
+                "    }",
+                "  }",
+                "}"
+            ]));
+    }
+
+    void Because() => _result = ScreenplayPackageProvenance.PackagesFrom(
+        Path.Combine(_folder, ProjectRestoreState.AssetsFileName),
+        "net9.0");
+
+    [Fact] void should_read_only_the_selected_target() => _result.ShouldNotContain(new ResolvedScreenplayPackage("Marten", "8.0.0"));
+    [Fact] void should_read_only_source_framework_packages() => _result.ShouldNotContain(new ResolvedScreenplayPackage("Unrelated", "1.0.0"));
+    [Fact] void should_return_resolved_packages_in_stable_order() => _result.ShouldContainOnly(
+        [
+            new ResolvedScreenplayPackage("Marten", "9.20.0"),
+            new ResolvedScreenplayPackage("WolverineFx", "6.23.1"),
+            new ResolvedScreenplayPackage("WolverineFx.Marten", "6.23.1")
+        ]);
+
+    void Destroy() => Directory.Delete(_folder, true);
+}

--- a/Source/Cli.Specs/for_ScreenplayPackageProvenance/when_reading_packages/and_the_assets_file_is_invalid.cs
+++ b/Source/Cli.Specs/for_ScreenplayPackageProvenance/when_reading_packages/and_the_assets_file_is_invalid.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Cli.for_ScreenplayPackageProvenance.when_reading_packages;
+
+public class and_the_assets_file_is_invalid : Specification
+{
+    string _assetsFile;
+    IReadOnlyList<ResolvedScreenplayPackage> _result;
+
+    void Establish()
+    {
+        _assetsFile = Path.GetTempFileName();
+        File.WriteAllText(_assetsFile, "{ invalid json");
+    }
+
+    void Because() => _result = ScreenplayPackageProvenance.PackagesFrom(_assetsFile, "net9.0");
+
+    [Fact] void should_return_no_provenance() => _result.ShouldBeEmpty();
+
+    void Destroy() => File.Delete(_assetsFile);
+}

--- a/Source/Cli.Specs/for_ScreenplayPackageProvenance/when_reading_packages/and_the_selected_target_is_missing.cs
+++ b/Source/Cli.Specs/for_ScreenplayPackageProvenance/when_reading_packages/and_the_selected_target_is_missing.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Cli.for_ScreenplayPackageProvenance.when_reading_packages;
+
+public class and_the_selected_target_is_missing : Specification
+{
+    string _assetsFile;
+    IReadOnlyList<ResolvedScreenplayPackage> _result;
+
+    void Establish()
+    {
+        _assetsFile = Path.GetTempFileName();
+        File.WriteAllText(_assetsFile, "{ \"targets\": { \"net8.0\": { \"Marten/8.0.0\": { \"type\": \"package\" } } } }");
+    }
+
+    void Because() => _result = ScreenplayPackageProvenance.PackagesFrom(_assetsFile, "net9.0");
+
+    [Fact] void should_not_fall_back_to_another_target() => _result.ShouldBeEmpty();
+
+    void Destroy() => File.Delete(_assetsFile);
+}

--- a/Source/Cli.Specs/for_ScreenplayPackageProvenance/when_reading_packages/and_the_selected_target_is_not_an_object.cs
+++ b/Source/Cli.Specs/for_ScreenplayPackageProvenance/when_reading_packages/and_the_selected_target_is_not_an_object.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Cli.for_ScreenplayPackageProvenance.when_reading_packages;
+
+public class and_the_selected_target_is_not_an_object : Specification
+{
+    string _assetsFile;
+    IReadOnlyList<ResolvedScreenplayPackage> _result;
+
+    void Establish()
+    {
+        _assetsFile = Path.GetTempFileName();
+        File.WriteAllText(_assetsFile, "{ \"targets\": { \"net9.0\": \"not a target graph\" } }");
+    }
+
+    void Because() => _result = ScreenplayPackageProvenance.PackagesFrom(_assetsFile, "net9.0");
+
+    [Fact] void should_return_no_provenance() => _result.ShouldBeEmpty();
+
+    void Destroy() => File.Delete(_assetsFile);
+}

--- a/Source/Cli/Cli.csproj
+++ b/Source/Cli/Cli.csproj
@@ -29,6 +29,11 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <AssemblyMetadata Include="Cratis.Arc.Screenplay.PackageVersion" Value="$(CratisArcScreenplayVersion)" />
+        <AssemblyMetadata Include="Cratis.CritterStack.Screenplay.PackageVersion" Value="$(CratisCritterStackScreenplayVersion)" />
+    </ItemGroup>
+
+    <ItemGroup>
         <PackageReference Include="Cratis.Arc.Screenplay" />
         <PackageReference Include="Cratis.CritterStack.Screenplay" />
         <PackageReference Include="Cratis.Screenplay.Generation.Contracts" />

--- a/Source/Cli/Commands/Screenplay/CritterStackScreenplayGeneration.cs
+++ b/Source/Cli/Commands/Screenplay/CritterStackScreenplayGeneration.cs
@@ -58,6 +58,16 @@ public sealed class CritterStackScreenplayGeneration : IScreenplayGeneration
                 Compilation = compilation
             })
             .ToArray();
+        var optionDiagnostics = options.ModulesFromNamespaceRoots
+            ?
+            [
+                new ScreenplayDiagnostic(
+                    ScreenplayDiagnosticSeverity.Warning,
+                    ScreenplayDiagnosticCodes.UnsupportedGenerationOption,
+                    "The Marten and Critter Stack providers do not support --modules-from-namespace-roots; the option was not applied",
+                    targetPath)
+            ]
+            : Array.Empty<ScreenplayDiagnostic>();
         var result = new CritterStackScreenplayGenerator().Generate(
             projects,
             new CritterStackScreenplayOptions
@@ -69,7 +79,7 @@ public sealed class CritterStackScreenplayGeneration : IScreenplayGeneration
 
         return new GeneratedScreenplay(
             result.Source,
-            [.. loaded.Diagnostics, .. result.Diagnostics.Select(Map)])
+            [.. loaded.Diagnostics, .. optionDiagnostics, .. result.Diagnostics.Select(Map)])
         {
             Projects = loaded.ProjectNames
         };

--- a/Source/Cli/Commands/Screenplay/GenerateScreenplayCommand.cs
+++ b/Source/Cli/Commands/Screenplay/GenerateScreenplayCommand.cs
@@ -63,7 +63,7 @@ public class GenerateScreenplayCommand : AsyncCommand<GenerateScreenplaySettings
         }
 
         var generated = await _generation.Generate(target.Path!, settings.ToGenerationOptions(), cancellationToken);
-        ScreenplayDiagnosticsWriter.Write(format, generated.Diagnostics);
+        ScreenplayDiagnosticsWriter.Write(format, generated.Diagnostics, generated.Provenance);
 
         var exitCode = ScreenplayDiagnostics.ExitCodeFor(generated.Diagnostics);
 
@@ -73,12 +73,16 @@ public class GenerateScreenplayCommand : AsyncCommand<GenerateScreenplaySettings
         {
             if (exitCode != ExitCodes.Success)
             {
-                WriteError(
-                    format,
-                    true,
-                    ErrorFor(generated),
-                    "Pass --file to write the document that was generated anyway, or resolve the reported errors",
-                    ExitCodes.ValidationErrorCode);
+                if (!ScreenplayDiagnosticsWriter.IsMachineReadable(format))
+                {
+                    WriteError(
+                        format,
+                        true,
+                        ErrorFor(generated),
+                        "Pass --file to write the document that was generated anyway, or resolve the reported errors",
+                        ExitCodes.ValidationErrorCode);
+                }
+
                 return exitCode;
             }
 
@@ -92,12 +96,16 @@ public class GenerateScreenplayCommand : AsyncCommand<GenerateScreenplaySettings
 
         if (exitCode != ExitCodes.Success)
         {
-            WriteError(
-                format,
-                false,
-                ErrorFor(generated),
-                $"The document was still written to {outputPath} — review it, then resolve the reported errors",
-                ExitCodes.ValidationErrorCode);
+            if (!ScreenplayDiagnosticsWriter.IsMachineReadable(format))
+            {
+                WriteError(
+                    format,
+                    false,
+                    ErrorFor(generated),
+                    $"The document was still written to {outputPath} — review it, then resolve the reported errors",
+                    ExitCodes.ValidationErrorCode);
+            }
+
             return exitCode;
         }
 

--- a/Source/Cli/Commands/Screenplay/GeneratedScreenplay.cs
+++ b/Source/Cli/Commands/Screenplay/GeneratedScreenplay.cs
@@ -20,6 +20,11 @@ public record GeneratedScreenplay(string Source, IReadOnlyList<ScreenplayDiagnos
     public IReadOnlyList<string> Projects { get; init; } = [];
 
     /// <summary>
+    /// Gets provider, target-framework, resolved-package, assembly-capability, and compatibility provenance.
+    /// </summary>
+    public ScreenplayGenerationProvenance? Provenance { get; init; }
+
+    /// <summary>
     /// Gets an outcome carrying no source and a single error diagnostic.
     /// </summary>
     /// <param name="code">The stable diagnostic code.</param>

--- a/Source/Cli/Commands/Screenplay/IScreenplaySourceProvider.cs
+++ b/Source/Cli/Commands/Screenplay/IScreenplaySourceProvider.cs
@@ -14,6 +14,11 @@ interface IScreenplaySourceProvider
     string Name { get; }
 
     /// <summary>
+    /// Gets the bundled provider package version, falling back to its assembly version when package metadata is unavailable.
+    /// </summary>
+    string Version { get; }
+
+    /// <summary>
     /// Gets provider names this more-specific provider replaces when both match.
     /// </summary>
     IReadOnlyList<string> Supersedes { get; }
@@ -29,6 +34,13 @@ interface IScreenplaySourceProvider
     /// <param name="loaded">The loaded source compilations.</param>
     /// <returns><see langword="true"/> when the provider matches.</returns>
     bool Matches(LoadedCompilation loaded);
+
+    /// <summary>
+    /// Selects the loaded projects this provider will actually interpret and report provenance for.
+    /// </summary>
+    /// <param name="loaded">The workspace-level loaded compilations.</param>
+    /// <returns>The provider-selected compilations.</returns>
+    LoadedCompilation SelectFrom(LoadedCompilation loaded);
 
     /// <summary>
     /// Generates the Screenplay from already loaded source.

--- a/Source/Cli/Commands/Screenplay/LoadedCompilation.cs
+++ b/Source/Cli/Commands/Screenplay/LoadedCompilation.cs
@@ -14,6 +14,11 @@ namespace Cratis.Cli.Commands.Screenplay;
 public record LoadedCompilation(IReadOnlyList<Compilation> Compilations, IReadOnlyList<string> ProjectNames, IReadOnlyList<ScreenplayDiagnostic> Diagnostics)
 {
     /// <summary>
+    /// Gets CLI-owned project, target-framework, package, assembly, and capability provenance in compilation order.
+    /// </summary>
+    public IReadOnlyList<ScreenplayProjectProvenance> ProjectProvenance { get; init; } = [];
+
+    /// <summary>
     /// Gets a failed outcome carrying a single error diagnostic.
     /// </summary>
     /// <param name="code">The stable diagnostic code.</param>

--- a/Source/Cli/Commands/Screenplay/ProjectRestoreState.cs
+++ b/Source/Cli/Commands/Screenplay/ProjectRestoreState.cs
@@ -35,8 +35,19 @@ public static class ProjectRestoreState
     public static bool IsRestored(string? projectFilePath, string? intermediateAssemblyPath)
     {
         var folders = FoldersHoldingTheAssetsFile(projectFilePath, intermediateAssemblyPath);
-        return folders.Count == 0 || folders.Exists(folder => File.Exists(Path.Combine(folder, AssetsFileName)));
+        return folders.Count == 0 || AssetsFileFor(projectFilePath, intermediateAssemblyPath) is not null;
     }
+
+    /// <summary>
+    /// Gets the NuGet assets file that applies to a project.
+    /// </summary>
+    /// <param name="projectFilePath">The full path of the project file.</param>
+    /// <param name="intermediateAssemblyPath">The full path of the assembly the project compiles into its intermediate output folder.</param>
+    /// <returns>The assets file path, or <see langword="null"/> when it cannot be found.</returns>
+    public static string? AssetsFileFor(string? projectFilePath, string? intermediateAssemblyPath) =>
+        FoldersHoldingTheAssetsFile(projectFilePath, intermediateAssemblyPath)
+            .Select(folder => Path.Combine(folder, AssetsFileName))
+            .FirstOrDefault(File.Exists);
 
     /// <summary>
     /// Builds the message reported for projects that have not been restored.
@@ -62,17 +73,16 @@ public static class ProjectRestoreState
     static List<string> FoldersHoldingTheAssetsFile(string? projectFilePath, string? intermediateAssemblyPath)
     {
         var folders = new List<string>();
-
-        if (FolderOf(projectFilePath) is { } project)
-        {
-            folders.Add(Path.Combine(project, DefaultIntermediateFolderName));
-        }
-
         var current = FolderOf(intermediateAssemblyPath);
         for (var level = 0; current is not null && level < LevelsAboveIntermediateAssembly; level++)
         {
             folders.Add(current);
             current = Path.GetDirectoryName(current);
+        }
+
+        if (FolderOf(projectFilePath) is { } project)
+        {
+            folders.Add(Path.Combine(project, DefaultIntermediateFolderName));
         }
 
         return folders;

--- a/Source/Cli/Commands/Screenplay/ProviderScreenplayGeneration.cs
+++ b/Source/Cli/Commands/Screenplay/ProviderScreenplayGeneration.cs
@@ -39,14 +39,46 @@ public sealed class ProviderScreenplayGeneration : IScreenplayGeneration
         }
 
         var loaded = await ScreenplayCompilationLoader.Load(targetPath, includeAllProjects: true, cancellationToken);
+        if (loaded.Compilations.Count == 0)
+        {
+            return new GeneratedScreenplay(string.Empty, loaded.Diagnostics)
+            {
+                Projects = loaded.ProjectNames,
+                Provenance = explicitProvider is null
+                    ? null
+                    : new ScreenplayGenerationProvenance(explicitProvider.Name, explicitProvider.Version, loaded.ProjectProvenance, null)
+            };
+        }
+
         var selection = explicitProvider is null ? Discover(loaded, targetPath) : new ProviderSelection(explicitProvider, null);
         if (selection.Error is not null)
         {
-            return selection.Error;
+            return selection.Error with
+            {
+                Diagnostics = [.. loaded.Diagnostics, .. selection.Error.Diagnostics],
+                Projects = loaded.ProjectNames
+            };
         }
 
         var provider = selection.Provider!;
-        return AmbiguousHosts(loaded, targetPath, provider) ?? provider.GenerateFrom(loaded, targetPath, options);
+        var selected = provider.SelectFrom(loaded);
+        var compatibility = ScreenplayCompatibility.Evaluate(provider, selected);
+        if (compatibility.BlockingDiagnostic is not null)
+        {
+            return new GeneratedScreenplay(
+                string.Empty,
+                [.. loaded.Diagnostics, compatibility.BlockingDiagnostic])
+            {
+                Projects = selected.ProjectNames,
+                Provenance = compatibility.Provenance
+            };
+        }
+
+        var generated = AmbiguousHosts(selected, targetPath, provider) ?? provider.GenerateFrom(selected, targetPath, options);
+        return generated with
+        {
+            Provenance = compatibility.Complete(generated.Diagnostics)
+        };
     }
 
     internal ProviderSelection Discover(LoadedCompilation loaded, string targetPath)

--- a/Source/Cli/Commands/Screenplay/ScreenplayCompatibility.cs
+++ b/Source/Cli/Commands/Screenplay/ScreenplayCompatibility.cs
@@ -1,0 +1,304 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Cli.Commands.Screenplay;
+
+/// <summary>
+/// Assesses source-framework package evidence without conflating it with source recognition or Screenplay lowering.
+/// </summary>
+static class ScreenplayCompatibility
+{
+    static readonly HashSet<(string Marten, string Wolverine)> _canonicalCritterStack =
+    [
+        ("6.3.0", "1.11.1"),
+        ("9.20.0", "6.23.1"),
+        ("9.20.1", "6.23.1"),
+        ("9.23.0", "6.29.1")
+    ];
+
+    static readonly HashSet<string> _canonicalMarten = new(StringComparer.Ordinal)
+    {
+        "9.20.1"
+    };
+
+    /// <summary>
+    /// Creates provider and compatibility provenance before source interpretation starts.
+    /// </summary>
+    /// <param name="provider">The selected provider.</param>
+    /// <param name="loaded">The selected project compilations and workspace provenance.</param>
+    /// <returns>The compatibility evaluation.</returns>
+    public static ScreenplayCompatibilityEvaluation Evaluate(IScreenplaySourceProvider provider, LoadedCompilation loaded)
+    {
+        if (provider.Name == ScreenplayProviders.Arc)
+        {
+            return new ScreenplayCompatibilityEvaluation(
+                new ScreenplayGenerationProvenance(provider.Name, provider.Version, loaded.ProjectProvenance, null),
+                null);
+        }
+
+        var packages = loaded.ProjectProvenance.SelectMany(project => project.Packages).ToArray();
+        var marten = VersionsOf(packages, "Marten");
+        var wolverine = VersionsOf(packages, "WolverineFx");
+        var wolverineMarten = VersionsOf(packages, "WolverineFx.Marten");
+        var unknown = UnknownReason(provider.Name, marten, wolverine, wolverineMarten);
+        if (unknown is not null)
+        {
+            return Blocked(
+                provider,
+                loaded,
+                ScreenplaySupportTier.Unknown,
+                ScreenplayRecognitionStatus.Unknown,
+                ScreenplayDiagnosticCodes.UnknownFrameworkVersion,
+                unknown);
+        }
+
+        var wolverineVersion = wolverine.Length == 0 ? null : wolverine[0];
+        var unsupported = NewerMajorReason(provider.Name, marten[0], wolverineVersion);
+        if (unsupported is not null)
+        {
+            return Blocked(
+                provider,
+                loaded,
+                ScreenplaySupportTier.Unsupported,
+                ScreenplayRecognitionStatus.Unsupported,
+                ScreenplayDiagnosticCodes.UnsupportedFrameworkVersion,
+                unsupported);
+        }
+
+        var unreviewed = UnreviewedMajorReason(provider.Name, marten[0], wolverineVersion);
+        if (unreviewed is not null)
+        {
+            return Blocked(
+                provider,
+                loaded,
+                ScreenplaySupportTier.Unknown,
+                ScreenplayRecognitionStatus.Unknown,
+                ScreenplayDiagnosticCodes.UnknownFrameworkVersion,
+                unreviewed);
+        }
+
+        var packageSetIsCanonical = IsCanonicalPackageSet(provider.Name, marten[0], wolverineVersion, wolverineMarten);
+        var providerCarriesCanonicalBaseline = ProviderCarriesCanonicalBaseline(provider.Version);
+        var tier = packageSetIsCanonical && providerCarriesCanonicalBaseline
+            ? ScreenplaySupportTier.Canonical
+            : ScreenplaySupportTier.SourceReviewed;
+        var packageSet = provider.Name == ScreenplayProviders.Marten
+            ? $"Marten {marten[0]}"
+            : $"Marten {marten[0]} with WolverineFx {wolverine[0]}";
+        var explanation = ExplanationFor(tier, packageSetIsCanonical, packageSet, provider.Version);
+        var report = new ScreenplayCompatibilityReport(
+            tier,
+            ScreenplayRecognitionStatus.Recognized,
+            ScreenplaySemanticConformance.RequiresHumanReview,
+            ScreenplayLoweringFidelity.NotEvaluated,
+            explanation);
+
+        return new ScreenplayCompatibilityEvaluation(
+            new ScreenplayGenerationProvenance(provider.Name, provider.Version, loaded.ProjectProvenance, report),
+            null);
+    }
+
+    static ScreenplayCompatibilityEvaluation Blocked(
+        IScreenplaySourceProvider provider,
+        LoadedCompilation loaded,
+        ScreenplaySupportTier tier,
+        ScreenplayRecognitionStatus recognition,
+        string code,
+        string explanation)
+    {
+        var report = new ScreenplayCompatibilityReport(
+            tier,
+            recognition,
+            recognition == ScreenplayRecognitionStatus.Unsupported
+                ? ScreenplaySemanticConformance.Unsupported
+                : ScreenplaySemanticConformance.NotEvaluated,
+            ScreenplayLoweringFidelity.NotEvaluated,
+            explanation);
+        var diagnostic = new ScreenplayDiagnostic(
+            ScreenplayDiagnosticSeverity.Error,
+            code,
+            $"{explanation}. Generation stopped before source semantics were interpreted",
+            null);
+        return new ScreenplayCompatibilityEvaluation(
+            new ScreenplayGenerationProvenance(provider.Name, provider.Version, loaded.ProjectProvenance, report),
+            diagnostic);
+    }
+
+    static string[] VersionsOf(IEnumerable<ResolvedScreenplayPackage> packages, string packageId) =>
+    [
+        .. packages
+            .Where(package => string.Equals(package.Id, packageId, StringComparison.OrdinalIgnoreCase))
+            .Select(package => package.Version)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .Order(StringComparer.Ordinal)
+    ];
+
+    static string? UnknownReason(
+        string provider,
+        string[] marten,
+        string[] wolverine,
+        string[] wolverineMarten)
+    {
+        if (marten.Length == 0)
+        {
+            return "Marten was recognized in assembly metadata, but its resolved NuGet package version was not found for the selected target framework";
+        }
+
+        if (marten.Length > 1)
+        {
+            return $"Projects resolve divergent Marten versions: {string.Join(", ", marten)}";
+        }
+
+        if (MajorOf(marten[0]) is null)
+        {
+            return $"Marten version '{marten[0]}' cannot be classified";
+        }
+
+        if (provider != ScreenplayProviders.CritterStack)
+        {
+            return null;
+        }
+
+        if (wolverine.Length == 0)
+        {
+            return "Wolverine was recognized in assembly metadata, but its resolved WolverineFx package version was not found for the selected target framework";
+        }
+
+        if (wolverine.Length > 1)
+        {
+            return $"Projects resolve divergent WolverineFx versions: {string.Join(", ", wolverine)}";
+        }
+
+        if (MajorOf(wolverine[0]) is null)
+        {
+            return $"WolverineFx version '{wolverine[0]}' cannot be classified";
+        }
+
+        if (wolverineMarten.Length > 1)
+        {
+            return $"Projects resolve divergent WolverineFx.Marten versions: {string.Join(", ", wolverineMarten)}";
+        }
+
+        if (wolverineMarten.Length == 1 && !string.Equals(wolverineMarten[0], wolverine[0], StringComparison.OrdinalIgnoreCase))
+        {
+            return $"WolverineFx.Marten {wolverineMarten[0]} does not match WolverineFx {wolverine[0]}";
+        }
+
+        return wolverineMarten.Length == 1 && MajorOf(wolverineMarten[0]) is null
+            ? $"WolverineFx.Marten version '{wolverineMarten[0]}' cannot be classified"
+            : null;
+    }
+
+    static string? NewerMajorReason(string provider, string marten, string? wolverine)
+    {
+        if (MajorOf(marten)!.Value > 9)
+        {
+            return $"Marten {marten} is newer than the highest source-reviewed major (9)";
+        }
+
+        return provider == ScreenplayProviders.CritterStack && MajorOf(wolverine!)!.Value > 6
+            ? $"WolverineFx {wolverine} is newer than the highest source-reviewed major (6)"
+            : null;
+    }
+
+    static string? UnreviewedMajorReason(string provider, string marten, string? wolverine)
+    {
+        if (MajorOf(marten)!.Value is not 6 and not 9)
+        {
+            return $"Marten {marten} has no canonical or source-reviewed major-generation evidence";
+        }
+
+        return provider == ScreenplayProviders.CritterStack && MajorOf(wolverine!)!.Value is not 1 and not 6
+            ? $"WolverineFx {wolverine} has no canonical or source-reviewed major-generation evidence"
+            : null;
+    }
+
+    static string ExplanationFor(
+        ScreenplaySupportTier tier,
+        bool packageSetIsCanonical,
+        string packageSet,
+        string providerVersion)
+    {
+        if (tier == ScreenplaySupportTier.Canonical)
+        {
+            return $"{packageSet} matches a pinned canonical package set for bundled provider {providerVersion}; only fixture-asserted behaviors are canonical";
+        }
+
+        return packageSetIsCanonical
+            ? $"{packageSet} is canonical for Critter Stack provider 0.3.0 or newer, but bundled provider {providerVersion} predates that complete baseline"
+            : $"{packageSet} is within source-reviewed major generations but is not an exact canonical package set";
+    }
+
+    static bool IsCanonicalPackageSet(string provider, string marten, string? wolverine, string[] wolverineMarten) =>
+        provider == ScreenplayProviders.Marten
+            ? _canonicalMarten.Contains(marten)
+            : _canonicalCritterStack.Contains((marten, wolverine!)) &&
+              wolverineMarten.Length == 1 &&
+              string.Equals(wolverineMarten[0], wolverine, StringComparison.OrdinalIgnoreCase);
+
+    static bool ProviderCarriesCanonicalBaseline(string providerVersion) =>
+        System.Version.TryParse(providerVersion, out var parsed) && parsed >= new System.Version(0, 3, 0);
+
+    static int? MajorOf(string version)
+    {
+        var separator = version.IndexOfAny(['-', '+']);
+        if (separator == version.Length - 1)
+        {
+            return null;
+        }
+
+        var core = separator < 0 ? version : version[..separator];
+        return System.Version.TryParse(core, out var parsed) ? parsed.Major : null;
+    }
+}
+
+/// <summary>
+/// Represents compatibility admission before generation and finalizes lowering evidence afterwards.
+/// </summary>
+/// <param name="Provenance">The pre-generation provenance report.</param>
+/// <param name="BlockingDiagnostic">The diagnostic that prevents generation, when compatibility is not admitted.</param>
+sealed record ScreenplayCompatibilityEvaluation(
+    ScreenplayGenerationProvenance Provenance,
+    ScreenplayDiagnostic? BlockingDiagnostic)
+{
+    /// <summary>
+    /// Finalizes semantic and lowering dimensions from generation diagnostics.
+    /// </summary>
+    /// <param name="diagnostics">Everything reported while interpreting and lowering source.</param>
+    /// <returns>The finalized provenance.</returns>
+    public ScreenplayGenerationProvenance Complete(IReadOnlyList<ScreenplayDiagnostic> diagnostics)
+    {
+        if (Provenance.Compatibility is not { } compatibility)
+        {
+            return Provenance;
+        }
+
+        var failed = diagnostics.Any(diagnostic => diagnostic.Severity == ScreenplayDiagnosticSeverity.Error);
+        var lossReported = diagnostics.Any(diagnostic =>
+            diagnostic.Code.StartsWith("GEN", StringComparison.Ordinal) ||
+            diagnostic.Code.StartsWith("MARTEN", StringComparison.Ordinal) ||
+            diagnostic.Code.StartsWith("WOLVERINE", StringComparison.Ordinal) ||
+            diagnostic.Code.StartsWith("CRITTER", StringComparison.Ordinal) ||
+            diagnostic.Code == ScreenplayDiagnosticCodes.UnsupportedGenerationOption);
+        return Provenance with
+        {
+            Compatibility = compatibility with
+            {
+                SemanticConformance = failed
+                    ? ScreenplaySemanticConformance.Contradictory
+                    : ScreenplaySemanticConformance.RequiresHumanReview,
+                LoweringFidelity = LoweringFidelityFor(failed, lossReported)
+            }
+        };
+    }
+
+    static ScreenplayLoweringFidelity LoweringFidelityFor(bool failed, bool lossReported)
+    {
+        if (failed)
+        {
+            return ScreenplayLoweringFidelity.Failed;
+        }
+
+        return lossReported ? ScreenplayLoweringFidelity.LossReported : ScreenplayLoweringFidelity.NoReportedLoss;
+    }
+}

--- a/Source/Cli/Commands/Screenplay/ScreenplayCompilationLoader.cs
+++ b/Source/Cli/Commands/Screenplay/ScreenplayCompilationLoader.cs
@@ -159,6 +159,7 @@ public static class ScreenplayCompilationLoader
     {
         var compilations = new List<Compilation>();
         var names = new List<string>();
+        var projectProvenance = new List<ScreenplayProjectProvenance>();
 
         // A project that yields no compilation is left out of the document rather than ending the run, so that a
         // solution still describes the projects that did load - and is reported as an error, because a document
@@ -187,8 +188,16 @@ public static class ScreenplayCompilationLoader
                 continue;
             }
 
+            var targetFramework = ScreenplayFrameworkReferences.TargetFrameworkOf(project);
+            var assetsFile = ProjectRestoreState.AssetsFileFor(project.FilePath, project.CompilationOutputInfo.AssemblyPath);
             compilations.Add(compilation);
             names.Add(name);
+            projectProvenance.Add(new ScreenplayProjectProvenance(
+                name,
+                targetFramework,
+                ScreenplayPackageProvenance.PackagesFrom(assetsFile, targetFramework),
+                ScreenplayPackageProvenance.AssembliesFrom(compilation),
+                ScreenplayFrameworkCapabilities.From(compilation)));
         }
 
         if (compilations.Count == 0)
@@ -206,6 +215,9 @@ public static class ScreenplayCompilationLoader
                     failures);
         }
 
-        return new LoadedCompilation(compilations, names, [.. failures, .. unloadable]);
+        return new LoadedCompilation(compilations, names, [.. failures, .. unloadable])
+        {
+            ProjectProvenance = projectProvenance
+        };
     }
 }

--- a/Source/Cli/Commands/Screenplay/ScreenplayDiagnosticCodes.cs
+++ b/Source/Cli/Commands/Screenplay/ScreenplayDiagnosticCodes.cs
@@ -65,4 +65,19 @@ public static class ScreenplayDiagnosticCodes
     /// More than one unrelated source provider recognizes the loaded application.
     /// </summary>
     public const string AmbiguousProviders = "CLI0011";
+
+    /// <summary>
+    /// Resolved package provenance is insufficient to classify the recognized framework generation safely.
+    /// </summary>
+    public const string UnknownFrameworkVersion = "CLI0012";
+
+    /// <summary>
+    /// A resolved framework major generation is newer than or outside the source-reviewed compatibility baseline.
+    /// </summary>
+    public const string UnsupportedFrameworkVersion = "CLI0013";
+
+    /// <summary>
+    /// A provider does not support a requested generation option and therefore leaves it unapplied.
+    /// </summary>
+    public const string UnsupportedGenerationOption = "CLI0014";
 }

--- a/Source/Cli/Commands/Screenplay/ScreenplayDiagnosticsWriter.cs
+++ b/Source/Cli/Commands/Screenplay/ScreenplayDiagnosticsWriter.cs
@@ -17,21 +17,34 @@ public static class ScreenplayDiagnosticsWriter
     /// </summary>
     /// <param name="format">The resolved output format.</param>
     /// <param name="diagnostics">The diagnostics to write.</param>
-    public static void Write(string format, IEnumerable<ScreenplayDiagnostic> diagnostics)
+    public static void Write(string format, IEnumerable<ScreenplayDiagnostic> diagnostics) =>
+        Write(format, diagnostics, null);
+
+    /// <summary>
+    /// Writes source provenance and diagnostics to standard error in the given output format.
+    /// </summary>
+    /// <param name="format">The resolved output format.</param>
+    /// <param name="diagnostics">The diagnostics to write.</param>
+    /// <param name="provenance">Optional source-provider and compatibility provenance.</param>
+    public static void Write(
+        string format,
+        IEnumerable<ScreenplayDiagnostic> diagnostics,
+        ScreenplayGenerationProvenance? provenance)
     {
-        var groups = ScreenplayDiagnostics.GroupBySeverity(diagnostics);
-        if (groups.Count == 0)
+        var materialized = diagnostics.ToArray();
+        var groups = ScreenplayDiagnostics.GroupBySeverity(materialized);
+        if (groups.Count == 0 && provenance is null)
         {
             return;
         }
 
         if (IsMachineReadable(format))
         {
-            WriteJson(format, groups);
+            Console.Error.WriteLine(JsonFor(format, materialized, provenance));
             return;
         }
 
-        WriteText(groups);
+        WriteText(groups, provenance);
     }
 
     /// <summary>
@@ -74,13 +87,17 @@ public static class ScreenplayDiagnosticsWriter
         return $"  {LabelFor(diagnostic.Severity)}{code}:{location} {diagnostic.Message}";
     }
 
-    static bool IsMachineReadable(string format) =>
-        string.Equals(format, OutputFormats.Json, StringComparison.Ordinal) ||
-        string.Equals(format, OutputFormats.JsonCompact, StringComparison.Ordinal) ||
-        string.Equals(format, OutputFormats.JsonQuiet, StringComparison.Ordinal) ||
-        string.Equals(format, OutputFormats.Quiet, StringComparison.Ordinal);
-
-    static void WriteJson(string format, IEnumerable<IGrouping<ScreenplayDiagnosticSeverity, ScreenplayDiagnostic>> groups)
+    /// <summary>
+    /// Serializes provenance and diagnostics for a machine-readable output format.
+    /// </summary>
+    /// <param name="format">The resolved output format.</param>
+    /// <param name="diagnostics">The diagnostics to serialize.</param>
+    /// <param name="provenance">Optional source-provider and compatibility provenance.</param>
+    /// <returns>The JSON payload.</returns>
+    internal static string JsonFor(
+        string format,
+        IEnumerable<ScreenplayDiagnostic> diagnostics,
+        ScreenplayGenerationProvenance? provenance)
     {
         var options = string.Equals(format, OutputFormats.Json, StringComparison.Ordinal)
             ? OutputFormatter.IndentedJsonSerializerOptions
@@ -88,20 +105,59 @@ public static class ScreenplayDiagnosticsWriter
 
         var payload = new
         {
-            Diagnostics = groups.SelectMany(group => group.Select(diagnostic => new
-            {
-                Severity = LabelFor(diagnostic.Severity),
-                diagnostic.Code,
-                diagnostic.Message,
-                diagnostic.Location
-            }))
+            Provenance = provenance is null
+                ? null
+                : new
+                {
+                    provenance.Provider,
+                    provenance.ProviderVersion,
+                    Projects = provenance.Projects.Select(project => new
+                    {
+                        project.Project,
+                        project.TargetFramework,
+                        project.Packages,
+                        project.Assemblies,
+                        project.Capabilities
+                    }),
+                    Compatibility = provenance.Compatibility is null
+                        ? null
+                        : new
+                        {
+                            SupportTier = provenance.Compatibility.SupportTier.ToString(),
+                            RecognitionStatus = provenance.Compatibility.RecognitionStatus.ToString(),
+                            SemanticConformance = provenance.Compatibility.SemanticConformance.ToString(),
+                            LoweringFidelity = provenance.Compatibility.LoweringFidelity.ToString(),
+                            provenance.Compatibility.Explanation
+                        }
+                },
+            Diagnostics = ScreenplayDiagnostics.GroupBySeverity(diagnostics)
+                .SelectMany(group => group.Select(diagnostic => new
+                {
+                    Severity = LabelFor(diagnostic.Severity),
+                    diagnostic.Code,
+                    diagnostic.Message,
+                    diagnostic.Location
+                }))
         };
 
-        Console.Error.WriteLine(JsonSerializer.Serialize(payload, options));
+        return JsonSerializer.Serialize(payload, options);
     }
 
-    static void WriteText(IEnumerable<IGrouping<ScreenplayDiagnosticSeverity, ScreenplayDiagnostic>> groups)
+    internal static bool IsMachineReadable(string format) =>
+        string.Equals(format, OutputFormats.Json, StringComparison.Ordinal) ||
+        string.Equals(format, OutputFormats.JsonCompact, StringComparison.Ordinal) ||
+        string.Equals(format, OutputFormats.JsonQuiet, StringComparison.Ordinal) ||
+        string.Equals(format, OutputFormats.Quiet, StringComparison.Ordinal);
+
+    static void WriteText(
+        IEnumerable<IGrouping<ScreenplayDiagnosticSeverity, ScreenplayDiagnostic>> groups,
+        ScreenplayGenerationProvenance? provenance)
     {
+        if (provenance is not null)
+        {
+            WriteProvenance(provenance);
+        }
+
         foreach (var group in groups)
         {
             Console.Error.WriteLine();
@@ -112,5 +168,34 @@ public static class ScreenplayDiagnosticsWriter
                 Console.Error.WriteLine(LineFor(diagnostic));
             }
         }
+    }
+
+    static void WriteProvenance(ScreenplayGenerationProvenance provenance)
+    {
+        Console.Error.WriteLine();
+        Console.Error.WriteLine("source compatibility:");
+        Console.Error.WriteLine($"  provider: {provenance.Provider} {provenance.ProviderVersion}");
+        foreach (var project in provenance.Projects)
+        {
+            Console.Error.WriteLine($"  project: {project.Project} ({project.TargetFramework ?? "unknown target framework"})");
+            Console.Error.WriteLine($"    packages: {Describe(project.Packages.Select(package => $"{package.Id} {package.Version}"))}");
+            Console.Error.WriteLine($"    assemblies: {Describe(project.Assemblies.Select(assembly => $"{assembly.Name} {assembly.Version}"))}");
+            Console.Error.WriteLine($"    capabilities: {Describe(project.Capabilities)}");
+        }
+
+        if (provenance.Compatibility is { } compatibility)
+        {
+            Console.Error.WriteLine($"  support tier: {compatibility.SupportTier}");
+            Console.Error.WriteLine($"  recognition: {compatibility.RecognitionStatus}");
+            Console.Error.WriteLine($"  semantic conformance: {compatibility.SemanticConformance}");
+            Console.Error.WriteLine($"  lowering fidelity: {compatibility.LoweringFidelity}");
+            Console.Error.WriteLine($"  evidence: {compatibility.Explanation}");
+        }
+    }
+
+    static string Describe(IEnumerable<string> values)
+    {
+        var materialized = values.ToArray();
+        return materialized.Length == 0 ? "none resolved" : string.Join(", ", materialized);
     }
 }

--- a/Source/Cli/Commands/Screenplay/ScreenplayFrameworkCapabilities.cs
+++ b/Source/Cli/Commands/Screenplay/ScreenplayFrameworkCapabilities.cs
@@ -1,0 +1,44 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.CodeAnalysis;
+
+namespace Cratis.Cli.Commands.Screenplay;
+
+/// <summary>
+/// Fingerprints source-framework API generations through exact metadata names.
+/// </summary>
+static class ScreenplayFrameworkCapabilities
+{
+    static readonly (string Capability, string[] MetadataNames)[] _known =
+    [
+        ("marten.compiled-query", ["Marten.Linq.ICompiledQuery`2", "Marten.Linq.ICompiledQuery`1"]),
+        ("marten.event-projection", ["Marten.Events.Projections.EventProjection"]),
+        ("marten.multi-stream-projection", ["Marten.Events.Projections.MultiStreamProjection`2"]),
+        ("marten.projection-lifecycle.jasperfx", ["JasperFx.Events.Projections.ProjectionLifecycle"]),
+        ("marten.projection-lifecycle.legacy", ["Marten.Events.Projections.ProjectionLifecycle"]),
+        ("marten.single-stream-projection.one-identity", ["Marten.Events.Aggregation.SingleStreamProjection`1", "Marten.Events.Projections.SingleStreamProjection`1"]),
+        ("marten.single-stream-projection.two-identities", ["Marten.Events.Aggregation.SingleStreamProjection`2", "Marten.Events.Projections.SingleStreamProjection`2"]),
+        ("marten.subscription", ["Marten.Subscriptions.ISubscription", "Marten.Subscriptions.SubscriptionBase"]),
+        ("wolverine.dcb-model", ["Wolverine.Persistence.EventSourcing.DcbModelAttribute"]),
+        ("wolverine.events-to-append", ["Wolverine.Persistence.EventSourcing.EventsToAppend"]),
+        ("wolverine.handler-attribute", ["Wolverine.Attributes.WolverineHandlerAttribute"]),
+        ("wolverine.legacy-marten-aggregate", ["Wolverine.Marten.AggregateHandlerAttribute", "Wolverine.Marten.WriteAggregateAttribute"]),
+        ("wolverine.side-effect", ["Wolverine.ISideEffect"]),
+        ("wolverine.store-agnostic-decider", ["Wolverine.Persistence.EventSourcing.DeciderFunctionAttribute"]),
+        ("wolverine.store-agnostic-write-model", ["Wolverine.Persistence.EventSourcing.WriteModelAttribute"])
+    ];
+
+    /// <summary>
+    /// Gets every recognized capability present in the compilation.
+    /// </summary>
+    /// <param name="compilation">The selected project compilation.</param>
+    /// <returns>The stable capability names in deterministic order.</returns>
+    public static IReadOnlyList<string> From(Compilation compilation) =>
+    [
+        .. _known
+            .Where(capability => capability.MetadataNames.Any(metadataName => compilation.GetTypeByMetadataName(metadataName) is not null))
+            .Select(capability => capability.Capability)
+            .Order(StringComparer.Ordinal)
+    ];
+}

--- a/Source/Cli/Commands/Screenplay/ScreenplayFrameworkReferences.cs
+++ b/Source/Cli/Commands/Screenplay/ScreenplayFrameworkReferences.cs
@@ -50,7 +50,12 @@ static class ScreenplayFrameworkReferences
         return references.Length == 0 ? compilation : compilation.AddReferences(references);
     }
 
-    static string? TargetFrameworkOf(Project project)
+    /// <summary>
+    /// Gets the target framework selected for an MSBuild project instance.
+    /// </summary>
+    /// <param name="project">The selected project.</param>
+    /// <returns>The target-framework moniker when it can be resolved.</returns>
+    internal static string? TargetFrameworkOf(Project project)
     {
         var assemblyPath = project.CompilationOutputInfo.AssemblyPath;
         if (!string.IsNullOrWhiteSpace(assemblyPath))

--- a/Source/Cli/Commands/Screenplay/ScreenplayGenerationProvenance.cs
+++ b/Source/Cli/Commands/Screenplay/ScreenplayGenerationProvenance.cs
@@ -1,0 +1,165 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Cli.Commands.Screenplay;
+
+/// <summary>
+/// Represents the evidence tier assigned to a source framework package set.
+/// </summary>
+public enum ScreenplaySupportTier
+{
+    /// <summary>
+    /// The exact package set and its asserted behaviors pass a pinned canonical fixture.
+    /// </summary>
+    Canonical,
+
+    /// <summary>
+    /// The framework source and metadata names have been reviewed, but this exact package set is not canonical.
+    /// </summary>
+    SourceReviewed,
+
+    /// <summary>
+    /// The APIs are recognized but part of their source semantics cannot be interpreted exactly.
+    /// </summary>
+    RecognizedWithLoss,
+
+    /// <summary>
+    /// The package or API generation is outside available evidence.
+    /// </summary>
+    Unknown,
+
+    /// <summary>
+    /// The adapter deliberately excludes the package or API generation.
+    /// </summary>
+    Unsupported
+}
+
+/// <summary>
+/// Represents whether the selected provider recognized the source framework evidence.
+/// </summary>
+public enum ScreenplayRecognitionStatus
+{
+    /// <summary>
+    /// The provider recognized the required source framework evidence.
+    /// </summary>
+    Recognized,
+
+    /// <summary>
+    /// The available evidence is insufficient to recognize the framework generation safely.
+    /// </summary>
+    Unknown,
+
+    /// <summary>
+    /// The recognized framework generation is deliberately unsupported.
+    /// </summary>
+    Unsupported
+}
+
+/// <summary>
+/// Represents what static generation establishes about application semantics.
+/// </summary>
+public enum ScreenplaySemanticConformance
+{
+    /// <summary>
+    /// Semantic conformance was not evaluated because compatibility admission stopped generation.
+    /// </summary>
+    NotEvaluated,
+
+    /// <summary>
+    /// Static interpretation completed, but human review is still required before downstream use.
+    /// </summary>
+    RequiresHumanReview,
+
+    /// <summary>
+    /// Generation found contradictory or invalid source evidence.
+    /// </summary>
+    Contradictory,
+
+    /// <summary>
+    /// Semantic conformance was not evaluated because the framework generation is unsupported.
+    /// </summary>
+    Unsupported
+}
+
+/// <summary>
+/// Represents what the generated Screenplay preserved after source interpretation.
+/// </summary>
+public enum ScreenplayLoweringFidelity
+{
+    /// <summary>
+    /// Lowering was not evaluated because compatibility admission stopped generation.
+    /// </summary>
+    NotEvaluated,
+
+    /// <summary>
+    /// No lowering loss was reported; this is not a claim of runtime equivalence.
+    /// </summary>
+    NoReportedLoss,
+
+    /// <summary>
+    /// One or more diagnostics report omitted or approximated behavior.
+    /// </summary>
+    LossReported,
+
+    /// <summary>
+    /// Generation failed before a trustworthy Screenplay could be produced.
+    /// </summary>
+    Failed
+}
+
+/// <summary>
+/// Represents the resolved NuGet identity of a source framework package.
+/// </summary>
+/// <param name="Id">The package identifier.</param>
+/// <param name="Version">The resolved package version.</param>
+public record ResolvedScreenplayPackage(string Id, string Version);
+
+/// <summary>
+/// Represents a framework assembly that corroborates resolved package provenance.
+/// </summary>
+/// <param name="Name">The assembly name.</param>
+/// <param name="Version">The assembly version.</param>
+public record ScreenplayAssemblyIdentity(string Name, string Version);
+
+/// <summary>
+/// Represents source-framework provenance for one selected project and target framework.
+/// </summary>
+/// <param name="Project">The project name.</param>
+/// <param name="TargetFramework">The target framework selected by the workspace.</param>
+/// <param name="Packages">The resolved source-framework packages for the selected target.</param>
+/// <param name="Assemblies">The referenced framework assemblies that corroborate the packages.</param>
+/// <param name="Capabilities">The recognized assembly capability fingerprints.</param>
+public record ScreenplayProjectProvenance(
+    string Project,
+    string? TargetFramework,
+    IReadOnlyList<ResolvedScreenplayPackage> Packages,
+    IReadOnlyList<ScreenplayAssemblyIdentity> Assemblies,
+    IReadOnlyList<string> Capabilities);
+
+/// <summary>
+/// Represents compatibility evidence separately from recognition, semantic review, and lowering fidelity.
+/// </summary>
+/// <param name="SupportTier">The package-set evidence tier.</param>
+/// <param name="RecognitionStatus">Whether the provider recognized the framework generation.</param>
+/// <param name="SemanticConformance">What static interpretation established about application semantics.</param>
+/// <param name="LoweringFidelity">What Screenplay lowering reported.</param>
+/// <param name="Explanation">Why the tier and statuses were assigned.</param>
+public record ScreenplayCompatibilityReport(
+    ScreenplaySupportTier SupportTier,
+    ScreenplayRecognitionStatus RecognitionStatus,
+    ScreenplaySemanticConformance SemanticConformance,
+    ScreenplayLoweringFidelity LoweringFidelity,
+    string Explanation);
+
+/// <summary>
+/// Represents the complete CLI-owned provenance of one source-to-Screenplay generation.
+/// </summary>
+/// <param name="Provider">The selected source provider.</param>
+/// <param name="ProviderVersion">The bundled provider package version, or its assembly version when package metadata is unavailable.</param>
+/// <param name="Projects">The selected project, target-framework, package, assembly, and capability evidence.</param>
+/// <param name="Compatibility">The compatibility assessment when the provider publishes one.</param>
+public record ScreenplayGenerationProvenance(
+    string Provider,
+    string ProviderVersion,
+    IReadOnlyList<ScreenplayProjectProvenance> Projects,
+    ScreenplayCompatibilityReport? Compatibility);

--- a/Source/Cli/Commands/Screenplay/ScreenplayPackageProvenance.cs
+++ b/Source/Cli/Commands/Screenplay/ScreenplayPackageProvenance.cs
@@ -1,0 +1,119 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.CodeAnalysis;
+
+namespace Cratis.Cli.Commands.Screenplay;
+
+/// <summary>
+/// Reads source-framework package and assembly provenance without loading framework runtime assemblies.
+/// </summary>
+static class ScreenplayPackageProvenance
+{
+    static readonly HashSet<string> _frameworkAssemblies = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "JasperFx.Events",
+        "Marten",
+        "Wolverine",
+        "Wolverine.Marten"
+    };
+
+    /// <summary>
+    /// Reads the resolved source-framework packages for one selected target from a NuGet assets file.
+    /// </summary>
+    /// <param name="assetsFile">The assets file written by restore.</param>
+    /// <param name="targetFramework">The target framework selected by the workspace.</param>
+    /// <returns>The relevant resolved packages in deterministic order.</returns>
+    public static IReadOnlyList<ResolvedScreenplayPackage> PackagesFrom(string? assetsFile, string? targetFramework)
+    {
+        if (string.IsNullOrWhiteSpace(assetsFile) || !File.Exists(assetsFile))
+        {
+            return [];
+        }
+
+        try
+        {
+            using var document = JsonDocument.Parse(File.ReadAllBytes(assetsFile));
+            if (!document.RootElement.TryGetProperty("targets", out var targets) ||
+                targets.ValueKind != JsonValueKind.Object ||
+                TargetOf(targets, targetFramework) is not { } target)
+            {
+                return [];
+            }
+
+            return
+            [
+                .. target.Value.EnumerateObject()
+                    .Where(entry => IsFrameworkPackage(entry.Name) && IsPackage(entry.Value))
+                    .Select(entry => PackageFrom(entry.Name))
+                    .Where(package => package is not null)
+                    .Cast<ResolvedScreenplayPackage>()
+                    .OrderBy(package => package.Id, StringComparer.Ordinal)
+                    .ThenBy(package => package.Version, StringComparer.Ordinal)
+            ];
+        }
+        catch (JsonException)
+        {
+            return [];
+        }
+        catch (IOException)
+        {
+            return [];
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return [];
+        }
+    }
+
+    /// <summary>
+    /// Gets framework assembly identities referenced by a compilation.
+    /// </summary>
+    /// <param name="compilation">The selected project compilation.</param>
+    /// <returns>The relevant identities in deterministic order.</returns>
+    public static IReadOnlyList<ScreenplayAssemblyIdentity> AssembliesFrom(Compilation compilation) =>
+    [
+        .. compilation.ReferencedAssemblyNames
+            .Where(identity => _frameworkAssemblies.Contains(identity.Name))
+            .Select(identity => new ScreenplayAssemblyIdentity(identity.Name, identity.Version.ToString()))
+            .OrderBy(identity => identity.Name, StringComparer.Ordinal)
+            .ThenBy(identity => identity.Version, StringComparer.Ordinal)
+    ];
+
+    static JsonProperty? TargetOf(JsonElement targets, string? targetFramework)
+    {
+        if (string.IsNullOrWhiteSpace(targetFramework))
+        {
+            return null;
+        }
+
+        var available = targets.EnumerateObject().OrderBy(target => target.Name, StringComparer.Ordinal).ToArray();
+        var selected = available
+            .Where(target => target.Value.ValueKind == JsonValueKind.Object && string.Equals(target.Name, targetFramework, StringComparison.OrdinalIgnoreCase))
+            .Cast<JsonProperty?>()
+            .FirstOrDefault();
+        return selected ?? available
+            .Where(target => target.Value.ValueKind == JsonValueKind.Object && target.Name.StartsWith($"{targetFramework}/", StringComparison.OrdinalIgnoreCase))
+            .Cast<JsonProperty?>()
+            .FirstOrDefault();
+    }
+
+    static bool IsFrameworkPackage(string library) =>
+        library.StartsWith("Marten/", StringComparison.OrdinalIgnoreCase) ||
+        library.StartsWith("WolverineFx/", StringComparison.OrdinalIgnoreCase) ||
+        library.StartsWith("WolverineFx.", StringComparison.OrdinalIgnoreCase);
+
+    static bool IsPackage(JsonElement library) =>
+        library.ValueKind == JsonValueKind.Object &&
+        library.TryGetProperty("type", out var type) &&
+        type.ValueKind == JsonValueKind.String &&
+        string.Equals(type.GetString(), "package", StringComparison.OrdinalIgnoreCase);
+
+    static ResolvedScreenplayPackage? PackageFrom(string library)
+    {
+        var separator = library.LastIndexOf('/');
+        return separator <= 0 || separator == library.Length - 1
+            ? null
+            : new ResolvedScreenplayPackage(library[..separator], library[(separator + 1)..]);
+    }
+}

--- a/Source/Cli/Commands/Screenplay/ScreenplaySourceProviders.cs
+++ b/Source/Cli/Commands/Screenplay/ScreenplaySourceProviders.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Reflection;
+
 namespace Cratis.Cli.Commands.Screenplay;
 
 /// <summary>
@@ -26,19 +28,47 @@ static class ProviderEvidence
         compilation.GetTypeByMetadataName("Wolverine.WolverineOptions") is not null;
 }
 
+static class ProviderAssemblyVersion
+{
+    public static string Of(Type providerType, string packageId)
+    {
+        var packageVersion = typeof(ProviderAssemblyVersion).Assembly
+            .GetCustomAttributes<AssemblyMetadataAttribute>()
+            .FirstOrDefault(metadata => string.Equals(metadata.Key, $"{packageId}.PackageVersion", StringComparison.Ordinal))
+            ?.Value;
+        if (!string.IsNullOrWhiteSpace(packageVersion))
+        {
+            return packageVersion;
+        }
+
+        var assembly = providerType.Assembly;
+        var informational = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
+        return string.IsNullOrWhiteSpace(informational)
+            ? assembly.GetName().Version?.ToString() ?? "unknown"
+            : informational.Split('+')[0];
+    }
+}
+
 sealed class ArcSourceProvider : IScreenplaySourceProvider
 {
     public string Name => ScreenplayProviders.Arc;
+    public string Version => ProviderAssemblyVersion.Of(typeof(Cratis.Arc.Screenplay.ScreenplayGenerator), "Cratis.Arc.Screenplay");
     public IReadOnlyList<string> Supersedes => [];
     public bool RequiresSingleHost => false;
     public bool Matches(LoadedCompilation loaded) => loaded.Compilations.Any(ScreenplayProjectSelection.CanDeclareAnArtifact);
+    public LoadedCompilation SelectFrom(LoadedCompilation loaded) => Narrow(loaded);
     public GeneratedScreenplay GenerateFrom(LoadedCompilation loaded, string targetPath, ScreenplayGenerationOptions options) =>
         ArcScreenplayGeneration.GenerateFrom(Narrow(loaded), targetPath, options);
 
     static LoadedCompilation Narrow(LoadedCompilation loaded)
     {
         var selected = loaded.Compilations
-            .Select((compilation, index) => new { Compilation = compilation, Name = loaded.ProjectNames[index] })
+            .Select((compilation, index) => new
+            {
+                Compilation = compilation,
+                Name = loaded.ProjectNames[index],
+                Provenance = loaded.ProjectProvenance.Count > index ? loaded.ProjectProvenance[index] : null
+            })
             .Where(_ => ScreenplayProjectSelection.CanDeclareAnArtifact(_.Compilation))
             .ToArray();
         return selected.Length == loaded.Compilations.Count
@@ -46,16 +76,21 @@ sealed class ArcSourceProvider : IScreenplaySourceProvider
             : new LoadedCompilation(
                 [.. selected.Select(_ => _.Compilation)],
                 [.. selected.Select(_ => _.Name)],
-                loaded.Diagnostics);
+                loaded.Diagnostics)
+            {
+                ProjectProvenance = [.. selected.Where(_ => _.Provenance is not null).Select(_ => _.Provenance!)]
+            };
     }
 }
 
 sealed class MartenSourceProvider : IScreenplaySourceProvider
 {
     public string Name => ScreenplayProviders.Marten;
+    public string Version => ProviderAssemblyVersion.Of(typeof(Cratis.CritterStack.Screenplay.CritterStackScreenplayGenerator), "Cratis.CritterStack.Screenplay");
     public IReadOnlyList<string> Supersedes => [];
     public bool RequiresSingleHost => true;
     public bool Matches(LoadedCompilation loaded) => loaded.Compilations.Any(ProviderEvidence.HasMarten);
+    public LoadedCompilation SelectFrom(LoadedCompilation loaded) => loaded;
     public GeneratedScreenplay GenerateFrom(LoadedCompilation loaded, string targetPath, ScreenplayGenerationOptions options) =>
         CritterStackScreenplayGeneration.GenerateFrom(loaded, targetPath, options);
 }
@@ -63,10 +98,12 @@ sealed class MartenSourceProvider : IScreenplaySourceProvider
 sealed class CritterStackSourceProvider : IScreenplaySourceProvider
 {
     public string Name => ScreenplayProviders.CritterStack;
+    public string Version => ProviderAssemblyVersion.Of(typeof(Cratis.CritterStack.Screenplay.CritterStackScreenplayGenerator), "Cratis.CritterStack.Screenplay");
     public IReadOnlyList<string> Supersedes => [ScreenplayProviders.Marten];
     public bool RequiresSingleHost => true;
     public bool Matches(LoadedCompilation loaded) => loaded.Compilations.Any(_ =>
         ProviderEvidence.HasMarten(_) && ProviderEvidence.HasWolverine(_));
+    public LoadedCompilation SelectFrom(LoadedCompilation loaded) => loaded;
     public GeneratedScreenplay GenerateFrom(LoadedCompilation loaded, string targetPath, ScreenplayGenerationOptions options) =>
         CritterStackScreenplayGeneration.GenerateFrom(loaded, targetPath, options);
 }


### PR DESCRIPTION
# Summary

Screenplay source generation now reports exactly which provider, target framework, packages, assemblies, and API capabilities informed the result, while keeping compatibility evidence separate from semantic and lowering outcomes.

## Added

- Report resolved source-package provenance and explicit compatibility dimensions for Screenplay generation. (#87)
- Fail closed for unknown or unsupported Marten and Wolverine generations. (#87)

## Changed

- Emit one deterministic machine-readable provenance and diagnostics payload on standard error. (#87)