### PR TITLE
Require explicit Screenplay target framework selection

### DIFF
--- a/Documentation/reference/screenplay.md
+++ b/Documentation/reference/screenplay.md
@@ -37,6 +37,7 @@ Pass `--file` to write it directly instead. The output is written as raw UTF-8, 
 |---|---|
 | `--file <FILE>` | File to write the generated Screenplay to. Writes to standard output when not given. |
 | `--provider <PROVIDER>` | Source provider: `auto`, `arc`, `marten`, or `critter-stack`. Defaults to auto detection. |
+| `--framework <TFM>` | Target framework to load from every multi-targeted application project, such as `net9.0`. Required when any application project targets several frameworks. |
 | `--domain <NAME>` | Name of the domain the generated document belongs to. Defaults to the assembly or root namespace of the project, and to the solution name when several projects are read. |
 | `--module <NAME>` | Name of the module every discovered feature is placed within. Defaults to the domain. |
 | `--skip-segments <COUNT>` | Number of leading namespace segments to skip when inferring features and slices. |
@@ -48,6 +49,7 @@ The output file uses `--file` rather than `-o`, because `-o/--output` is the glo
 cratis screenplay generate
 cratis screenplay generate ./MyApp.slnx --file MyApp.play
 cratis screenplay generate ./Source/MyApp/MyApp.csproj
+cratis screenplay generate ./MyApp.slnx --framework net9.0 --file MyApp.play
 cratis screenplay generate ./Banking.csproj --provider marten --file Banking.play
 cratis screenplay generate ./Helpdesk.csproj --provider critter-stack --file Helpdesk.play
 cratis screenplay generate --domain Library --module Lending --file Library.play
@@ -84,9 +86,11 @@ A Screenplay describes one application, and an application is regularly split ac
 - **With the Arc provider, projects that cannot declare an Arc/Chronicle artifact.** A Roslyn analyzer, build-time tool, or code-generation project resolving neither framework is left out. Marten/Wolverine contracts are frequently markerless and may live in referenced projects without a direct package reference, so Critter Stack analysis retains non-spec C# projects and lets the provider contribute only evidence it recognizes.
 - **Spec projects**, by name: the ones called, or ending in, `.Specs`, `.Specifications`, `.Tests`, `.Test`, `.IntegrationTests`, or `.Specs.AppHost`. Nothing about what a spec project can see tells it apart — it references the same framework the application does — so the name is what decides. `.Specs.AppHost` covers the host integration specs start the application in.
 
-A project that targets several frameworks is read once. The workspace opens it once per target framework and names the results `MyApp(net10.0)`, `MyApp(net9.0)`; the CLI selects one deterministically and the provenance report names the selected target. Package admission, capabilities, and the support tier apply only to that reported target framework — they make no claim about the project's other targets.
+A project that targets several frameworks must be selected explicitly. The workspace opens it once per target framework and names the results `MyApp(net10.0)`, `MyApp(net9.0)`. Without `--framework`, the CLI fails with `CLI0015`, names the base project and its available target frameworks in stable order, and asks you to select one. It never silently picks a variant.
 
-Pass a `.csproj` instead of the solution to describe a single project — pointing at a project is the instruction to read it, so it is read whatever it can see.
+`--framework` applies to every multi-targeted application project in the solution and matches the decorated workspace variant exactly, case-insensitively. If any such project does not offer the requested target, the CLI fails with `CLI0016` and lists that project's available targets. Projects that have only one workspace variant remain part of the application regardless of this option, so ordinary single-target dependency projects are not discarded. Spec projects are excluded before target-framework selection.
+
+Pass a `.csproj` instead of the solution to describe a single project — pointing at a project is the instruction to read it, so it is read whatever it can see. A multi-targeted project still requires `--framework`.
 
 The projects that were read are named in the result, so you can see what the document covers:
 
@@ -114,6 +118,8 @@ With `-o json` or `-o json-compact`, standard error is one JSON object containin
 **Warnings and information do not fail the command** — the document is still written. **An error does**: nothing is written and the command exits with a validation error, because a document that does not describe the source faithfully is worse than no document.
 
 ### Source and compatibility provenance
+
+Target-framework selection is a CLI-owned boundary before provider matching, compatibility admission, or source interpretation. Only after every multi-targeted project resolves to one variant does the CLI collect package, assembly, capability, and target-framework provenance. `CLI0015` and `CLI0016` therefore produce no provider-generated source or provenance; the command exits with a validation error and standard output stays empty.
 
 Every successful provider selection reports provenance on standard error, separately from the `.play` document on standard output. The report names:
 
