### PR TITLE
Use current published Screenplay adapters

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,17 +29,8 @@ jobs:
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 
-      # Bootstrap the first source-provider packages while their new package IDs await nuget.org trusted-publisher
-      # policies. Remove this step once both 0.1.0 releases are available from nuget.org.
-      - name: Download Screenplay source-provider packages
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          gh release download v0.1.0 --repo Cratis/Screenplay.Generation --pattern '*.nupkg' --dir ./Artifacts/Dependencies
-          gh release download v0.1.0 --repo Cratis/Screenplay.CritterStack --pattern '*.nupkg' --dir ./Artifacts/Dependencies
-
       - name: Restore
-        run: dotnet restore --property:Configuration=Release --source ./Artifacts/Dependencies --source https://api.nuget.org/v3/index.json
+        run: dotnet restore --property:Configuration=Release --source https://api.nuget.org/v3/index.json
 
       - name: Build
         run: dotnet build --no-restore --configuration Release

--- a/.github/workflows/publish-native.yml
+++ b/.github/workflows/publish-native.yml
@@ -28,15 +28,8 @@ jobs:
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 
-      - name: Download Screenplay source-provider packages
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          gh release download v0.1.0 --repo Cratis/Screenplay.Generation --pattern '*.nupkg' --dir ./Artifacts/Dependencies
-          gh release download v0.1.0 --repo Cratis/Screenplay.CritterStack --pattern '*.nupkg' --dir ./Artifacts/Dependencies
-
       - name: Restore
-        run: dotnet restore Source/Cli/Cli.csproj -r osx-arm64 --source ./Artifacts/Dependencies --source https://api.nuget.org/v3/index.json
+        run: dotnet restore Source/Cli/Cli.csproj -r osx-arm64 --source https://api.nuget.org/v3/index.json
 
       - name: Publish
         run: dotnet publish Source/Cli/Cli.csproj --no-restore -c Release -r osx-arm64 -p:SelfContained=true -p:PublishSingleFile=true -p:Version=${{ inputs.version }} -o ./publish/osx-arm64
@@ -65,15 +58,8 @@ jobs:
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 
-      - name: Download Screenplay source-provider packages
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          gh release download v0.1.0 --repo Cratis/Screenplay.Generation --pattern '*.nupkg' --dir ./Artifacts/Dependencies
-          gh release download v0.1.0 --repo Cratis/Screenplay.CritterStack --pattern '*.nupkg' --dir ./Artifacts/Dependencies
-
       - name: Restore
-        run: dotnet restore Source/Cli/Cli.csproj -r osx-x64 --source ./Artifacts/Dependencies --source https://api.nuget.org/v3/index.json
+        run: dotnet restore Source/Cli/Cli.csproj -r osx-x64 --source https://api.nuget.org/v3/index.json
 
       - name: Publish
         run: dotnet publish Source/Cli/Cli.csproj --no-restore -c Release -r osx-x64 -p:SelfContained=true -p:PublishSingleFile=true -p:Version=${{ inputs.version }} -o ./publish/osx-x64
@@ -102,15 +88,8 @@ jobs:
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 
-      - name: Download Screenplay source-provider packages
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          gh release download v0.1.0 --repo Cratis/Screenplay.Generation --pattern '*.nupkg' --dir ./Artifacts/Dependencies
-          gh release download v0.1.0 --repo Cratis/Screenplay.CritterStack --pattern '*.nupkg' --dir ./Artifacts/Dependencies
-
       - name: Restore
-        run: dotnet restore Source/Cli/Cli.csproj -r linux-x64 --source ./Artifacts/Dependencies --source https://api.nuget.org/v3/index.json
+        run: dotnet restore Source/Cli/Cli.csproj -r linux-x64 --source https://api.nuget.org/v3/index.json
 
       - name: Publish
         run: dotnet publish Source/Cli/Cli.csproj --no-restore -c Release -r linux-x64 -p:SelfContained=true -p:PublishSingleFile=true -p:Version=${{ inputs.version }} -o ./publish/linux-x64
