### PR TITLE
Take Generation 0.8 and Critter Stack 0.19

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -2,13 +2,13 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-    <CratisArcScreenplayVersion>22.0.0</CratisArcScreenplayVersion>
-    <CratisCritterStackScreenplayVersion>0.17.0</CratisCritterStackScreenplayVersion>
+    <CratisArcScreenplayVersion>22.1.0</CratisArcScreenplayVersion>
+    <CratisCritterStackScreenplayVersion>0.19.0</CratisCritterStackScreenplayVersion>
   </PropertyGroup>
   <ItemGroup>
     <!-- Cratis -->
-    <PackageVersion Include="Cratis.Arc.Screenplay" Version="22.1.0" />
-    <PackageVersion Include="Cratis.CritterStack.Screenplay" Version="0.19.0" />
+    <PackageVersion Include="Cratis.Arc.Screenplay" Version="$(CratisArcScreenplayVersion)" />
+    <PackageVersion Include="Cratis.CritterStack.Screenplay" Version="$(CratisCritterStackScreenplayVersion)" />
     <PackageVersion Include="Cratis.Screenplay.Generation.Contracts" Version="0.8.0" />
     <PackageVersion Include="Cratis.Screenplay.Generation" Version="0.8.0" />
     <PackageVersion Include="Cratis.Screenplay.Generation.DotNet" Version="0.8.0" />