@@ -180,6 +186,8 @@ The project does **not** have to have been built first. Sources MSBuild generate
 | No solution or project found in `PATH` or any parent folder | Not-found error. |
 | The solution holds no project that is not specs | Validation error (`CLI0001`). |
 | A project has not been restored | Validation error (`CLI0005`) naming it; nothing is generated. |
+| A project targets several frameworks and `--framework` is omitted | Validation error (`CLI0015`) naming the project and ordered available targets; provider interpretation does not start and no source or provenance is produced. |
+| A multi-targeted project does not offer the requested `--framework` | Validation error (`CLI0016`) naming the project and ordered available targets; provider interpretation does not start and no source or provenance is produced. |
 | No Arc project of the solution can declare a command or event type | Validation error (`CLI0006`). |
 | `--provider` does not name an available bundled provider | Validation error (`CLI0007`) listing the providers in this CLI build. |
 | Authored source still has compilation errors after framework-reference repair | Validation error (`CLI0008`); no Screenplay is generated. |

--- a/Source/Cli.Specs/for_GenerateScreenplayCommand/when_generating/and_generation_options_are_given.cs
+++ b/Source/Cli.Specs/for_GenerateScreenplayCommand/when_generating/and_generation_options_are_given.cs
@@ -12,6 +12,7 @@ public class and_generation_options_are_given : given.a_generate_screenplay_comm
         _settings.Module = "Lending";
         _settings.SkipSegments = 2;
         _settings.Provider = ScreenplayProviders.CritterStack;
+        _settings.Framework = "net9.0";
     }
 
     async Task Because() => await Execute();