@@ -139,15 +118,8 @@ jobs:
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 
-      - name: Download Screenplay source-provider packages
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          gh release download v0.1.0 --repo Cratis/Screenplay.Generation --pattern '*.nupkg' --dir ./Artifacts/Dependencies
-          gh release download v0.1.0 --repo Cratis/Screenplay.CritterStack --pattern '*.nupkg' --dir ./Artifacts/Dependencies
-
       - name: Restore
-        run: dotnet restore Source/Cli/Cli.csproj -r linux-arm64 --source ./Artifacts/Dependencies --source https://api.nuget.org/v3/index.json
+        run: dotnet restore Source/Cli/Cli.csproj -r linux-arm64 --source https://api.nuget.org/v3/index.json
 
       - name: Publish
         run: dotnet publish Source/Cli/Cli.csproj --no-restore -c Release -r linux-arm64 -p:SelfContained=true -p:PublishSingleFile=true -p:Version=${{ inputs.version }} -o ./publish/linux-arm64

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -101,16 +101,8 @@ jobs:
       - name: Remove any existing artifacts
         run: rm -rf ${{ env.NUGET_OUTPUT }}
 
-      # Bootstrap until the new package IDs are available from nuget.org.
-      - name: Download Screenplay source-provider packages
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          gh release download v0.1.0 --repo Cratis/Screenplay.Generation --pattern '*.nupkg' --dir ./Artifacts/Dependencies
-          gh release download v0.1.0 --repo Cratis/Screenplay.CritterStack --pattern '*.nupkg' --dir ./Artifacts/Dependencies
-
       - name: Restore
-        run: dotnet restore --property:Configuration=Release --source ./Artifacts/Dependencies --source https://api.nuget.org/v3/index.json
+        run: dotnet restore --property:Configuration=Release --source https://api.nuget.org/v3/index.json
 
       - name: Build
         run: dotnet build --no-restore --configuration Release -p:Version=${{ needs.release.outputs.version }}

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,14 +3,14 @@
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <CratisArcScreenplayVersion>22.0.0</CratisArcScreenplayVersion>
-    <CratisCritterStackScreenplayVersion>0.13.0</CratisCritterStackScreenplayVersion>
+    <CratisCritterStackScreenplayVersion>0.13.1</CratisCritterStackScreenplayVersion>
   </PropertyGroup>
   <ItemGroup>
     <!-- Cratis -->
     <PackageVersion Include="Cratis.Arc.Screenplay" Version="$(CratisArcScreenplayVersion)" />
     <PackageVersion Include="Cratis.CritterStack.Screenplay" Version="$(CratisCritterStackScreenplayVersion)" />
-    <PackageVersion Include="Cratis.Screenplay.Generation.Contracts" Version="0.6.0" />
-    <PackageVersion Include="Cratis.Screenplay.Generation.DotNet" Version="0.6.0" />
+    <PackageVersion Include="Cratis.Screenplay.Generation.Contracts" Version="0.6.1" />
+    <PackageVersion Include="Cratis.Screenplay.Generation.DotNet" Version="0.6.1" />
     <PackageVersion Include="Cratis.Chronicle.Connections" Version="16.37.0" />
     <PackageVersion Include="Cratis.Chronicle.Contracts" Version="16.37.0" />
     <PackageVersion Include="Cratis.Fundamentals" Version="7.18.1" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,14 +3,14 @@
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <CratisArcScreenplayVersion>22.0.0</CratisArcScreenplayVersion>
-    <CratisCritterStackScreenplayVersion>0.1.0</CratisCritterStackScreenplayVersion>
+    <CratisCritterStackScreenplayVersion>0.13.0</CratisCritterStackScreenplayVersion>
   </PropertyGroup>
   <ItemGroup>
     <!-- Cratis -->
     <PackageVersion Include="Cratis.Arc.Screenplay" Version="$(CratisArcScreenplayVersion)" />
     <PackageVersion Include="Cratis.CritterStack.Screenplay" Version="$(CratisCritterStackScreenplayVersion)" />
