### PR TITLE
Characterize atomic adapter migration boundaries

### DIFF
--- a/Documentation/reference/screenplay.md
+++ b/Documentation/reference/screenplay.md
@@ -17,6 +17,16 @@ Reads a solution or project, discovers the source providers bundled with this CL
 
 Auto detection chooses the most specific matching provider. For example, Critter Stack supersedes its Marten foundation when both Marten and Wolverine are present. If unrelated providers match, the CLI reports the candidates rather than guessing. Use `--provider` as an explicit override for mixed applications and reproducible CI.
 
+### Adapter composition architecture (decision, not implementation)
+
+The current CLI has a **one-provider model**. It matches one allowlisted provider for the whole application scope, asks that provider to select projects, and invokes one complete generator facade. The allowlist is compiled into the CLI; package restore, application output, configuration, and arbitrary plugins cannot add executable adapters. This compile-time boundary is the trust model for source interpretation.
+
+The current provider name does not always identify the adapter set that executes. Both `marten` and `critter-stack` invoke the complete `Cratis.CritterStack.Screenplay` facade, whose parameterless composition includes the Critter Stack and Vogen adapters. Conversely, the Arc facade does not compose the cross-cutting Vogen adapter. Provenance can therefore report `marten` while Wolverine evidence remains in scope and Vogen facts are generated, or report `arc` while Vogen package, assembly, and capability evidence is visible but Vogen facts are omitted. The resolved Generation graph contains adapter identities, but the CLI facade currently discards that graph and reports only provider-level provenance.
+
+The target architecture is an **atomic adapter roster** selected across the application scope. Framework profiles such as `marten` and `critter-stack` will select allowlisted adapters only; they will not own complete generation facades. Cross-cutting adapters such as Vogen can then compose with Arc, Marten, or Critter Stack before one neutral resolution and lowering pass. This target is a decision for the next production increments, not behavior implemented by this CLI version.
+
+Until that work lands, explicit `--provider` is selection-only in name but not in execution semantics: `--provider marten` bypasses auto detection, yet it neither removes Wolverine evidence nor disables the Vogen adapter inside the Critter Stack facade. Do not use it as proof of adapter isolation. The migration is tracked by [Screenplay.Generation #17](https://github.com/Cratis/Screenplay.Generation/issues/17), [CLI #87](https://github.com/Cratis/CLI/issues/87), and the [Critter Stack roadmap #29](https://github.com/Cratis/Screenplay.CritterStack/issues/29).
+
 By default the document goes to standard output, so it composes with the shell:
 
 ```bash

--- a/Source/Cli.Specs/for_CliNuGetPackage/when_packing_a_sentinel_package.cs
+++ b/Source/Cli.Specs/for_CliNuGetPackage/when_packing_a_sentinel_package.cs
@@ -3,6 +3,7 @@
 
 using System.Diagnostics;
 using System.IO.Compression;
+using System.Text.Json;
 using System.Xml.Linq;
 
 namespace Cratis.Cli.for_CliNuGetPackage;
@@ -15,6 +16,7 @@ public class when_packing_a_sentinel_package : Specification
     string _outputDirectory;
     XDocument _nuspec;
     XDocument _toolSettings;
+    JsonDocument _dependencies;
     string[] _packageEntries;
 
     void Establish() => _outputDirectory = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), $"cratis-cli-package-{Guid.NewGuid():N}")).FullName;
@@ -59,6 +61,7 @@ public class when_packing_a_sentinel_package : Specification
         _packageEntries = [.. archive.Entries.Select(entry => entry.FullName)];
         _nuspec = await ReadXml(archive, "Cratis.Cli.nuspec");
         _toolSettings = await ReadXml(archive, "tools/net10.0/any/DotnetToolSettings.xml");
+        _dependencies = await ReadJson(archive, "tools/net10.0/any/Cratis.Cli.deps.json");
     }
 
     [Fact]
@@ -89,8 +92,29 @@ public class when_packing_a_sentinel_package : Specification
         command.Attribute("Runner")?.Value.ShouldEqual("dotnet");
     }
 
+    [Fact]
+    void should_freeze_the_current_atomic_adapter_package_closure()
+    {
+        RelevantDependencyLibraries().ShouldContainOnly(
+        [
+            "Cratis.CritterStack.Screenplay/0.15.0",
+            "Cratis.Screenplay.Generation.Contracts/0.7.1",
+            "Cratis.Screenplay.Generation.DotNet.Vogen/0.7.1",
+            "Cratis.Screenplay.Generation.DotNet/0.7.1",
+            "Cratis.Screenplay.Generation/0.7.1"
+        ]);
+    }
+
+    [Fact]
+    void should_bundle_the_cratis_vogen_adapter_without_a_target_vogen_runtime() =>
+        _dependencies.RootElement.GetProperty("libraries").EnumerateObject()
+            .Select(library => library.Name)
+            .Any(library => library.StartsWith("Vogen/", StringComparison.Ordinal))
+            .ShouldBeFalse();
+
     void Destroy()
     {
+        _dependencies?.Dispose();
         if (Directory.Exists(_outputDirectory))
         {
             Directory.Delete(_outputDirectory, true);
@@ -102,12 +126,31 @@ public class when_packing_a_sentinel_package : Specification
     XElement MetadataElement(string name) =>
         _nuspec.Descendants().Single(element => element.Name.LocalName == name);
 
+    string[] RelevantDependencyLibraries() =>
+    [
+        .. _dependencies.RootElement.GetProperty("libraries").EnumerateObject()
+            .Select(library => library.Name)
+            .Where(library =>
+                library.StartsWith("Cratis.CritterStack.Screenplay/", StringComparison.Ordinal) ||
+                library.StartsWith("Cratis.Screenplay.Generation", StringComparison.Ordinal) ||
+                library.StartsWith("Vogen/", StringComparison.Ordinal))
+            .Order(StringComparer.Ordinal)
+    ];
+
     static async Task<XDocument> ReadXml(ZipArchive archive, string path)
     {
         var entry = archive.GetEntry(path) ?? throw new PackageMetadataVerificationFailed($"The sentinel package is missing '{path}'.");
         await using var stream = await entry.OpenAsync();
 
         return await XDocument.LoadAsync(stream, LoadOptions.None, CancellationToken.None);
+    }
+
+    static async Task<JsonDocument> ReadJson(ZipArchive archive, string path)
+    {
+        var entry = archive.GetEntry(path) ?? throw new PackageMetadataVerificationFailed($"The sentinel package is missing '{path}'.");
+        await using var stream = await entry.OpenAsync();
+
+        return await JsonDocument.ParseAsync(stream);
     }
 
     static string FindRepositoryRoot()

--- a/Source/Cli.Specs/for_ProviderScreenplayGeneration/given/an_application_scope.cs
+++ b/Source/Cli.Specs/for_ProviderScreenplayGeneration/given/an_application_scope.cs
@@ -1,0 +1,224 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.CritterStack.Screenplay;
+using Cratis.Screenplay.Generation;
+using Cratis.Screenplay.Generation.DotNet;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+
+namespace Cratis.Cli.for_ProviderScreenplayGeneration.given;
+
+public class an_application_scope : Specification
+{
+    protected static readonly string MartenSource = string.Join(
+        '\n',
+        [
+            "namespace Marten",
+            "{",
+            "    public interface IDocumentStore;",
+            "    public class StoreOptions",
+            "    {",
+            "        public Marten.Events.Projections.ProjectionOptions Projections { get; } = new();",
+            "    }",
+            "}",
+            "namespace Marten.Events.Projections",
+            "{",
+            "    public enum SnapshotLifecycle { Inline }",
+            "    public class ProjectionOptions",
+            "    {",
+            "        public void Snapshot<T>(SnapshotLifecycle lifecycle) { }",
+            "    }",
+            "}",
+            "namespace Banking",
+            "{",
+            "    public record AccountOpened(System.Guid AccountId);",
+            "    public class Account",
+            "    {",
+            "        public System.Guid Id { get; set; }",
+            "        public void Apply(AccountOpened opened) { }",
+            "    }",
+            "    public static class Configuration",
+            "    {",
+            "        public static void Configure(Marten.StoreOptions options) =>",
+            "            options.Projections.Snapshot<Account>(Marten.Events.Projections.SnapshotLifecycle.Inline);",
+            "    }",
+            "}"
+        ]);
+
+    protected static readonly string WolverineSource = string.Join(
+        '\n',
+        [
+            "namespace Wolverine",
+            "{",
+            "    public sealed class WolverineOptions;",
+            "}"
+        ]);
+
+    protected static readonly string VogenConceptSource = string.Join(
+        '\n',
+        [
+            "namespace Concepts",
+            "{",
+            "    [Vogen.ValueObject<System.Guid>]",
+            "    public partial struct OrderId;",
+            "}"
+        ]);
+
+    protected static readonly string ArcSource = string.Join(
+        '\n',
+        [
+            "namespace Cratis.Arc.Commands.ModelBound",
+            "{",
+            "    public sealed class CommandAttribute : System.Attribute;",
+            "}",
+            "namespace Cratis.Chronicle.Events",
+            "{",
+            "    public sealed class EventTypeAttribute : System.Attribute;",
+            "}",
+            "namespace Ordering.Placement",
+            "{",
+            "    [Cratis.Chronicle.Events.EventType]",
+            "    public record OrderPlaced(string Customer);",
+            string.Empty,
+            "    [Cratis.Arc.Commands.ModelBound.Command]",
+            "    public record PlaceOrder(string Customer);",
+            "}"
+        ]);
+
+    protected static readonly ResolvedScreenplayPackage[] MartenPackages =
+    [
+        new("Marten", "9.20.1")
+    ];
+
+    protected static readonly ResolvedScreenplayPackage[] CritterStackPackages =
+    [
+        new("Marten", "9.23.0"),
+        new("WolverineFx", "6.29.1"),
+        new("WolverineFx.Marten", "6.29.1")
+    ];
+
+    protected static readonly ResolvedScreenplayPackage[] VogenMartenPackages =
+    [
+        new("Marten", "9.29.0"),
+        new("Vogen", "8.0.7")
+    ];
+
+    protected static readonly ResolvedScreenplayPackage[] VogenCritterStackPackages =
+    [
+        new("Marten", "9.29.0"),
+        new("Vogen", "8.0.7"),
+        new("WolverineFx", "6.29.2")
+    ];
+
+    protected static project_source Project(
+        string name,
+        IReadOnlyList<ResolvedScreenplayPackage> packages,
+        bool referencesVogen,
+        params string[] sources) => new(name, packages, referencesVogen, sources);
+
+    protected static LoadedCompilation LoadedFrom(params project_source[] projects)
+    {
+        var compilations = projects.Select(CompilationFrom).ToArray();
+        return new LoadedCompilation(
+            compilations,
+            [.. projects.Select(project => project.Name)],
+            [])
+        {
+            AuthoredSyntaxTrees = [.. compilations.Select(compilation => compilation.SyntaxTrees.ToHashSet())],
+            ProjectProvenance =
+            [
+                .. projects.Select((project, index) => new ScreenplayProjectProvenance(
+                    project.Name,
+                    "net10.0",
+                    project.Packages,
+                    ScreenplayPackageProvenance.AssembliesFrom(compilations[index]),
+                    ScreenplayFrameworkCapabilities.From(compilations[index])))
+            ]
+        };
+    }
+
+    protected static async Task<GeneratedScreenplay> Generate(
+        LoadedCompilation loaded,
+        string provider = ScreenplayProviders.Auto,
+        string targetPath = "/workspace/Application.slnx")
+    {
+        var generation = new ProviderScreenplayGeneration(
+            ScreenplaySourceProviders.Default,
+            (_, _, _) => Task.FromResult(loaded));
+
+        return await generation.Generate(
+            targetPath,
+            Cratis.Cli.Commands.Screenplay.ScreenplayGenerationOptions.Default with { Provider = provider },
+            CancellationToken.None);
+    }
+
+    protected static GeneratedScreenplayDefinition GenerateWithCritterStackFacade(LoadedCompilation loaded) =>
+        new CritterStackScreenplayGenerator().Generate(
+            DotNetProjectsFrom(loaded),
+            new CritterStackScreenplayOptions { Domain = "Application" });
+
+    protected static IReadOnlyList<DotNetProjectCompilation> DotNetProjectsFrom(LoadedCompilation loaded) =>
+    [
+        .. loaded.Compilations.Select((compilation, index) => new DotNetProjectCompilation
+        {
+            Name = loaded.ProjectNames[index],
+            ProjectPath = $"/workspace/{loaded.ProjectNames[index]}/{loaded.ProjectNames[index]}.csproj",
+            SourceRoot = $"/workspace/{loaded.ProjectNames[index]}",
+            Compilation = compilation,
+            AuthoredSyntaxTrees = loaded.AuthoredSyntaxTrees[index]
+        })
+    ];
+
+    static Compilation CompilationFrom(project_source project)
+    {
+        var references = TrustedPlatformReferences().ToList();
+        if (project.ReferencesVogen)
+        {
+            references.Add(VogenMetadataReference());
+        }
+
+        return CSharpCompilation.Create(
+            project.Name,
+            [.. project.Sources.Select((source, index) => CSharpSyntaxTree.ParseText(source, path: $"/workspace/{project.Name}/{index}.cs"))],
+            references,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+    }
+
+    static MetadataReference VogenMetadataReference()
+    {
+        var source = string.Join(
+            '\n',
+            [
+                "[assembly: System.Reflection.AssemblyVersion(\"8.0.7.0\")]",
+                "namespace Vogen",
+                "{",
+                "    public sealed class ValueObjectAttribute : System.Attribute",
+                "    {",
+                "        public ValueObjectAttribute(System.Type underlyingType) { }",
+                "    }",
+                "    public sealed class ValueObjectAttribute<T> : System.Attribute;",
+                "}"
+            ]);
+        var compilation = CSharpCompilation.Create(
+            "Vogen",
+            [CSharpSyntaxTree.ParseText(source, path: "/metadata/Vogen.cs")],
+            TrustedPlatformReferences(),
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+        using var stream = new MemoryStream();
+        compilation.Emit(stream).Success.ShouldBeTrue();
+
+        return MetadataReference.CreateFromImage(stream.ToArray());
+    }
+
+    static IEnumerable<MetadataReference> TrustedPlatformReferences() =>
+        ((string)AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES")!)
+            .Split(Path.PathSeparator)
+            .Select(path => MetadataReference.CreateFromFile(path));
+
+    protected sealed record project_source(
+        string Name,
+        IReadOnlyList<ResolvedScreenplayPackage> Packages,
+        bool ReferencesVogen,
+        IReadOnlyList<string> Sources);
+}

--- a/Source/Cli.Specs/for_ProviderScreenplayGeneration/when_generating/with_arc_and_vogen.cs
+++ b/Source/Cli.Specs/for_ProviderScreenplayGeneration/when_generating/with_arc_and_vogen.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Cli.for_ProviderScreenplayGeneration.when_generating;
+
+/// <summary>
+/// Freezes the legacy omission: Arc selection retains Vogen provenance but its facade cannot compose Vogen facts.
+/// </summary>
+public class with_arc_and_vogen : given.an_application_scope
+{
+    GeneratedScreenplay _result = null!;
+
+    async Task Because() => _result = await Generate(
+        LoadedFrom(Project(
+            "Application",
+            [new ResolvedScreenplayPackage("Vogen", "8.0.7")],
+            true,
+            ArcSource,
+            VogenConceptSource)));
+
+    [Fact] void should_report_arc() => _result.Provenance!.Provider.ShouldEqual(ScreenplayProviders.Arc);
+    [Fact] void should_execute_the_arc_facade() => _result.Source.ShouldContain("command PlaceOrder");
+    [Fact] void should_omit_the_cross_cutting_vogen_concept_as_current_legacy_behavior() => _result.Source.ShouldNotContain("concept OrderId");
+    [Fact] void should_retain_vogen_capability_evidence_even_though_generation_omits_it() => _result.Provenance!.Projects.Single().Capabilities.ShouldContain("vogen.value-object");
+}

--- a/Source/Cli.Specs/for_ProviderScreenplayGeneration/when_generating/with_duplicate_project_names_and_qualified_subjects.cs
+++ b/Source/Cli.Specs/for_ProviderScreenplayGeneration/when_generating/with_duplicate_project_names_and_qualified_subjects.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Screenplay.Generation;
+
+namespace Cratis.Cli.for_ProviderScreenplayGeneration.when_generating;
+
+public class with_duplicate_project_names_and_qualified_subjects : given.an_application_scope
+{
+    string[] _forwardSubjects = [];
+    string[] _reversedSubjects = [];
+
+    void Because()
+    {
+        const string salesConcept = "namespace Sales { [Vogen.ValueObject<System.Guid>] public partial struct OrderId; }";
+        const string supportConcept = "namespace Support { [Vogen.ValueObject<System.Guid>] public partial struct OrderId; }";
+        var sales = Project("Shared", VogenMartenPackages, true, MartenSource, salesConcept);
+        var support = Project("Shared", [], true, supportConcept);
+
+        _forwardSubjects = SubjectsFrom(GenerateWithCritterStackFacade(LoadedFrom(sales, support)));
+        _reversedSubjects = SubjectsFrom(GenerateWithCritterStackFacade(LoadedFrom(support, sales)));
+    }
+
+    /// <summary>
+    /// Freezes the repeated Shared segment as legacy Generation 0.7.1 qualification, not the desired atomic-roster shape.
+    /// </summary>
+    [Fact] void should_repeat_the_duplicate_project_name_in_each_qualified_subject_as_current_legacy_behavior() => _forwardSubjects.ShouldContainOnly(["dotnet://Shared/Shared/Sales.OrderId", "dotnet://Shared/Shared/Support.OrderId"]);
+    [Fact] void should_resolve_the_same_subjects_when_duplicate_named_projects_are_reversed() => _reversedSubjects.ShouldContainOnly(_forwardSubjects);
+
+    static string[] SubjectsFrom(GeneratedScreenplayDefinition result) =>
+    [
+        .. result.Graph.ConceptRepresentations
+            .Select(representation => representation.Concept.Value)
+            .Order(StringComparer.Ordinal)
+    ];
+}

--- a/Source/Cli.Specs/for_ProviderScreenplayGeneration/when_generating/with_explicit_marten_and_wolverine_evidence.cs
+++ b/Source/Cli.Specs/for_ProviderScreenplayGeneration/when_generating/with_explicit_marten_and_wolverine_evidence.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Cli.for_ProviderScreenplayGeneration.when_generating;
+
+/// <summary>
+/// Freezes the legacy mismatch: explicit provider selection changes the reported profile, not the complete facade.
+/// </summary>
+public class with_explicit_marten_and_wolverine_evidence : given.an_application_scope
+{
+    GeneratedScreenplay _explicitResult = null!;
+    GeneratedScreenplay _autoResult = null!;
+
+    async Task Because()
+    {
+        var loaded = LoadedFrom(Project("Application", CritterStackPackages, false, MartenSource, WolverineSource));
+        _explicitResult = await Generate(loaded, ScreenplayProviders.Marten);
+        _autoResult = await Generate(loaded);
+    }
+
+    [Fact] void should_report_the_explicit_marten_profile() => _explicitResult.Provenance!.Provider.ShouldEqual(ScreenplayProviders.Marten);
+    [Fact] void should_keep_wolverine_evidence_under_the_marten_profile() => _explicitResult.Provenance!.Projects.Single().Packages.ShouldContain(new ResolvedScreenplayPackage("WolverineFx", "6.29.1"));
+    [Fact] void should_run_the_same_complete_critter_stack_facade_as_auto_selection() => _explicitResult.Source.ShouldEqual(_autoResult.Source);
+    [Fact] void should_document_that_auto_selection_reports_a_different_provider_for_the_same_output() => _autoResult.Provenance!.Provider.ShouldEqual(ScreenplayProviders.CritterStack);
+}

--- a/Source/Cli.Specs/for_ProviderScreenplayGeneration/when_generating/with_marten_and_wolverine_in_one_project.cs
+++ b/Source/Cli.Specs/for_ProviderScreenplayGeneration/when_generating/with_marten_and_wolverine_in_one_project.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Cli.for_ProviderScreenplayGeneration.when_generating;
+
+public class with_marten_and_wolverine_in_one_project : given.an_application_scope
+{
+    GeneratedScreenplay _result = null!;
+
+    async Task Because() => _result = await Generate(
+        LoadedFrom(Project("Application", CritterStackPackages, false, MartenSource, WolverineSource)));
+
+    [Fact] void should_report_critter_stack() => _result.Provenance!.Provider.ShouldEqual(ScreenplayProviders.CritterStack);
+    [Fact] void should_execute_the_complete_critter_stack_facade() => _result.Source.ShouldContain("reducer AccountSnapshot => Account");
+    [Fact] void should_keep_all_critter_stack_package_evidence() => _result.Provenance!.Projects.Single().Packages.ShouldContainOnly(CritterStackPackages);
+}

--- a/Source/Cli.Specs/for_ProviderScreenplayGeneration/when_generating/with_marten_and_wolverine_in_separate_projects.cs
+++ b/Source/Cli.Specs/for_ProviderScreenplayGeneration/when_generating/with_marten_and_wolverine_in_separate_projects.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Cli.for_ProviderScreenplayGeneration.when_generating;
+
+public class with_marten_and_wolverine_in_separate_projects : given.an_application_scope
+{
+    GeneratedScreenplay _result = null!;
+
+    async Task Because() => _result = await Generate(
+        LoadedFrom(
+            Project(
+                "Persistence",
+                [new ResolvedScreenplayPackage("Marten", "9.23.0"), new ResolvedScreenplayPackage("WolverineFx.Marten", "6.29.1")],
+                false,
+                MartenSource),
+            Project("Worker", [new ResolvedScreenplayPackage("WolverineFx", "6.29.1")], false, WolverineSource)));
+
+    [Fact] void should_report_critter_stack_for_the_application_scope() => _result.Provenance!.Provider.ShouldEqual(ScreenplayProviders.CritterStack);
+    [Fact] void should_execute_the_complete_facade_across_both_projects() => _result.Source.ShouldContain("reducer AccountSnapshot => Account");
+    [Fact] void should_report_both_projects() => _result.Projects.ShouldContainOnly(["Persistence", "Worker"]);
+    [Fact] void should_keep_each_projects_package_evidence_separate() => _result.Provenance!.Projects.Select(project => project.Packages.Count).ShouldContainOnly([2, 1]);
+}

--- a/Source/Cli.Specs/for_ProviderScreenplayGeneration/when_generating/with_marten_only.cs
+++ b/Source/Cli.Specs/for_ProviderScreenplayGeneration/when_generating/with_marten_only.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Cli.for_ProviderScreenplayGeneration.when_generating;
+
+public class with_marten_only : given.an_application_scope
+{
+    GeneratedScreenplay _result = null!;
+
+    async Task Because() => _result = await Generate(
+        LoadedFrom(Project("Persistence", MartenPackages, false, MartenSource)));
+
+    [Fact] void should_report_marten() => _result.Provenance!.Provider.ShouldEqual(ScreenplayProviders.Marten);
+    [Fact] void should_report_the_critter_stack_facade_version_as_the_marten_provider_version() => _result.Provenance!.ProviderVersion.ShouldEqual("0.15.0");
+    [Fact] void should_execute_the_complete_critter_stack_facade() => _result.Source.ShouldContain("reducer AccountSnapshot => Account");
+    [Fact] void should_report_only_marten_package_evidence() => _result.Provenance!.Projects.Single().Packages.ShouldContainOnly(MartenPackages);
+}

--- a/Source/Cli.Specs/for_ProviderScreenplayGeneration/when_generating/with_split_projects_in_reversed_order.cs
+++ b/Source/Cli.Specs/for_ProviderScreenplayGeneration/when_generating/with_split_projects_in_reversed_order.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Cli.for_ProviderScreenplayGeneration.when_generating;
+
+/// <summary>
+/// Characterizes the stable semantic output and the legacy loader-order project reporting separately.
+/// </summary>
+public class with_split_projects_in_reversed_order : given.an_application_scope
+{
+    GeneratedScreenplay _forward = null!;
+    GeneratedScreenplay _reversed = null!;
+
+    async Task Because()
+    {
+        var persistence = Project(
+            "Persistence",
+            [new ResolvedScreenplayPackage("Marten", "9.23.0"), new ResolvedScreenplayPackage("WolverineFx.Marten", "6.29.1")],
+            false,
+            MartenSource);
+        var worker = Project("Worker", [new ResolvedScreenplayPackage("WolverineFx", "6.29.1")], false, WolverineSource);
+        _forward = await Generate(LoadedFrom(persistence, worker));
+        _reversed = await Generate(LoadedFrom(worker, persistence));
+    }
+
+    [Fact] void should_select_critter_stack_in_both_orders() => _reversed.Provenance!.Provider.ShouldEqual(_forward.Provenance!.Provider);
+    [Fact] void should_generate_identical_semantic_output_in_both_orders() => _reversed.Source.ShouldEqual(_forward.Source);
+    [Fact] void should_preserve_loader_order_in_reported_projects_as_current_legacy_behavior() => _reversed.Projects.ShouldContainOnly(["Worker", "Persistence"]);
+}

--- a/Source/Cli.Specs/for_ProviderScreenplayGeneration/when_generating/with_unrelated_arc_and_marten_matches.cs
+++ b/Source/Cli.Specs/for_ProviderScreenplayGeneration/when_generating/with_unrelated_arc_and_marten_matches.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Cli.for_ProviderScreenplayGeneration.when_generating;
+
+public class with_unrelated_arc_and_marten_matches : given.an_application_scope
+{
+    GeneratedScreenplay _result = null!;
+
+    async Task Because() => _result = await Generate(
+        LoadedFrom(
+            Project("Arc", [], false, ArcSource),
+            Project("Persistence", MartenPackages, false, MartenSource)));
+
+    [Fact] void should_not_choose_a_provider() => _result.Provenance.ShouldBeNull();
+    [Fact] void should_not_execute_either_complete_facade() => _result.Source.ShouldBeEmpty();
+    [Fact] void should_report_ambiguous_unrelated_matches() => _result.Diagnostics.Single().Code.ShouldEqual(ScreenplayDiagnosticCodes.AmbiguousProviders);
+    [Fact] void should_name_arc_and_marten_in_stable_order() => _result.Diagnostics.Single().Message.ShouldContain("arc, marten");
+}

--- a/Source/Cli.Specs/for_ProviderScreenplayGeneration/when_generating/with_vogen_and_critter_stack.cs
+++ b/Source/Cli.Specs/for_ProviderScreenplayGeneration/when_generating/with_vogen_and_critter_stack.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Cli.for_ProviderScreenplayGeneration.when_generating;
+
+public class with_vogen_and_critter_stack : given.an_application_scope
+{
+    GeneratedScreenplay _result = null!;
+
+    async Task Because() => _result = await Generate(
+        LoadedFrom(Project(
+            "Application",
+            VogenCritterStackPackages,
+            true,
+            MartenSource,
+            WolverineSource,
+            VogenConceptSource)));
+
+    [Fact] void should_report_critter_stack() => _result.Provenance!.Provider.ShouldEqual(ScreenplayProviders.CritterStack);
+    [Fact] void should_execute_the_vogen_part_of_the_complete_facade() => _result.Source.ShouldContain("concept OrderId : Uuid");
+    [Fact] void should_execute_the_marten_part_of_the_complete_facade() => _result.Source.ShouldContain("reducer AccountSnapshot => Account");
+    [Fact] void should_keep_vogen_visible_as_resolved_application_evidence() => _result.Provenance!.Projects.Single().Packages.ShouldContain(new ResolvedScreenplayPackage("Vogen", "8.0.7"));
+}

--- a/Source/Cli.Specs/for_ProviderScreenplayGeneration/when_generating/with_vogen_and_critter_stack_resolved_evidence.cs
+++ b/Source/Cli.Specs/for_ProviderScreenplayGeneration/when_generating/with_vogen_and_critter_stack_resolved_evidence.cs
@@ -1,0 +1,44 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.CritterStack.Screenplay;
+using Cratis.Screenplay.Generation;
+using Cratis.Screenplay.Generation.DotNet.Vogen;
+
+namespace Cratis.Cli.for_ProviderScreenplayGeneration.when_generating;
+
+/// <summary>
+/// Reads the complete facade result directly because the CLI facade discards its resolved graph.
+/// </summary>
+public class with_vogen_and_critter_stack_resolved_evidence : given.an_application_scope
+{
+    GeneratedScreenplayDefinition _result = null!;
+    AdapterIdentity[] _adapterIdentities = [];
+
+    void Because()
+    {
+        _result = GenerateWithCritterStackFacade(
+            LoadedFrom(Project(
+                "Application",
+                VogenCritterStackPackages,
+                true,
+                MartenSource,
+                WolverineSource,
+                VogenConceptSource)));
+        _adapterIdentities =
+        [
+            .. _result.Graph.Artifacts
+                .SelectMany(artifact => artifact.Variants)
+                .SelectMany(variant => variant.Evidence)
+                .Concat(_result.Graph.ConceptRepresentations
+                    .SelectMany(representation => representation.Variants)
+                    .SelectMany(variant => variant.Evidence))
+                .Select(evidence => evidence.Adapter)
+                .Distinct()
+        ];
+    }
+
+    [Fact] void should_resolve_evidence_from_the_critter_stack_adapter() => _adapterIdentities.ShouldContain(new CritterStackScreenplayAdapter().Identity);
+    [Fact] void should_resolve_evidence_from_the_vogen_adapter() => _adapterIdentities.ShouldContain(new VogenConceptScreenplayAdapter().Identity);
+    [Fact] void should_expose_the_resolved_graph_only_from_the_complete_facade_result() => _result.Graph.Artifacts.ShouldNotBeEmpty();
+}

--- a/Source/Cli.Specs/for_ProviderScreenplayGeneration/when_generating/with_vogen_and_marten.cs
+++ b/Source/Cli.Specs/for_ProviderScreenplayGeneration/when_generating/with_vogen_and_marten.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Cli.for_ProviderScreenplayGeneration.when_generating;
+
+/// <summary>
+/// Freezes the legacy facade behavior: Vogen is not a selectable provider, but the Marten profile still runs it.
+/// </summary>
+public class with_vogen_and_marten : given.an_application_scope
+{
+    GeneratedScreenplay _result = null!;
+
+    async Task Because() => _result = await Generate(
+        LoadedFrom(Project("Application", VogenMartenPackages, true, MartenSource, VogenConceptSource)));
+
+    [Fact] void should_report_marten_without_naming_vogen_as_a_provider() => _result.Provenance!.Provider.ShouldEqual(ScreenplayProviders.Marten);
+    [Fact] void should_execute_the_hidden_vogen_adapter_inside_the_complete_critter_stack_facade() => _result.Source.ShouldContain("concept OrderId : Uuid");
+    [Fact] void should_expose_vogen_only_as_target_evidence() => _result.Provenance!.Projects.Single().Capabilities.ShouldContain("vogen.value-object");
+    [Fact] void should_report_the_target_vogen_assembly_identity() => _result.Provenance!.Projects.Single().Assemblies.ShouldContain(new ScreenplayAssemblyIdentity("Vogen", "8.0.7.0"));
+}


### PR DESCRIPTION
# Summary

Freeze the current provider, facade, adapter-evidence, project-order, and package-closure behavior before replacing complete providers with a compile-time atomic adapter roster. The documentation records which observations are legacy limitations rather than target behavior. (#95)