@@ -24,6 +25,11 @@ public class and_generation_options_are_given : given.a_generate_screenplay_comm
     [Fact] void should_pass_the_provider_to_the_generation() => _generation.Received(1).Generate(
         Arg.Any<string>(),
         Arg.Is<ScreenplayGenerationOptions>(options => options.Provider == ScreenplayProviders.CritterStack),
+        Arg.Any<CancellationToken>());
+
+    [Fact] void should_pass_the_target_framework_to_the_generation() => _generation.Received(1).Generate(
+        Arg.Any<string>(),
+        Arg.Is<ScreenplayGenerationOptions>(options => options.TargetFramework == "net9.0"),
         Arg.Any<CancellationToken>());
 
     [Fact] void should_leave_the_modules_named_by_one_name() => _generation.Received(1).Generate(

--- a/Source/Cli.Specs/for_ProviderScreenplayGeneration/when_generating/and_target_framework_selection_fails.cs
+++ b/Source/Cli.Specs/for_ProviderScreenplayGeneration/when_generating/and_target_framework_selection_fails.cs
@@ -1,0 +1,77 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Cli.for_ProviderScreenplayGeneration.when_generating;
+
+public class and_target_framework_selection_fails : Specification
+{
+    const string TargetPath = "/workspace/Application.slnx";
+    const string RequestedFramework = "net9.0";
+
+    TrackingProvider _provider;
+    LoadedCompilation _failedLoad;
+    GeneratedScreenplay _result;
+    string? _frameworkPassedToLoader;
+
+    void Establish()
+    {
+        _provider = new TrackingProvider();
+        _failedLoad = LoadedCompilation.Failed(
+            ScreenplayDiagnosticCodes.AmbiguousTargetFramework,
+            "Project 'Application' targets multiple frameworks: net8.0, net9.0. Pass --framework <TFM> to select one",
+            TargetPath);
+    }
+
+    async Task Because()
+    {
+        var generation = new ProviderScreenplayGeneration([_provider], Load);
+        _result = await generation.Generate(
+            TargetPath,
+            ScreenplayGenerationOptions.Default with
+            {
+                Provider = ScreenplayProviders.Arc,
+                TargetFramework = RequestedFramework
+            },
+            CancellationToken.None);
+    }
+
+    Task<LoadedCompilation> Load(string targetPath, string? targetFramework, CancellationToken cancellationToken)
+    {
+        _frameworkPassedToLoader = targetFramework;
+        return Task.FromResult(_failedLoad);
+    }
+
+    [Fact] void should_pass_the_requested_framework_to_the_loader() => _frameworkPassedToLoader.ShouldEqual(RequestedFramework);
+    [Fact] void should_propagate_the_selection_error() => _result.Diagnostics.Single().Code.ShouldEqual(ScreenplayDiagnosticCodes.AmbiguousTargetFramework);
+    [Fact] void should_generate_no_source() => _result.Source.ShouldBeEmpty();
+    [Fact] void should_report_no_provenance() => _result.Provenance.ShouldBeNull();
+    [Fact] void should_not_interpret_the_source() => _provider.DidGenerate.ShouldBeFalse();
+    [Fact] void should_not_select_provider_projects() => _provider.DidSelect.ShouldBeFalse();
+
+    sealed class TrackingProvider : IScreenplaySourceProvider
+    {
+        public string Name => ScreenplayProviders.Arc;
+        public string Version => "1.0.0";
+        public IReadOnlyList<string> Supersedes => [];
+        public bool RequiresSingleHost => false;
+        public bool DidSelect { get; private set; }
+        public bool DidGenerate { get; private set; }
+
+        public bool Matches(LoadedCompilation loaded) => true;
+
+        public LoadedCompilation SelectFrom(LoadedCompilation loaded)
+        {
+            DidSelect = true;
+            return loaded;
+        }
+
+        public GeneratedScreenplay GenerateFrom(
+            LoadedCompilation loaded,
+            string targetPath,
+            ScreenplayGenerationOptions options)
+        {
+            DidGenerate = true;
+            return new GeneratedScreenplay("generated", []);
+        }
+    }
+}

--- a/Source/Cli.Specs/for_ScreenplayTargetFrameworkSelector/when_selecting/and_a_single_target_project_is_also_present.cs
+++ b/Source/Cli.Specs/for_ScreenplayTargetFrameworkSelector/when_selecting/and_a_single_target_project_is_also_present.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Cli.for_ScreenplayTargetFrameworkSelector.when_selecting;
+
+public class and_a_single_target_project_is_also_present : Specification
+{
+    ScreenplayTargetFrameworkSelection _result;
+
+    void Because() => _result = ScreenplayTargetFrameworkSelector.Select(
+        ["Application(net8.0)", "Application(net9.0)", "Shared"],
+        "net9.0");
+
+    [Fact] void should_keep_the_selected_application_framework() => _result.ProjectNames.ShouldContain("Application(net9.0)");
+    [Fact] void should_keep_the_single_target_project() => _result.ProjectNames.ShouldContain("Shared");
+    [Fact] void should_not_report_an_error() => _result.Diagnostics.ShouldBeEmpty();
+}

--- a/Source/Cli.Specs/for_ScreenplayTargetFrameworkSelector/when_selecting/and_frameworks_are_out_of_order.cs
+++ b/Source/Cli.Specs/for_ScreenplayTargetFrameworkSelector/when_selecting/and_frameworks_are_out_of_order.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Cli.for_ScreenplayTargetFrameworkSelector.when_selecting;
+
+public class and_frameworks_are_out_of_order : Specification
+{
+    ScreenplayTargetFrameworkSelection _result;
+
+    void Because() => _result = ScreenplayTargetFrameworkSelector.Select(
+        ["Application(net9.0)", "Application(net8.0)", "Application(net10.0)"],
+        requestedFramework: null);
+
+    [Fact] void should_order_the_available_frameworks() => _result.Diagnostics.Single().Message.ShouldEqual(
+        "Project 'Application' targets multiple frameworks: net10.0, net8.0, net9.0. Pass --framework <TFM> to select one");
+}

--- a/Source/Cli.Specs/for_ScreenplayTargetFrameworkSelector/when_selecting/and_no_framework_is_requested.cs
+++ b/Source/Cli.Specs/for_ScreenplayTargetFrameworkSelector/when_selecting/and_no_framework_is_requested.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Cli.for_ScreenplayTargetFrameworkSelector.when_selecting;
+
+public class and_no_framework_is_requested : Specification
+{
+    ScreenplayTargetFrameworkSelection _result;
+
+    void Because() => _result = ScreenplayTargetFrameworkSelector.Select(
+        ["Application(net8.0)", "Shared", "Application(net9.0)"],
+        requestedFramework: null,
+        "/workspace/Application.slnx");
+
+    [Fact] void should_fail_closed() => _result.IsSuccessful.ShouldBeFalse();
+    [Fact] void should_retain_the_single_target_project() => _result.ProjectNames.ShouldContainOnly(["Shared"]);
+    [Fact] void should_report_the_ambiguous_framework_code() => _result.Diagnostics.Single().Code.ShouldEqual(ScreenplayDiagnosticCodes.AmbiguousTargetFramework);
+    [Fact] void should_name_the_project_and_available_frameworks() => _result.Diagnostics.Single().Message.ShouldContain("'Application' targets multiple frameworks: net8.0, net9.0");
+    [Fact] void should_explain_how_to_select_one() => _result.Diagnostics.Single().Message.ShouldContain("--framework <TFM>");
+    [Fact] void should_locate_the_diagnostic_at_the_target() => _result.Diagnostics.Single().Location.ShouldEqual("/workspace/Application.slnx");
+}

--- a/Source/Cli.Specs/for_ScreenplayTargetFrameworkSelector/when_selecting/and_several_project_groups_are_present.cs
+++ b/Source/Cli.Specs/for_ScreenplayTargetFrameworkSelector/when_selecting/and_several_project_groups_are_present.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Cli.for_ScreenplayTargetFrameworkSelector.when_selecting;
+
+public class and_several_project_groups_are_present : Specification
+{
+    ScreenplayTargetFrameworkSelection _result;
+
+    void Because() => _result = ScreenplayTargetFrameworkSelector.Select(
+        [
+            "Worker(net9.0)",
+            "Api(net8.0)",
+            "Shared",
+            "Worker(net8.0)",
+            "Api(net9.0)"
+        ],
+        "net9.0");
+
+    [Fact] void should_select_the_requested_variant_from_every_multi_target_group() => _result.ProjectNames.ShouldContainOnly(
+        ["Api(net9.0)", "Shared", "Worker(net9.0)"]);
+    [Fact] void should_preserve_project_ordering() => _result.ProjectNames.SequenceEqual(
+        ["Api(net9.0)", "Shared", "Worker(net9.0)"]).ShouldBeTrue();
+    [Fact] void should_not_report_an_error() => _result.Diagnostics.ShouldBeEmpty();
+}

--- a/Source/Cli.Specs/for_ScreenplayTargetFrameworkSelector/when_selecting/and_the_requested_framework_has_different_casing.cs
+++ b/Source/Cli.Specs/for_ScreenplayTargetFrameworkSelector/when_selecting/and_the_requested_framework_has_different_casing.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Cli.for_ScreenplayTargetFrameworkSelector.when_selecting;
+
+public class and_the_requested_framework_has_different_casing : Specification
+{
+    ScreenplayTargetFrameworkSelection _result;
+
+    void Because() => _result = ScreenplayTargetFrameworkSelector.Select(
+        ["Application(net9.0-windows)", "Application(net9.0)"],
+        "NET9.0");
+
+    [Fact] void should_select_the_exact_framework_case_insensitively() => _result.ProjectNames.ShouldContainOnly(["Application(net9.0)"]);
+    [Fact] void should_not_report_an_error() => _result.Diagnostics.ShouldBeEmpty();
+}

--- a/Source/Cli.Specs/for_ScreenplayTargetFrameworkSelector/when_selecting/and_the_requested_framework_is_unavailable.cs
+++ b/Source/Cli.Specs/for_ScreenplayTargetFrameworkSelector/when_selecting/and_the_requested_framework_is_unavailable.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Cli.for_ScreenplayTargetFrameworkSelector.when_selecting;
+
+public class and_the_requested_framework_is_unavailable : Specification
+{
+    ScreenplayTargetFrameworkSelection _result;
+
+    void Because() => _result = ScreenplayTargetFrameworkSelector.Select(
+        ["Application(net8.0)", "Application(net9.0)"],
+        "net10.0");
+
+    [Fact] void should_fail_closed() => _result.IsSuccessful.ShouldBeFalse();
+    [Fact] void should_report_the_unavailable_framework_code() => _result.Diagnostics.Single().Code.ShouldEqual(ScreenplayDiagnosticCodes.UnavailableTargetFramework);
+    [Fact] void should_name_the_requested_and_available_frameworks() => _result.Diagnostics.Single().Message.ShouldEqual(
+        "Project 'Application' does not target requested framework 'net10.0'. Available target frameworks: net8.0, net9.0");
+}

--- a/Source/Cli/Commands/Screenplay/ArcScreenplayGeneration.cs
+++ b/Source/Cli/Commands/Screenplay/ArcScreenplayGeneration.cs
@@ -17,7 +17,7 @@ public sealed class ArcScreenplayGeneration : IScreenplayGeneration
 {
     /// <inheritdoc/>
     public async Task<GeneratedScreenplay> Generate(string targetPath, ScreenplayGenerationOptions options, CancellationToken cancellationToken) =>
-        GenerateFrom(await ScreenplayCompilationLoader.Load(targetPath, cancellationToken), targetPath, options);
+        GenerateFrom(await ScreenplayCompilationLoader.Load(targetPath, options.TargetFramework, cancellationToken), targetPath, options);
 
     /// <summary>
     /// Generates the document from compilations that have already been loaded.

--- a/Source/Cli/Commands/Screenplay/CritterStackScreenplayGeneration.cs
+++ b/Source/Cli/Commands/Screenplay/CritterStackScreenplayGeneration.cs
@@ -18,7 +18,7 @@ public sealed class CritterStackScreenplayGeneration : IScreenplayGeneration
         ScreenplayGenerationOptions options,
         CancellationToken cancellationToken) =>
         GenerateFrom(
-            await ScreenplayCompilationLoader.Load(targetPath, includeAllProjects: true, cancellationToken),
+            await ScreenplayCompilationLoader.Load(targetPath, includeAllProjects: true, options.TargetFramework, cancellationToken),
             targetPath,
             options);
 

--- a/Source/Cli/Commands/Screenplay/GenerateScreenplayCommand.cs
+++ b/Source/Cli/Commands/Screenplay/GenerateScreenplayCommand.cs
@@ -16,6 +16,7 @@ namespace Cratis.Cli.Commands.Screenplay;
 [LlmOption("[PATH]", "string", "Solution (.slnx, .sln, .slnf), project (.csproj), or folder to read. Defaults to the current directory, searching upwards for a solution or project.")]
 [LlmOption("--file", "string", "File to write the generated Screenplay to. Writes to standard output when not given.")]
 [LlmOption("--provider", "string", "Source framework provider: auto, arc, marten, or critter-stack.")]
+[LlmOption("--framework", "string", "Target framework to load from multi-targeted projects. Required when any application project targets several frameworks.")]
 [LlmOption("--domain", "string", "Name of the domain the generated document belongs to.")]
 [LlmOption("--module", "string", "Name of the module every discovered feature is placed within.")]
 [LlmOption("--skip-segments", "int", "Number of leading namespace segments to skip when inferring features and slices.")]

--- a/Source/Cli/Commands/Screenplay/GenerateScreenplaySettings.cs
+++ b/Source/Cli/Commands/Screenplay/GenerateScreenplaySettings.cs
@@ -33,6 +33,13 @@ public class GenerateScreenplaySettings : GlobalSettings
     public string Provider { get; set; } = ScreenplayProviders.Auto;
 
     /// <summary>
+    /// Gets or sets the target framework to load from multi-targeted projects.
+    /// </summary>
+    [CommandOption("--framework <TFM>")]
+    [Description("Target framework to load from multi-targeted projects. Required when any application project targets several frameworks.")]
+    public string? Framework { get; set; }
+
+    /// <summary>
     /// Gets or sets the domain the generated document belongs to.
     /// </summary>
     [CommandOption("--domain <NAME>")]
@@ -74,5 +81,9 @@ public class GenerateScreenplaySettings : GlobalSettings
     /// Gets the generation options these settings describe.
     /// </summary>
     /// <returns>The <see cref="ScreenplayGenerationOptions"/>.</returns>
-    public ScreenplayGenerationOptions ToGenerationOptions() => new(Domain, Module, SkipSegments, ModulesFromNamespaceRoots, Provider);
+    public ScreenplayGenerationOptions ToGenerationOptions() =>
+        new(Domain, Module, SkipSegments, ModulesFromNamespaceRoots, Provider)
+        {
+            TargetFramework = Framework
+        };
 }