-    <PackageVersion Include="Cratis.Screenplay.Generation.Contracts" Version="0.1.0" />
-    <PackageVersion Include="Cratis.Screenplay.Generation.DotNet" Version="0.1.0" />
+    <PackageVersion Include="Cratis.Screenplay.Generation.Contracts" Version="0.6.0" />
+    <PackageVersion Include="Cratis.Screenplay.Generation.DotNet" Version="0.6.0" />
     <PackageVersion Include="Cratis.Chronicle.Connections" Version="16.37.0" />
     <PackageVersion Include="Cratis.Chronicle.Contracts" Version="16.37.0" />
     <PackageVersion Include="Cratis.Fundamentals" Version="7.18.1" />

--- a/Documentation/reference/screenplay.md
+++ b/Documentation/reference/screenplay.md
@@ -134,12 +134,12 @@ These values deliberately do not imply one another. A canonical package set can 
 
 ```text
 source compatibility:
-  provider: critter-stack 0.1.0
+  provider: critter-stack 0.13.0
   project: Helpdesk.Api (net9.0)
     packages: Marten 9.23.0, WolverineFx 6.29.1, WolverineFx.Marten 6.29.1
     assemblies: Marten 9.23.0.0, Wolverine 6.29.1.0
     capabilities: marten.event-projection, wolverine.handler-attribute
-  support tier: SourceReviewed
+  support tier: Canonical
   recognition: Recognized
   semantic conformance: RequiresHumanReview
   lowering fidelity: LossReported

--- a/Documentation/reference/screenplay.md
+++ b/Documentation/reference/screenplay.md
@@ -134,7 +134,7 @@ These values deliberately do not imply one another. A canonical package set can 
 
 ```text
 source compatibility:
-  provider: critter-stack 0.13.0
+  provider: critter-stack 0.13.1
   project: Helpdesk.Api (net9.0)
     packages: Marten 9.23.0, WolverineFx 6.29.1, WolverineFx.Marten 6.29.1
     assemblies: Marten 9.23.0.0, Wolverine 6.29.1.0

--- a/Source/Cli.Specs/for_CritterStackScreenplayGeneration/given/a_marten_application_built_from_source.cs
+++ b/Source/Cli.Specs/for_CritterStackScreenplayGeneration/given/a_marten_application_built_from_source.cs
@@ -47,16 +47,18 @@ public class a_marten_application_built_from_source : Specification
 
     protected LoadedCompilation Loaded { get; private set; } = null!;
 