--- a/Documentation/reference/screenplay.md
+++ b/Documentation/reference/screenplay.md
@@ -150,7 +150,7 @@ These values deliberately do not imply one another. A canonical package set can 
 
 ```text
 source compatibility:
-  provider: critter-stack 0.17.0
+  provider: critter-stack 0.19.0
   project: Helpdesk.Api (net9.0)
     packages: Marten 9.29.0, Vogen 8.0.7, WolverineFx 6.29.2
     assemblies: Marten 9.29.0.0, Vogen 8.0.7.0, Wolverine 6.29.2.0

--- a/Source/Cli.Specs/for_CliNuGetPackage/when_packing_a_sentinel_package.cs
+++ b/Source/Cli.Specs/for_CliNuGetPackage/when_packing_a_sentinel_package.cs
@@ -97,12 +97,12 @@ public class when_packing_a_sentinel_package : Specification
     {
         RelevantDependencyLibraries().ShouldContainOnly(
         [
-            "Cratis.Arc.Screenplay/22.0.0",
-            "Cratis.CritterStack.Screenplay/0.17.0",
-            "Cratis.Screenplay.Generation.Contracts/0.7.1",
-            "Cratis.Screenplay.Generation.DotNet.Vogen/0.7.1",
-            "Cratis.Screenplay.Generation.DotNet/0.7.1",
-            "Cratis.Screenplay.Generation/0.7.1"
+            "Cratis.Arc.Screenplay/22.1.0",
+            "Cratis.CritterStack.Screenplay/0.19.0",
+            "Cratis.Screenplay.Generation.Contracts/0.8.0",
+            "Cratis.Screenplay.Generation.DotNet.Vogen/0.8.0",
+            "Cratis.Screenplay.Generation.DotNet/0.8.0",
+            "Cratis.Screenplay.Generation/0.8.0"
         ]);
     }
 

--- a/Source/Cli.Specs/for_CritterStackScreenplayGeneration/when_generating/from_authored_vogen_metadata.cs
+++ b/Source/Cli.Specs/for_CritterStackScreenplayGeneration/when_generating/from_authored_vogen_metadata.cs
@@ -16,5 +16,8 @@ public class from_authored_vogen_metadata : given.a_vogen_critter_stack_applicat
     [Fact] void should_generate_the_non_generic_vogen_concept() => _result.Source.ShouldContain("concept CustomerCode : String");
     [Fact] void should_keep_critter_stack_command_evidence_separate() => _result.Source.ShouldContain("command PlaceOrder");
     [Fact] void should_use_critter_stack_persistence_evidence_for_identity() => _result.Source.ShouldContain("id OrderId");
-    [Fact] void should_keep_marten_lowering_evidence_separate() => _result.Diagnostics.Select(diagnostic => diagnostic.Code).ShouldContainOnly("MARTEN0003");
+    [Fact] void should_keep_document_and_unlowered_aggregate_evidence_separate() => _result.Diagnostics.Select(diagnostic => diagnostic.Code).ShouldContainOnly(
+        "MARTEN0003",
+        "GEN0004",
+        "GEN0004");
 }

--- a/Source/Cli.Specs/for_CritterStackScreenplayGeneration/when_generating/from_marten_source.cs
+++ b/Source/Cli.Specs/for_CritterStackScreenplayGeneration/when_generating/from_marten_source.cs
@@ -16,5 +16,10 @@ public class from_marten_source : given.a_marten_application_built_from_source
     [Fact] void should_generate_the_read_model() => _result.Source.ShouldContain("readmodel Account");
     [Fact] void should_generate_the_event() => _result.Source.ShouldContain("event AccountOpened");
     [Fact] void should_generate_the_reducer() => _result.Source.ShouldContain("reducer AccountSnapshot => Account");
-    [Fact] void should_report_no_diagnostics() => _result.Diagnostics.ShouldBeEmpty();
+    [Fact] void should_report_the_unlowered_aggregate_role() => _result.Diagnostics.ShouldContainOnly(
+        new ScreenplayDiagnostic(
+            ScreenplayDiagnosticSeverity.Warning,
+            "GEN0004",
+            "The recognized Aggregate artifact 'Account' cannot yet be represented by the Screenplay lowerer and was omitted",
+            "Account.cs"));
 }

--- a/Source/Cli.Specs/for_ProviderScreenplayGeneration/when_generating/with_duplicate_project_names_and_qualified_subjects.cs
+++ b/Source/Cli.Specs/for_ProviderScreenplayGeneration/when_generating/with_duplicate_project_names_and_qualified_subjects.cs
@@ -22,7 +22,7 @@ public class with_duplicate_project_names_and_qualified_subjects : given.an_appl
     }
 
     /// <summary>
-    /// Freezes the repeated Shared segment as legacy Generation 0.7.1 qualification, not the desired atomic-roster shape.
+    /// Freezes the repeated Shared segment as legacy complete-provider qualification, not the desired atomic-roster shape.
     /// </summary>
     [Fact] void should_repeat_the_duplicate_project_name_in_each_qualified_subject_as_current_legacy_behavior() => _forwardSubjects.ShouldContainOnly(["dotnet://Shared/Shared/Sales.OrderId", "dotnet://Shared/Shared/Support.OrderId"]);
     [Fact] void should_resolve_the_same_subjects_when_duplicate_named_projects_are_reversed() => _reversedSubjects.ShouldContainOnly(_forwardSubjects);

--- a/Source/Cli.Specs/for_ProviderScreenplayGeneration/when_generating/with_marten_only.cs
+++ b/Source/Cli.Specs/for_ProviderScreenplayGeneration/when_generating/with_marten_only.cs
@@ -11,7 +11,7 @@ public class with_marten_only : given.an_application_scope
         LoadedFrom(Project("Persistence", MartenPackages, false, MartenSource)));
 
     [Fact] void should_report_marten() => _result.Provenance!.Provider.ShouldEqual(ScreenplayProviders.Marten);
-    [Fact] void should_report_the_critter_stack_facade_version_as_the_marten_provider_version() => _result.Provenance!.ProviderVersion.ShouldEqual("0.17.0");
+    [Fact] void should_report_the_critter_stack_facade_version_as_the_marten_provider_version() => _result.Provenance!.ProviderVersion.ShouldEqual("0.19.0");
     [Fact] void should_execute_the_complete_critter_stack_facade() => _result.Source.ShouldContain("reducer AccountSnapshot => Account");
     [Fact] void should_report_only_marten_package_evidence() => _result.Provenance!.Projects.Single().Packages.ShouldContainOnly(MartenPackages);
 }

--- a/Source/Cli.Specs/for_ScreenplayCompatibility/when_assessing/and_the_critter_stack_package_set_is_canonical.cs
+++ b/Source/Cli.Specs/for_ScreenplayCompatibility/when_assessing/and_the_critter_stack_package_set_is_canonical.cs
@@ -15,7 +15,7 @@ public class and_the_critter_stack_package_set_is_canonical : given.compatibilit
             new ResolvedScreenplayPackage("WolverineFx.Marten", "6.29.1")));
 
     [Fact] void should_admit_generation() => _result.BlockingDiagnostic.ShouldBeNull();
-    [Fact] void should_report_the_bundled_provider_version() => _result.Provenance.ProviderVersion.ShouldEqual("0.17.0");
+    [Fact] void should_report_the_bundled_provider_version() => _result.Provenance.ProviderVersion.ShouldEqual("0.19.0");
     [Fact] void should_report_canonical_support() => _result.Provenance.Compatibility!.SupportTier.ShouldEqual(ScreenplaySupportTier.Canonical);
     [Fact] void should_keep_recognition_separate() => _result.Provenance.Compatibility!.RecognitionStatus.ShouldEqual(ScreenplayRecognitionStatus.Recognized);
     [Fact] void should_require_semantic_review() => _result.Provenance.Compatibility!.SemanticConformance.ShouldEqual(ScreenplaySemanticConformance.RequiresHumanReview);

--- a/Source/Cli.Specs/for_ScreenplayCompatibility/when_assessing/and_the_vogen_package_set_is_canonical.cs
+++ b/Source/Cli.Specs/for_ScreenplayCompatibility/when_assessing/and_the_vogen_package_set_is_canonical.cs
@@ -19,5 +19,5 @@ public class and_the_vogen_package_set_is_canonical : given.compatibility_eviden
     [Fact] void should_keep_package_recognition_separate() => _result.Provenance.Compatibility!.RecognitionStatus.ShouldEqual(ScreenplayRecognitionStatus.Recognized);
     [Fact] void should_keep_semantic_review_separate() => _result.Provenance.Compatibility!.SemanticConformance.ShouldEqual(ScreenplaySemanticConformance.RequiresHumanReview);
     [Fact] void should_not_claim_lowering_before_generation() => _result.Provenance.Compatibility!.LoweringFidelity.ShouldEqual(ScreenplayLoweringFidelity.NotEvaluated);
-    [Fact] void should_explain_the_exact_vogen_baseline() => _result.Provenance.Compatibility!.Explanation.ShouldContain("Vogen 8.0.7 matches a pinned canonical package set for bundled provider 0.17.0");
+    [Fact] void should_explain_the_exact_vogen_baseline() => _result.Provenance.Compatibility!.Explanation.ShouldContain("Vogen 8.0.7 matches a pinned canonical package set for bundled provider 0.19.0");
 }

--- a/Source/Cli.Specs/for_ScreenplayCompatibility/when_completing/and_vogen_lowering_reports_loss.cs
+++ b/Source/Cli.Specs/for_ScreenplayCompatibility/when_completing/and_vogen_lowering_reports_loss.cs
@@ -10,7 +10,7 @@ public class and_vogen_lowering_reports_loss : given.compatibility_evidence
     void Because()
     {
         var evaluation = ScreenplayCompatibility.Evaluate(
-            new a_provider(ScreenplayProviders.CritterStack, "0.17.0"),
+            new a_provider(ScreenplayProviders.CritterStack, "0.19.0"),
             LoadedWithVogenEvidence(
                 new ResolvedScreenplayPackage("Marten", "9.29.0"),
                 new ResolvedScreenplayPackage("Vogen", "8.0.7"),


### PR DESCRIPTION
# Summary

Update the installed source-to-Screenplay pipeline to the typed fail-closed Generation contracts and bounded DCB-enabled Critter Stack release. Keep provider metadata aligned with the dependency graph after the current Arc package update.

## Changed
- Update all four Screenplay Generation packages to 0.8.0 and Critter Stack Screenplay to 0.19.0. (#87)
- Preserve newly visible unsupported Aggregate roles as explicit `GEN0004` lowering loss instead of expecting silent omission. (#87)
- Report the actual Arc 22.1.0 and Critter Stack 0.19.0 provider versions in assembly metadata and package sentinels. (#87)