--- a/Source/Cli/Commands/Screenplay/ProviderScreenplayGeneration.cs
+++ b/Source/Cli/Commands/Screenplay/ProviderScreenplayGeneration.cs
@@ -9,6 +9,7 @@ namespace Cratis.Cli.Commands.Screenplay;
 public sealed class ProviderScreenplayGeneration : IScreenplayGeneration
 {
     readonly IReadOnlyList<IScreenplaySourceProvider> _providers;
+    readonly Func<string, string?, CancellationToken, Task<LoadedCompilation>> _load;
 
     /// <summary>
     /// Initializes generation with every allowlisted provider bundled into this CLI build.
@@ -19,8 +20,19 @@ public sealed class ProviderScreenplayGeneration : IScreenplayGeneration
     }
 
     internal ProviderScreenplayGeneration(IReadOnlyList<IScreenplaySourceProvider> providers)
+        : this(
+            providers,
+            static (targetPath, targetFramework, cancellationToken) =>
+                ScreenplayCompilationLoader.Load(targetPath, includeAllProjects: true, targetFramework, cancellationToken))
+    {
+    }
+
+    internal ProviderScreenplayGeneration(
+        IReadOnlyList<IScreenplaySourceProvider> providers,
+        Func<string, string?, CancellationToken, Task<LoadedCompilation>> load)
     {
         _providers = providers;
+        _load = load;
     }
 
     /// <inheritdoc/>