-    void Establish() => Loaded = new(
-        [
-            CSharpCompilation.Create(
-                ProjectName,
-                [CSharpSyntaxTree.ParseText(Source, path: "/workspace/Banking/Account.cs")],
-                References(),
-                new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary))
-        ],
-        [ProjectName],
-        []);
+    void Establish()
+    {
+        var compilation = CSharpCompilation.Create(
+            ProjectName,
+            [CSharpSyntaxTree.ParseText(Source, path: "/workspace/Banking/Account.cs")],
+            References(),
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+        Loaded = new([compilation], [ProjectName], [])
+        {
+            AuthoredSyntaxTrees = [compilation.SyntaxTrees.ToHashSet()]
+        };
+    }
 
     static IEnumerable<MetadataReference> References() =>
         ((string)AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES")!)

--- a/Source/Cli.Specs/for_ScreenplayCompatibility/when_assessing/and_the_critter_stack_package_set_is_canonical.cs
+++ b/Source/Cli.Specs/for_ScreenplayCompatibility/when_assessing/and_the_critter_stack_package_set_is_canonical.cs
@@ -8,13 +8,14 @@ public class and_the_critter_stack_package_set_is_canonical : given.compatibilit
     ScreenplayCompatibilityEvaluation _result;
 
     void Because() => _result = ScreenplayCompatibility.Evaluate(
-        new a_provider(ScreenplayProviders.CritterStack, "0.3.0"),
+        new CritterStackSourceProvider(),
         LoadedWith(
             new ResolvedScreenplayPackage("Marten", "9.23.0"),
             new ResolvedScreenplayPackage("WolverineFx", "6.29.1"),
             new ResolvedScreenplayPackage("WolverineFx.Marten", "6.29.1")));
 
     [Fact] void should_admit_generation() => _result.BlockingDiagnostic.ShouldBeNull();
+    [Fact] void should_report_the_bundled_provider_version() => _result.Provenance.ProviderVersion.ShouldEqual("0.13.0");
     [Fact] void should_report_canonical_support() => _result.Provenance.Compatibility!.SupportTier.ShouldEqual(ScreenplaySupportTier.Canonical);
     [Fact] void should_keep_recognition_separate() => _result.Provenance.Compatibility!.RecognitionStatus.ShouldEqual(ScreenplayRecognitionStatus.Recognized);
     [Fact] void should_require_semantic_review() => _result.Provenance.Compatibility!.SemanticConformance.ShouldEqual(ScreenplaySemanticConformance.RequiresHumanReview);

--- a/Source/Cli.Specs/for_ScreenplayCompatibility/when_assessing/and_the_critter_stack_package_set_is_canonical.cs
+++ b/Source/Cli.Specs/for_ScreenplayCompatibility/when_assessing/and_the_critter_stack_package_set_is_canonical.cs
@@ -15,7 +15,7 @@ public class and_the_critter_stack_package_set_is_canonical : given.compatibilit
             new ResolvedScreenplayPackage("WolverineFx.Marten", "6.29.1")));
 
     [Fact] void should_admit_generation() => _result.BlockingDiagnostic.ShouldBeNull();
-    [Fact] void should_report_the_bundled_provider_version() => _result.Provenance.ProviderVersion.ShouldEqual("0.13.0");
+    [Fact] void should_report_the_bundled_provider_version() => _result.Provenance.ProviderVersion.ShouldEqual("0.13.1");
     [Fact] void should_report_canonical_support() => _result.Provenance.Compatibility!.SupportTier.ShouldEqual(ScreenplaySupportTier.Canonical);
     [Fact] void should_keep_recognition_separate() => _result.Provenance.Compatibility!.RecognitionStatus.ShouldEqual(ScreenplayRecognitionStatus.Recognized);
     [Fact] void should_require_semantic_review() => _result.Provenance.Compatibility!.SemanticConformance.ShouldEqual(ScreenplaySemanticConformance.RequiresHumanReview);

--- a/Source/Cli/Commands/Screenplay/CritterStackScreenplayGeneration.cs
+++ b/Source/Cli/Commands/Screenplay/CritterStackScreenplayGeneration.cs
@@ -55,7 +55,10 @@ public sealed class CritterStackScreenplayGeneration : IScreenplayGeneration
                 Name = loaded.ProjectNames[index],
                 ProjectPath = targetPath,
                 SourceRoot = sourceRoot,
-                Compilation = compilation
+                Compilation = compilation,
+                AuthoredSyntaxTrees = loaded.AuthoredSyntaxTrees.Count > index
+                    ? loaded.AuthoredSyntaxTrees[index]
+                    : new HashSet<Microsoft.CodeAnalysis.SyntaxTree>()
             })
             .ToArray();
         var optionDiagnostics = options.ModulesFromNamespaceRoots