@@ -38,13 +50,13 @@ public sealed class ProviderScreenplayGeneration : IScreenplayGeneration
             return InvalidProvider(requested, targetPath);
         }
 
-        var loaded = await ScreenplayCompilationLoader.Load(targetPath, includeAllProjects: true, cancellationToken);
+        var loaded = await _load(targetPath, options.TargetFramework, cancellationToken);
         if (loaded.Compilations.Count == 0)
         {
             return new GeneratedScreenplay(string.Empty, loaded.Diagnostics)
             {
                 Projects = loaded.ProjectNames,
-                Provenance = explicitProvider is null
+                Provenance = explicitProvider is null || loaded.Diagnostics.Any(IsTargetFrameworkSelectionError)
                     ? null
                     : new ScreenplayGenerationProvenance(explicitProvider.Name, explicitProvider.Version, loaded.ProjectProvenance, null)
             };
@@ -124,6 +136,10 @@ public sealed class ProviderScreenplayGeneration : IScreenplayGeneration
                 $"Solution contains several deployable application hosts: {string.Join(", ", hosts)}. Target one .csproj explicitly",
                 targetPath);
     }
+
+    static bool IsTargetFrameworkSelectionError(ScreenplayDiagnostic diagnostic) =>
+        string.Equals(diagnostic.Code, ScreenplayDiagnosticCodes.AmbiguousTargetFramework, StringComparison.Ordinal) ||
+        string.Equals(diagnostic.Code, ScreenplayDiagnosticCodes.UnavailableTargetFramework, StringComparison.Ordinal);
 
     string ProviderNames() => string.Join(", ", _providers.Select(_ => _.Name).Order(StringComparer.Ordinal));
 