--- a/Source/Cli/Commands/Screenplay/LoadedCompilation.cs
+++ b/Source/Cli/Commands/Screenplay/LoadedCompilation.cs
@@ -14,6 +14,11 @@ namespace Cratis.Cli.Commands.Screenplay;
 public record LoadedCompilation(IReadOnlyList<Compilation> Compilations, IReadOnlyList<string> ProjectNames, IReadOnlyList<ScreenplayDiagnostic> Diagnostics)
 {
     /// <summary>
+    /// Gets the syntax trees known to come from authored project documents in compilation order.
+    /// </summary>
+    public IReadOnlyList<IReadOnlySet<SyntaxTree>> AuthoredSyntaxTrees { get; init; } = [];
+
+    /// <summary>
     /// Gets CLI-owned project, target-framework, package, assembly, and capability provenance in compilation order.
     /// </summary>
     public IReadOnlyList<ScreenplayProjectProvenance> ProjectProvenance { get; init; } = [];

--- a/Source/Cli/Commands/Screenplay/ScreenplayCompilationLoader.cs
+++ b/Source/Cli/Commands/Screenplay/ScreenplayCompilationLoader.cs
@@ -159,6 +159,7 @@ public static class ScreenplayCompilationLoader
     {
         var compilations = new List<Compilation>();
         var names = new List<string>();
+        var authoredSyntaxTrees = new List<IReadOnlySet<SyntaxTree>>();
         var projectProvenance = new List<ScreenplayProjectProvenance>();
 
         // A project that yields no compilation is left out of the document rather than ending the run, so that a
@@ -168,6 +169,15 @@ public static class ScreenplayCompilationLoader
 
         foreach (var loaded in selected)
         {
+            var authoredTrees = new HashSet<SyntaxTree>();
+            foreach (var document in loaded.Documents)
+            {
+                if (await document.GetSyntaxTreeAsync(cancellationToken) is { } syntaxTree)
+                {
+                    authoredTrees.Add(syntaxTree);
+                }
+            }
+
             var project = GeneratedResourceSources.AddMissingTo(loaded);
             var name = ScreenplayProjectSelection.WithoutTargetFramework(project.Name);
             var compilation = await project.GetCompilationAsync(cancellationToken);
@@ -192,6 +202,7 @@ public static class ScreenplayCompilationLoader
             var assetsFile = ProjectRestoreState.AssetsFileFor(project.FilePath, project.CompilationOutputInfo.AssemblyPath);
             compilations.Add(compilation);
             names.Add(name);
+            authoredSyntaxTrees.Add(authoredTrees);
             projectProvenance.Add(new ScreenplayProjectProvenance(
                 name,
                 targetFramework,
@@ -217,6 +228,7 @@ public static class ScreenplayCompilationLoader
 
         return new LoadedCompilation(compilations, names, [.. failures, .. unloadable])
         {
+            AuthoredSyntaxTrees = authoredSyntaxTrees,
             ProjectProvenance = projectProvenance
         };
     }

--- a/Source/Cli/Commands/Screenplay/ScreenplaySourceProviders.cs
+++ b/Source/Cli/Commands/Screenplay/ScreenplaySourceProviders.cs
@@ -67,6 +67,7 @@ sealed class ArcSourceProvider : IScreenplaySourceProvider
             {
                 Compilation = compilation,
                 Name = loaded.ProjectNames[index],
+                AuthoredSyntaxTrees = loaded.AuthoredSyntaxTrees.Count > index ? loaded.AuthoredSyntaxTrees[index] : null,
                 Provenance = loaded.ProjectProvenance.Count > index ? loaded.ProjectProvenance[index] : null
             })
             .Where(_ => ScreenplayProjectSelection.CanDeclareAnArtifact(_.Compilation))
@@ -78,6 +79,7 @@ sealed class ArcSourceProvider : IScreenplaySourceProvider
                 [.. selected.Select(_ => _.Name)],
                 loaded.Diagnostics)
             {
+                AuthoredSyntaxTrees = [.. selected.Where(_ => _.AuthoredSyntaxTrees is not null).Select(_ => _.AuthoredSyntaxTrees!)],
                 ProjectProvenance = [.. selected.Where(_ => _.Provenance is not null).Select(_ => _.Provenance!)]
             };
     }


### PR DESCRIPTION
# Changed
- Take Screenplay Generation 0.6.0 and Critter Stack Screenplay 0.13.0. (Cratis/cli#87)
- Preserve authored syntax-tree provenance required by current source adapters. (Cratis/cli#87)
- Report exact canonical package sets with the current bundled provider. (Cratis/cli#87)

## Removed
- Remove obsolete GitHub release package bootstrap and local dependency sources now trusted NuGet publishing is available. (Cratis/cli#87)