--- a/Source/Cli/Commands/Screenplay/ScreenplayCompilationLoader.cs
+++ b/Source/Cli/Commands/Screenplay/ScreenplayCompilationLoader.cs
@@ -47,7 +47,7 @@ public static class ScreenplayCompilationLoader
     /// <returns>The <see cref="LoadedCompilation"/> describing the outcome.</returns>
     [MethodImpl(MethodImplOptions.NoInlining)]
     public static Task<LoadedCompilation> Load(string targetPath, CancellationToken cancellationToken) =>
-        Load(targetPath, includeAllProjects: false, cancellationToken);
+        Load(targetPath, includeAllProjects: false, targetFramework: null, cancellationToken);
 
     /// <summary>
     /// Loads the given solution or project and optionally retains every non-spec C# project for provider analysis.
@@ -57,19 +57,51 @@ public static class ScreenplayCompilationLoader
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The <see cref="LoadedCompilation"/> describing the outcome.</returns>
     [MethodImpl(MethodImplOptions.NoInlining)]
-    public static async Task<LoadedCompilation> Load(
+    public static Task<LoadedCompilation> Load(
         string targetPath,
         bool includeAllProjects,
+        CancellationToken cancellationToken) =>
+        Load(targetPath, includeAllProjects, targetFramework: null, cancellationToken);
+
+    /// <summary>
+    /// Loads the given solution or project for the requested target framework.
+    /// </summary>
+    /// <param name="targetPath">The full path of the solution or project file.</param>
+    /// <param name="targetFramework">The target framework to load from multi-targeted projects.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The <see cref="LoadedCompilation"/> describing the outcome.</returns>
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    internal static Task<LoadedCompilation> Load(
+        string targetPath,
+        string? targetFramework,
+        CancellationToken cancellationToken) =>
+        Load(targetPath, includeAllProjects: false, targetFramework, cancellationToken);
+
+    /// <summary>
+    /// Loads the given solution or project for the requested target framework and optionally retains every non-spec
+    /// C# project for provider analysis.
+    /// </summary>
+    /// <param name="targetPath">The full path of the solution or project file.</param>
+    /// <param name="includeAllProjects">Whether solution projects should bypass Arc-specific artifact filtering.</param>
+    /// <param name="targetFramework">The target framework to load from multi-targeted projects.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The <see cref="LoadedCompilation"/> describing the outcome.</returns>
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    internal static async Task<LoadedCompilation> Load(
+        string targetPath,
+        bool includeAllProjects,
+        string? targetFramework,
         CancellationToken cancellationToken)
     {
         RegisterMSBuild();
-        return await LoadWithWorkspace(targetPath, includeAllProjects, cancellationToken);
+        return await LoadWithWorkspace(targetPath, includeAllProjects, targetFramework, cancellationToken);
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
     static async Task<LoadedCompilation> LoadWithWorkspace(
         string targetPath,
         bool includeAllProjects,
+        string? targetFramework,
         CancellationToken cancellationToken)
     {
         var failures = new List<ScreenplayDiagnostic>();
@@ -93,18 +125,10 @@ public static class ScreenplayCompilationLoader
             ? (await workspace.OpenSolutionAsync(targetPath, cancellationToken: cancellationToken)).Projects
             : [await workspace.OpenProjectAsync(targetPath, cancellationToken: cancellationToken)];
 
-        // A multi-targeted project is opened once per target framework and every result holds the same application,
-        // so the names are grouped without the framework each one carries and one of them is read.
-        var byName = projects
-            .Where(project => project.Language == LanguageNames.CSharp)
-            .GroupBy(project => ScreenplayProjectSelection.WithoutTargetFramework(project.Name), StringComparer.Ordinal)
-            .ToDictionary(
-                group => group.Key,
-                group => group.OrderBy(project => project.Name, StringComparer.Ordinal).First(),
-                StringComparer.Ordinal);
-
-        var narrowed = ScreenplayProjectSelection.Narrow(byName.Keys);
-        if (narrowed.Count == 0)
+        var candidates = projects
+            .Where(project => project.Language == LanguageNames.CSharp && !ScreenplayProjectSelection.IsSpecProject(project.Name))
+            .ToArray();
+        if (candidates.Length == 0)
         {
             return LoadedCompilation.Failed(
                 ScreenplayDiagnosticCodes.NoProject,
@@ -113,7 +137,21 @@ public static class ScreenplayCompilationLoader
                 failures);
         }
 
-        var selected = narrowed.Select(name => byName[name]).ToArray();
+        var frameworkSelection = ScreenplayTargetFrameworkSelector.Select(
+            candidates.Select(project => project.Name),
+            targetFramework,
+            targetPath);
+        if (!frameworkSelection.IsSuccessful)
+        {
+            return new LoadedCompilation(
+                [],
+                [],
+                [.. failures, .. frameworkSelection.Diagnostics]);
+        }
+
+        var selected = frameworkSelection.ProjectNames
+            .Select(name => candidates.First(project => string.Equals(project.Name, name, StringComparison.Ordinal)))
+            .ToArray();
 
         var unrestored = selected
             .Where(project => !ProjectRestoreState.IsRestored(project.FilePath, project.CompilationOutputInfo.AssemblyPath))

--- a/Source/Cli/Commands/Screenplay/ScreenplayDiagnosticCodes.cs
+++ b/Source/Cli/Commands/Screenplay/ScreenplayDiagnosticCodes.cs
@@ -80,4 +80,14 @@ public static class ScreenplayDiagnosticCodes
     /// A provider does not support a requested generation option and therefore leaves it unapplied.
     /// </summary>
     public const string UnsupportedGenerationOption = "CLI0014";
+
+    /// <summary>
+    /// A project targets several frameworks and no target framework was requested.
+    /// </summary>
+    public const string AmbiguousTargetFramework = "CLI0015";
+
+    /// <summary>
+    /// A requested target framework is not available for a multi-targeted project.
+    /// </summary>
+    public const string UnavailableTargetFramework = "CLI0016";
 }

--- a/Source/Cli/Commands/Screenplay/ScreenplayGenerationOptions.cs
+++ b/Source/Cli/Commands/Screenplay/ScreenplayGenerationOptions.cs
@@ -19,6 +19,12 @@ public record ScreenplayGenerationOptions(
     string Provider = ScreenplayProviders.Auto)
 {
     /// <summary>
+    /// Gets the target framework to load from multi-targeted projects; <see langword="null"/> requires an explicit
+    /// choice when a project targets several frameworks.
+    /// </summary>
+    public string? TargetFramework { get; init; }
+
+    /// <summary>
     /// Gets the options that leave every choice to the generator.
     /// </summary>
     public static ScreenplayGenerationOptions Default { get; } = new(null, null, null, Provider: ScreenplayProviders.Auto);

--- a/Source/Cli/Commands/Screenplay/ScreenplayTargetFrameworkSelector.cs
+++ b/Source/Cli/Commands/Screenplay/ScreenplayTargetFrameworkSelector.cs
@@ -1,0 +1,84 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Cli.Commands.Screenplay;
+
+internal static class ScreenplayTargetFrameworkSelector
+{
+    internal static ScreenplayTargetFrameworkSelection Select(
+        IEnumerable<string> projectNames,
+        string? requestedFramework,
+        string? location = null)
+    {
+        var selected = new List<string>();
+        var diagnostics = new List<ScreenplayDiagnostic>();
+        var requested = string.IsNullOrWhiteSpace(requestedFramework) ? null : requestedFramework;
+
+        foreach (var group in projectNames
+                     .GroupBy(ScreenplayProjectSelection.WithoutTargetFramework, StringComparer.Ordinal)
+                     .OrderBy(_ => _.Key, StringComparer.Ordinal))
+        {
+            var variants = group.Order(StringComparer.Ordinal).ToArray();
+            if (variants.Length == 1)
+            {
+                selected.Add(variants[0]);
+                continue;
+            }
+
+            var frameworks = variants
+                .Select(TargetFrameworkOf)
+                .OfType<string>()
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .Order(StringComparer.OrdinalIgnoreCase)
+                .ThenBy(_ => _, StringComparer.Ordinal)
+                .ToArray();
+            var available = string.Join(", ", frameworks);
+
+            if (requested is null)
+            {
+                diagnostics.Add(new ScreenplayDiagnostic(
+                    ScreenplayDiagnosticSeverity.Error,
+                    ScreenplayDiagnosticCodes.AmbiguousTargetFramework,
+                    $"Project '{group.Key}' targets multiple frameworks: {available}. Pass --framework <TFM> to select one",
+                    location));
+                continue;
+            }
+
+            var matching = variants.FirstOrDefault(
+                variant => string.Equals(TargetFrameworkOf(variant), requested, StringComparison.OrdinalIgnoreCase));
+            if (matching is null)
+            {
+                diagnostics.Add(new ScreenplayDiagnostic(
+                    ScreenplayDiagnosticSeverity.Error,
+                    ScreenplayDiagnosticCodes.UnavailableTargetFramework,
+                    $"Project '{group.Key}' does not target requested framework '{requested}'. Available target frameworks: {available}",
+                    location));
+                continue;
+            }
+
+            selected.Add(matching);
+        }
+
+        return new ScreenplayTargetFrameworkSelection(selected, diagnostics);
+    }
+
+    static string? TargetFrameworkOf(string projectName)
+    {
+        if (!projectName.EndsWith(')'))
+        {
+            return null;
+        }
+
+        var openingParenthesis = projectName.LastIndexOf('(');
+        return openingParenthesis > 0 && openingParenthesis < projectName.Length - 2
+            ? projectName[(openingParenthesis + 1)..^1]
+            : null;
+    }
+}
+
+internal sealed record ScreenplayTargetFrameworkSelection(
+    IReadOnlyList<string> ProjectNames,
+    IReadOnlyList<ScreenplayDiagnostic> Diagnostics)
+{
+    internal bool IsSuccessful => Diagnostics.Count == 0;
+}


### PR DESCRIPTION
# Summary

Screenplay generation now fails closed instead of silently choosing one compilation when MSBuild exposes several target-framework variants.

## Added

- Add `--framework <TFM>` for explicit multi-target project selection. (#87)
- Report stable `CLI0015` and `CLI0016` diagnostics before provider interpretation when target selection is ambiguous or unavailable. (#87)

## Changed

- Preserve single-target dependency projects while selecting the requested variant from each multi-target application project. (#87)
- Document target-framework selection, provenance boundaries, and validation behavior. (#87)