### PR TITLE
Adopt stable Screenplay source identity

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,10 +9,10 @@
     <!-- Cratis -->
     <PackageVersion Include="Cratis.Arc.Screenplay" Version="$(CratisArcScreenplayVersion)" />
     <PackageVersion Include="Cratis.CritterStack.Screenplay" Version="$(CratisCritterStackScreenplayVersion)" />
-    <PackageVersion Include="Cratis.Screenplay.Generation.Contracts" Version="0.8.0" />
-    <PackageVersion Include="Cratis.Screenplay.Generation" Version="0.8.0" />
-    <PackageVersion Include="Cratis.Screenplay.Generation.DotNet" Version="0.8.0" />
-    <PackageVersion Include="Cratis.Screenplay.Generation.DotNet.Vogen" Version="0.8.0" />
+    <PackageVersion Include="Cratis.Screenplay.Generation.Contracts" Version="0.9.0" />
+    <PackageVersion Include="Cratis.Screenplay.Generation" Version="0.9.0" />
+    <PackageVersion Include="Cratis.Screenplay.Generation.DotNet" Version="0.9.0" />
+    <PackageVersion Include="Cratis.Screenplay.Generation.DotNet.Vogen" Version="0.9.0" />
     <PackageVersion Include="Cratis.Chronicle.Connections" Version="16.37.1" />
     <PackageVersion Include="Cratis.Chronicle.Contracts" Version="16.37.1" />
     <PackageVersion Include="Cratis.Fundamentals" Version="7.18.1" />

--- a/Documentation/reference/screenplay.md
+++ b/Documentation/reference/screenplay.md
@@ -135,6 +135,7 @@ Every successful provider selection reports provenance on standard error, separa
 
 - the selected provider and bundled provider package version;
 - every selected project and target framework;
+- each project's relocation-safe source-path policy: logical workspace-relative project path, stable project identity, policy version, display root, and ordinal case policy;
 - resolved Marten/Wolverine NuGet package IDs and versions, plus the analyzed application's optional `Vogen` package, from that target's `project.assets.json`;
 - referenced framework assembly identities and versions as corroboration, including `Vogen` when the application references it;
 - exact metadata capability fingerprints found by Roslyn, including `vogen.value-object` when both value-object attribute shapes are available.
@@ -155,6 +156,9 @@ source compatibility:
     packages: Marten 9.29.0, Vogen 8.0.7, WolverineFx 6.29.2
     assemblies: Marten 9.29.0.0, Vogen 8.0.7.0, Wolverine 6.29.2.0
     capabilities: marten.event-projection, vogen.value-object, wolverine.handler-attribute
+    logical project: Source/Helpdesk.Api/Helpdesk.Api.csproj
+    project identity: Source/Helpdesk.Api/Helpdesk.Api
+    source policy: version 1, Workspace display root, Ordinal case policy
   support tier: Canonical
   recognition: Recognized
   semantic conformance: RequiresHumanReview
@@ -167,7 +171,9 @@ The CLI bundles `Cratis.CritterStack.Screenplay` and the separate `Cratis.Screen
 
 Generated Vogen members only corroborate an authored partial value-object declaration; they never establish one. The adapter does not infer identity from a `Guid` backing, an `Id`-shaped name, or generated members. Provider version, package recognition, semantic conformance, and lowering fidelity remain independent dimensions. In particular, a `VOG` diagnostic reports lowering loss without changing a canonical support tier or claiming semantic equivalence.
 
-Arc reports provider, target-framework, package, assembly, and capability provenance but continues to use its existing adapter compatibility contract rather than the Critter Stack support-tier matrix.
+Arc reports provider, target-framework, package, assembly, capability, and source-policy provenance but continues to use its existing adapter compatibility contract rather than the Critter Stack support-tier matrix.
+
+Source-policy provenance never includes the physical checkout root, absolute project path, or Roslyn syntax-tree path. Direct project generation displays source locations relative to the project; solution and workspace generation displays them relative to the workspace. Stable file identity always uses the logical workspace-relative project path without `.csproj` plus the document's project-relative logical path. This keeps provenance and generated source locations identical after moving a checkout.
 
 ### Marten and Critter Stack preview
 
@@ -212,6 +218,7 @@ The project does **not** have to have been built first. Sources MSBuild generate
 | A resolved Marten/Wolverine major, or Vogen major newer than 8, is newer than the highest source-reviewed generation | Validation error (`CLI0013`); compatibility is `Unsupported` and source interpretation does not start. |
 | `--modules-from-namespace-roots` is used with Marten or Critter Stack | Warning (`CLI0014`); generation continues without applying the option and lowering fidelity reports loss. |
 | A project cannot be read into a compilation | Validation error (`CLI0004`) naming it; the remaining projects are still described. |
+| A project or authored document has a rooted, traversing, outside-workspace, duplicate, or unmapped source path | Validation error (`CLI0017`) naming the project; no source is interpreted. |
 | Generation reports one or more errors, with `--file` | Validation error; the document is written anyway. |
 | Generation reports one or more errors, writing to standard output | Validation error; nothing is written. |
 

--- a/Source/Cli.Specs/for_ArcScreenplayGeneration/given/an_application_built_from_source.cs
+++ b/Source/Cli.Specs/for_ArcScreenplayGeneration/given/an_application_built_from_source.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Cratis.Screenplay.Generation.DotNet;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 
@@ -44,16 +45,40 @@ public class an_application_built_from_source : Specification
     /// <summary>
     /// Gets what loading the application would have produced.
     /// </summary>
-    protected LoadedCompilation Loaded { get; private set; }
+    protected LoadedCompilation Loaded { get; set; }
 
-    void Establish() => Loaded = new(
-        [CSharpCompilation.Create(
+    /// <summary>
+    /// Gets the source metadata aligned with the application compilation.
+    /// </summary>
+    protected ScreenplayProjectSource ProjectSource { get; private set; }
+
+    void Establish()
+    {
+        var compilation = CSharpCompilation.Create(
             ProjectName,
             [CSharpSyntaxTree.ParseText(Source)],
             References(),
-            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary))],
-        [ProjectName],
-        []);
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+        Loaded = new([compilation], [ProjectName], []);
+        ProjectSource = new(
+            $"/workspace/{ProjectName}/{ProjectName}.csproj",
+            $"{ProjectName}/{ProjectName}.csproj",
+            DotNetSourcePaths.Create(
+                ProjectName,
+                new DotNetSourcePathPolicy
+                {
+                    DisplayRoot = DotNetSourceDisplayRoot.Workspace,
+                    CasePolicy = DotNetSourcePathCasePolicy.Ordinal
+                },
+                [
+                    new DotNetSourceDocument
+                    {
+                        SyntaxTree = compilation.SyntaxTrees.Single(),
+                        ProjectRelativePath = "Application.cs",
+                        WorkspaceRelativePath = $"{ProjectName}/Application.cs"
+                    }
+                ]));
+    }
 
     /// <summary>
     /// Gets the references the source needs to compile.

--- a/Source/Cli.Specs/for_ArcScreenplayGeneration/when_generating/and_project_sources_are_extra.cs
+++ b/Source/Cli.Specs/for_ArcScreenplayGeneration/when_generating/and_project_sources_are_extra.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Cli.for_ArcScreenplayGeneration.when_generating;
+
+public class and_project_sources_are_extra : given.an_application_built_from_source
+{
+    GeneratedScreenplay _result;
+
+    void Establish() => Loaded = Loaded with
+    {
+        ProjectSources = [ProjectSource, ProjectSource]
+    };
+
+    void Because() => _result = ArcScreenplayGeneration.GenerateFrom(
+        Loaded,
+        $"{ProjectName}.csproj",
+        ScreenplayGenerationOptions.Default);
+
+    [Fact] void should_fail_closed() => _result.Source.ShouldBeEmpty();
+    [Fact] void should_report_the_stable_source_metadata_code() => _result.Diagnostics.Single().Code.ShouldEqual("CLI0018");
+    [Fact] void should_report_the_mismatched_counts() => _result.Diagnostics.Single().Message.ShouldContain("2 entries for 1 compilations");
+    [Fact] void should_preserve_the_loaded_project_name() => _result.Projects.ShouldContainOnly([ProjectName]);
+}

--- a/Source/Cli.Specs/for_ArcScreenplayGeneration/when_generating/and_project_sources_are_partial.cs
+++ b/Source/Cli.Specs/for_ArcScreenplayGeneration/when_generating/and_project_sources_are_partial.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Cli.for_ArcScreenplayGeneration.when_generating;
+
+public class and_project_sources_are_partial : given.an_application_built_from_source
+{
+    GeneratedScreenplay _result;
+
+    void Establish() => Loaded = Loaded with
+    {
+        Compilations = [.. Loaded.Compilations, Loaded.Compilations.Single()],
+        ProjectNames = [ProjectName, "Tooling"],
+        ProjectSources = [ProjectSource]
+    };
+
+    void Because() => _result = ArcScreenplayGeneration.GenerateFrom(
+        Loaded,
+        $"{ProjectName}.slnx",
+        ScreenplayGenerationOptions.Default);
+
+    [Fact] void should_fail_closed() => _result.Source.ShouldBeEmpty();
+    [Fact] void should_report_the_stable_source_metadata_code() => _result.Diagnostics.Single().Code.ShouldEqual("CLI0018");
+    [Fact] void should_report_the_mismatched_counts() => _result.Diagnostics.Single().Message.ShouldContain("1 entries for 2 compilations");
+    [Fact] void should_preserve_the_loaded_project_names() => _result.Projects.ShouldContainOnly([ProjectName, "Tooling"]);
+}

--- a/Source/Cli.Specs/for_ArcScreenplayGeneration/when_generating/with_exact_project_source_metadata.cs
+++ b/Source/Cli.Specs/for_ArcScreenplayGeneration/when_generating/with_exact_project_source_metadata.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Cli.for_ArcScreenplayGeneration.when_generating;
+
+public class with_exact_project_source_metadata : given.an_application_built_from_source
+{
+    GeneratedScreenplay _result;
+
+    void Establish() => Loaded = Loaded with
+    {
+        ProjectSources = [ProjectSource]
+    };
+
+    void Because() => _result = ArcScreenplayGeneration.GenerateFrom(
+        Loaded,
+        $"{ProjectName}.csproj",
+        ScreenplayGenerationOptions.Default);
+
+    [Fact] void should_generate_the_screenplay() => _result.Source.ShouldContain("command ReserveBook");
+    [Fact] void should_not_report_invalid_source_metadata() => _result.Diagnostics.Select(_ => _.Code).ShouldNotContain("CLI0018");
+    [Fact] void should_preserve_the_loaded_project_name() => _result.Projects.ShouldContainOnly([ProjectName]);
+}

--- a/Source/Cli.Specs/for_CliNuGetPackage/when_packing_a_sentinel_package.cs
+++ b/Source/Cli.Specs/for_CliNuGetPackage/when_packing_a_sentinel_package.cs
@@ -99,10 +99,10 @@ public class when_packing_a_sentinel_package : Specification
         [
             "Cratis.Arc.Screenplay/22.1.0",
             "Cratis.CritterStack.Screenplay/0.19.0",
-            "Cratis.Screenplay.Generation.Contracts/0.8.0",
-            "Cratis.Screenplay.Generation.DotNet.Vogen/0.8.0",
-            "Cratis.Screenplay.Generation.DotNet/0.8.0",
-            "Cratis.Screenplay.Generation/0.8.0"
+            "Cratis.Screenplay.Generation.Contracts/0.9.0",
+            "Cratis.Screenplay.Generation.DotNet.Vogen/0.9.0",
+            "Cratis.Screenplay.Generation.DotNet/0.9.0",
+            "Cratis.Screenplay.Generation/0.9.0"
         ]);
     }
 

--- a/Source/Cli.Specs/for_CritterStackScreenplayGeneration/given/a_marten_application_built_from_source.cs
+++ b/Source/Cli.Specs/for_CritterStackScreenplayGeneration/given/a_marten_application_built_from_source.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Cratis.Screenplay.Generation.DotNet;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 
@@ -46,6 +47,7 @@ public class a_marten_application_built_from_source : Specification
         ]);
 
     protected LoadedCompilation Loaded { get; set; } = null!;
+    protected ScreenplayProjectSource ProjectSource { get; private set; } = null!;
 
     void Establish()
     {
@@ -58,6 +60,24 @@ public class a_marten_application_built_from_source : Specification
         {
             AuthoredSyntaxTrees = [compilation.SyntaxTrees.ToHashSet()]
         };
+        ProjectSource = new(
+            "/workspace/Banking/Banking.csproj",
+            "Banking/Banking.csproj",
+            DotNetSourcePaths.Create(
+                ProjectName,
+                new DotNetSourcePathPolicy
+                {
+                    DisplayRoot = DotNetSourceDisplayRoot.Workspace,
+                    CasePolicy = DotNetSourcePathCasePolicy.Ordinal
+                },
+                [
+                    new DotNetSourceDocument
+                    {
+                        SyntaxTree = compilation.SyntaxTrees.Single(),
+                        ProjectRelativePath = "Account.cs",
+                        WorkspaceRelativePath = "Banking/Account.cs"
+                    }
+                ]));
     }
 
     static IEnumerable<MetadataReference> References() =>

--- a/Source/Cli.Specs/for_CritterStackScreenplayGeneration/when_generating/and_project_sources_are_extra.cs
+++ b/Source/Cli.Specs/for_CritterStackScreenplayGeneration/when_generating/and_project_sources_are_extra.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Cli.for_CritterStackScreenplayGeneration.when_generating;
+
+public class and_project_sources_are_extra : given.a_marten_application_built_from_source
+{
+    GeneratedScreenplay _result = null!;
+
+    void Establish() => Loaded = Loaded with
+    {
+        ProjectSources = [ProjectSource, ProjectSource]
+    };
+
+    void Because() => _result = CritterStackScreenplayGeneration.GenerateFrom(
+        Loaded,
+        "/workspace/Banking/Banking.csproj",
+        ScreenplayGenerationOptions.Default with { Provider = ScreenplayProviders.Marten });
+
+    [Fact] void should_fail_closed() => _result.Source.ShouldBeEmpty();
+    [Fact] void should_report_the_stable_source_metadata_code() => _result.Diagnostics.Single().Code.ShouldEqual("CLI0018");
+    [Fact] void should_report_the_mismatched_counts() => _result.Diagnostics.Single().Message.ShouldContain("2 entries for 1 compilations");
+    [Fact] void should_preserve_the_loaded_project_name() => _result.Projects.ShouldContainOnly([ProjectName]);
+}

--- a/Source/Cli.Specs/for_CritterStackScreenplayGeneration/when_generating/and_project_sources_are_partial.cs
+++ b/Source/Cli.Specs/for_CritterStackScreenplayGeneration/when_generating/and_project_sources_are_partial.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Cli.for_CritterStackScreenplayGeneration.when_generating;
+
+public class and_project_sources_are_partial : given.a_marten_application_built_from_source
+{
+    GeneratedScreenplay _result = null!;
+
+    void Establish() => Loaded = Loaded with
+    {
+        Compilations = [.. Loaded.Compilations, Loaded.Compilations.Single()],
+        ProjectNames = [ProjectName, "Reporting"],
+        ProjectSources = [ProjectSource]
+    };
+
+    void Because() => _result = CritterStackScreenplayGeneration.GenerateFrom(
+        Loaded,
+        "/workspace/Banking.slnx",
+        ScreenplayGenerationOptions.Default with { Provider = ScreenplayProviders.Marten });
+
+    [Fact] void should_fail_closed() => _result.Source.ShouldBeEmpty();
+    [Fact] void should_report_the_stable_source_metadata_code() => _result.Diagnostics.Single().Code.ShouldEqual("CLI0018");
+    [Fact] void should_report_the_mismatched_counts() => _result.Diagnostics.Single().Message.ShouldContain("1 entries for 2 compilations");
+    [Fact] void should_preserve_the_loaded_project_names() => _result.Projects.ShouldContainOnly([ProjectName, "Reporting"]);
+}

--- a/Source/Cli.Specs/for_CritterStackScreenplayGeneration/when_generating/with_exact_project_source_metadata.cs
+++ b/Source/Cli.Specs/for_CritterStackScreenplayGeneration/when_generating/with_exact_project_source_metadata.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Cli.for_CritterStackScreenplayGeneration.when_generating;
+
+public class with_exact_project_source_metadata : given.a_marten_application_built_from_source
+{
+    GeneratedScreenplay _result = null!;
+
+    void Establish() => Loaded = Loaded with
+    {
+        ProjectSources = [ProjectSource]
+    };
+
+    void Because() => _result = CritterStackScreenplayGeneration.GenerateFrom(
+        Loaded,
+        "/workspace/Banking/Banking.csproj",
+        ScreenplayGenerationOptions.Default with { Provider = ScreenplayProviders.Marten });
+
+    [Fact] void should_generate_the_screenplay() => _result.Source.ShouldContain("readmodel Account");
+    [Fact] void should_not_report_invalid_source_metadata() => _result.Diagnostics.Select(_ => _.Code).ShouldNotContain("CLI0018");
+    [Fact] void should_preserve_the_loaded_project_name() => _result.Projects.ShouldContainOnly([ProjectName]);
+}

--- a/Source/Cli.Specs/for_CritterStackScreenplayGeneration/when_mapping_projects/with_workspace_source_metadata.cs
+++ b/Source/Cli.Specs/for_CritterStackScreenplayGeneration/when_mapping_projects/with_workspace_source_metadata.cs
@@ -1,0 +1,49 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Screenplay.Generation.DotNet;
+
+namespace Cratis.Cli.for_CritterStackScreenplayGeneration.when_mapping_projects;
+
+public class with_workspace_source_metadata : given.a_marten_application_built_from_source
+{
+    const string ActualProjectPath = "/physical/checkout/Source/Banking/Banking.csproj";
+    DotNetProjectSourceContext _sourceContext;
+    IReadOnlyList<DotNetProjectCompilation> _result;
+
+    void Establish()
+    {
+        var syntaxTree = Loaded.Compilations[0].SyntaxTrees.Single();
+        _sourceContext = DotNetSourcePaths.Create(
+            "Source/Banking/Banking",
+            new DotNetSourcePathPolicy
+            {
+                DisplayRoot = DotNetSourceDisplayRoot.Workspace,
+                CasePolicy = DotNetSourcePathCasePolicy.Ordinal
+            },
+            [
+                new DotNetSourceDocument
+                {
+                    SyntaxTree = syntaxTree,
+                    ProjectRelativePath = "Account.cs",
+                    WorkspaceRelativePath = "Source/Banking/Account.cs"
+                }
+            ]);
+        Loaded = Loaded with
+        {
+            ProjectSources =
+            [
+                new ScreenplayProjectSource(
+                    ActualProjectPath,
+                    "Source/Banking/Banking.csproj",
+                    _sourceContext)
+            ]
+        };
+    }
+
+    void Because() => _result = CritterStackScreenplayGeneration.ProjectsFrom(Loaded, "/physical/checkout/Application.slnx");
+
+    [Fact] void should_pass_the_actual_project_path() => _result[0].ProjectPath.ShouldEqual(ActualProjectPath);
+    [Fact] void should_pass_the_source_context() => _result[0].SourceContext.ShouldEqual(_sourceContext);
+    [Fact] void should_keep_the_legacy_source_root_fallback() => _result[0].SourceRoot.ShouldEqual("/physical/checkout");
+}

--- a/Source/Cli.Specs/for_CritterStackScreenplayGeneration/when_mapping_projects/without_workspace_source_metadata.cs
+++ b/Source/Cli.Specs/for_CritterStackScreenplayGeneration/when_mapping_projects/without_workspace_source_metadata.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Screenplay.Generation.DotNet;
+
+namespace Cratis.Cli.for_CritterStackScreenplayGeneration.when_mapping_projects;
+
+public class without_workspace_source_metadata : given.a_marten_application_built_from_source
+{
+    IReadOnlyList<DotNetProjectCompilation> _result;
+
+    void Because() => _result = CritterStackScreenplayGeneration.ProjectsFrom(Loaded, "/workspace/Application.slnx");
+
+    [Fact] void should_keep_the_target_as_the_legacy_project_path() => _result[0].ProjectPath.ShouldEqual("/workspace/Application.slnx");
+    [Fact] void should_keep_the_legacy_source_root() => _result[0].SourceRoot.ShouldEqual("/workspace");
+    [Fact] void should_not_invent_a_source_context() => _result[0].SourceContext.ShouldBeNull();
+}

--- a/Source/Cli.Specs/for_ProviderScreenplayGeneration/given/an_application_scope.cs
+++ b/Source/Cli.Specs/for_ProviderScreenplayGeneration/given/an_application_scope.cs
@@ -117,6 +117,19 @@ public class an_application_scope : Specification
         bool referencesVogen,
         params string[] sources) => new(name, packages, referencesVogen, sources);
 
+    protected static ScreenplayProjectSource SourceFor(string project) =>
+        new(
+            $"/workspace/{project}/{project}.csproj",
+            $"{project}/{project}.csproj",
+            DotNetSourcePaths.Create(
+                $"{project}/{project}",
+                new DotNetSourcePathPolicy
+                {
+                    DisplayRoot = DotNetSourceDisplayRoot.Workspace,
+                    CasePolicy = DotNetSourcePathCasePolicy.Ordinal
+                },
+                []));
+
     protected static LoadedCompilation LoadedFrom(params project_source[] projects)
     {
         var compilations = projects.Select(CompilationFrom).ToArray();

--- a/Source/Cli.Specs/for_ProviderScreenplayGeneration/when_generating/and_project_sources_are_extra.cs
+++ b/Source/Cli.Specs/for_ProviderScreenplayGeneration/when_generating/and_project_sources_are_extra.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Cli.for_ProviderScreenplayGeneration.when_generating;
+
+public class and_project_sources_are_extra : given.an_application_scope
+{
+    GeneratedScreenplay _result;
+
+    async Task Because()
+    {
+        var loaded = LoadedFrom(Project("Application", [], false, ArcSource)) with
+        {
+            ProjectSources = [SourceFor("Application"), SourceFor("Duplicate")]
+        };
+
+        _result = await Generate(loaded, ScreenplayProviders.Arc);
+    }
+
+    [Fact] void should_fail_closed() => _result.Source.ShouldBeEmpty();
+    [Fact] void should_report_the_stable_source_metadata_code() => _result.Diagnostics.Single().Code.ShouldEqual("CLI0018");
+    [Fact] void should_report_the_mismatched_counts() => _result.Diagnostics.Single().Message.ShouldContain("2 entries for 1 compilations");
+    [Fact] void should_preserve_the_loaded_project_name() => _result.Projects.ShouldContainOnly(["Application"]);
+}

--- a/Source/Cli.Specs/for_ProviderScreenplayGeneration/when_generating/and_project_sources_are_partial.cs
+++ b/Source/Cli.Specs/for_ProviderScreenplayGeneration/when_generating/and_project_sources_are_partial.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Cli.for_ProviderScreenplayGeneration.when_generating;
+
+public class and_project_sources_are_partial : given.an_application_scope
+{
+    GeneratedScreenplay _result;
+
+    async Task Because()
+    {
+        var loaded = LoadedFrom(
+            Project("Application", [], false, ArcSource),
+            Project("Tooling", [], false, "public class Tooling;")) with
+        {
+            ProjectSources = [SourceFor("Application")]
+        };
+
+        _result = await Generate(loaded, ScreenplayProviders.Arc);
+    }
+
+    [Fact] void should_fail_closed() => _result.Source.ShouldBeEmpty();
+    [Fact] void should_report_the_stable_source_metadata_code() => _result.Diagnostics.Single().Code.ShouldEqual("CLI0018");
+    [Fact] void should_report_the_mismatched_counts() => _result.Diagnostics.Single().Message.ShouldContain("1 entries for 2 compilations");
+    [Fact] void should_preserve_the_loaded_project_names() => _result.Projects.ShouldContainOnly(["Application", "Tooling"]);
+}

--- a/Source/Cli.Specs/for_ProviderScreenplayGeneration/when_selecting/and_arc_excludes_non_artifact_provenance.cs
+++ b/Source/Cli.Specs/for_ProviderScreenplayGeneration/when_selecting/and_arc_excludes_non_artifact_provenance.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Cratis.Screenplay.Generation.DotNet;
 using Microsoft.CodeAnalysis.CSharp;
 
 namespace Cratis.Cli.for_ProviderScreenplayGeneration.when_selecting;
@@ -11,24 +12,37 @@ public class and_arc_excludes_non_artifact_provenance : given.provider_compilati
 
     void Because()
     {
-        var loaded = new LoadedCompilation(
-            [
-                CSharpCompilation.Create(
-                    "Application",
-                    [CSharpSyntaxTree.ParseText("namespace Cratis.Arc.Commands.ModelBound { public class CommandAttribute : System.Attribute; }")],
-                    References()),
-                CSharpCompilation.Create(
-                    "Tooling",
-                    [CSharpSyntaxTree.ParseText("public class Tooling;")],
-                    References())
-            ],
-            ["Application", "Tooling"],
-            [])
+        var application = CSharpCompilation.Create(
+            "Application",
+            [CSharpSyntaxTree.ParseText("namespace Cratis.Arc.Commands.ModelBound { public class CommandAttribute : System.Attribute; }")],
+            References());
+        var tooling = CSharpCompilation.Create(
+            "Tooling",
+            [CSharpSyntaxTree.ParseText("public class Tooling;")],
+            References());
+        var policy = new DotNetSourcePathPolicy
         {
+            DisplayRoot = DotNetSourceDisplayRoot.Workspace,
+            CasePolicy = DotNetSourcePathCasePolicy.Ordinal
+        };
+        var loaded = new LoadedCompilation([application, tooling], ["Application", "Tooling"], [])
+        {
+            AuthoredSyntaxTrees = [application.SyntaxTrees.ToHashSet(), tooling.SyntaxTrees.ToHashSet()],
             ProjectProvenance =
             [
                 new ScreenplayProjectProvenance("Application", "net9.0", [], [], []),
                 new ScreenplayProjectProvenance("Tooling", "net9.0", [], [], [])
+            ],
+            ProjectSources =
+            [
+                new ScreenplayProjectSource(
+                    "/physical/Application/Application.csproj",
+                    "Application/Application.csproj",
+                    DotNetSourcePaths.Create("Application/Application", policy, [])),
+                new ScreenplayProjectSource(
+                    "/physical/Tooling/Tooling.csproj",
+                    "Tooling/Tooling.csproj",
+                    DotNetSourcePaths.Create("Tooling/Tooling", policy, []))
             ]
         };
 
@@ -36,5 +50,7 @@ public class and_arc_excludes_non_artifact_provenance : given.provider_compilati
     }
 
     [Fact] void should_keep_only_the_project_arc_will_interpret() => _result.ProjectNames.ShouldContainOnly(["Application"]);
+    [Fact] void should_keep_only_the_matching_authored_trees() => _result.AuthoredSyntaxTrees.Single().Single().ShouldEqual(_result.Compilations.Single().SyntaxTrees.Single());
     [Fact] void should_keep_only_the_matching_project_provenance() => _result.ProjectProvenance.Select(_ => _.Project).ShouldContainOnly(["Application"]);
+    [Fact] void should_keep_only_the_matching_project_source() => _result.ProjectSources.Select(_ => _.LogicalProjectPath).ShouldContainOnly(["Application/Application.csproj"]);
 }

--- a/Source/Cli.Specs/for_ScreenplayDiagnosticsWriter/when_writing_json/and_provenance_is_available.cs
+++ b/Source/Cli.Specs/for_ScreenplayDiagnosticsWriter/when_writing_json/and_provenance_is_available.cs
@@ -7,11 +7,12 @@ namespace Cratis.Cli.for_ScreenplayDiagnosticsWriter.when_writing_json;
 
 public class and_provenance_is_available : Specification
 {
+    string _json;
     JsonElement _result;
 
     void Because()
     {
-        var json = ScreenplayDiagnosticsWriter.JsonFor(
+        _json = ScreenplayDiagnosticsWriter.JsonFor(
             OutputFormats.JsonCompact,
             [],
             new ScreenplayGenerationProvenance(
@@ -24,6 +25,14 @@ public class and_provenance_is_available : Specification
                         [new ResolvedScreenplayPackage("Marten", "9.23.0")],
                         [new ScreenplayAssemblyIdentity("Marten", "9.0.0.0")],
                         ["marten.event-projection"])
+                    {
+                        SourcePolicy = new ScreenplaySourcePolicyProvenance(
+                            "Source/Application/Application.csproj",
+                            "Source/Application/Application",
+                            1,
+                            "Workspace",
+                            "Ordinal")
+                    }
                 ],
                 new ScreenplayCompatibilityReport(
                     ScreenplaySupportTier.Canonical,
@@ -31,13 +40,17 @@ public class and_provenance_is_available : Specification
                     ScreenplaySemanticConformance.RequiresHumanReview,
                     ScreenplayLoweringFidelity.NoReportedLoss,
                     "canonical fixture evidence")));
-        _result = JsonDocument.Parse(json).RootElement.Clone();
+        _result = JsonDocument.Parse(_json).RootElement.Clone();
     }
 
     [Fact] void should_report_the_provider_version() => _result.GetProperty("provenance").GetProperty("providerVersion").GetString().ShouldEqual("0.3.0");
     [Fact] void should_report_the_selected_target_framework() => _result.GetProperty("provenance").GetProperty("projects")[0].GetProperty("targetFramework").GetString().ShouldEqual("net9.0");
     [Fact] void should_report_the_resolved_package_version() => _result.GetProperty("provenance").GetProperty("projects")[0].GetProperty("packages")[0].GetProperty("version").GetString().ShouldEqual("9.23.0");
     [Fact] void should_report_the_assembly_version_separately() => _result.GetProperty("provenance").GetProperty("projects")[0].GetProperty("assemblies")[0].GetProperty("version").GetString().ShouldEqual("9.0.0.0");
+    [Fact] void should_report_the_logical_project_path() => _result.GetProperty("provenance").GetProperty("projects")[0].GetProperty("sourcePolicy").GetProperty("logicalProjectPath").GetString().ShouldEqual("Source/Application/Application.csproj");
+    [Fact] void should_report_the_stable_project_identity() => _result.GetProperty("provenance").GetProperty("projects")[0].GetProperty("sourcePolicy").GetProperty("projectIdentity").GetString().ShouldEqual("Source/Application/Application");
+    [Fact] void should_report_the_source_policy_only() => _result.GetProperty("provenance").GetProperty("projects")[0].GetProperty("sourcePolicy").EnumerateObject().Select(_ => _.Name).ShouldContainOnly(["logicalProjectPath", "projectIdentity", "policyVersion", "displayRoot", "casePolicy"]);
+    [Fact] void should_not_leak_a_physical_root() => _json.ShouldNotContain("/physical/");
     [Fact] void should_report_the_support_tier() => _result.GetProperty("provenance").GetProperty("compatibility").GetProperty("supportTier").GetString().ShouldEqual("Canonical");
     [Fact] void should_report_semantic_conformance_separately() => _result.GetProperty("provenance").GetProperty("compatibility").GetProperty("semanticConformance").GetString().ShouldEqual("RequiresHumanReview");
     [Fact] void should_report_lowering_fidelity_separately() => _result.GetProperty("provenance").GetProperty("compatibility").GetProperty("loweringFidelity").GetString().ShouldEqual("NoReportedLoss");

--- a/Source/Cli.Specs/for_ScreenplayDiagnosticsWriter/when_writing_text/and_source_policy_is_available.cs
+++ b/Source/Cli.Specs/for_ScreenplayDiagnosticsWriter/when_writing_text/and_source_policy_is_available.cs
@@ -1,0 +1,53 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Cli.for_ScreenplayDiagnosticsWriter.when_writing_text;
+
+[Collection(CliSpecsCollection.Name)]
+public class and_source_policy_is_available : Specification
+{
+    TextWriter _previousError;
+    StringWriter _error;
+    string _result;
+
+    void Establish()
+    {
+        _previousError = Console.Error;
+        _error = new StringWriter();
+        Console.SetError(_error);
+    }
+
+    void Because()
+    {
+        ScreenplayDiagnosticsWriter.Write(
+            OutputFormats.Plain,
+            [],
+            new ScreenplayGenerationProvenance(
+                ScreenplayProviders.CritterStack,
+                "0.19.0",
+                [
+                    new ScreenplayProjectProvenance("Application", "net10.0", [], [], [])
+                    {
+                        SourcePolicy = new ScreenplaySourcePolicyProvenance(
+                            "Source/Application/Application.csproj",
+                            "Source/Application/Application",
+                            1,
+                            "Workspace",
+                            "Ordinal")
+                    }
+                ],
+                null));
+        _result = _error.ToString();
+    }
+
+    [Fact] void should_report_the_logical_project() => _result.ShouldContain("logical project: Source/Application/Application.csproj");
+    [Fact] void should_report_the_stable_identity() => _result.ShouldContain("project identity: Source/Application/Application");
+    [Fact] void should_report_the_policy() => _result.ShouldContain("source policy: version 1, Workspace display root, Ordinal case policy");
+    [Fact] void should_not_report_a_physical_root() => _result.ShouldNotContain("/physical/");
+
+    void Destroy()
+    {
+        Console.SetError(_previousError);
+        _error.Dispose();
+    }
+}

--- a/Source/Cli.Specs/for_ScreenplayProjectSources/when_creating/from_a_direct_project.cs
+++ b/Source/Cli.Specs/for_ScreenplayProjectSources/when_creating/from_a_direct_project.cs
@@ -1,0 +1,65 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Screenplay.Generation.DotNet;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Cratis.Cli.for_ScreenplayProjectSources.when_creating;
+
+public class from_a_direct_project : Specification
+{
+    AdhocWorkspace _workspace;
+    string _projectPath;
+    ScreenplayProjectSource _source;
+    IReadOnlySet<SyntaxTree> _authoredSyntaxTrees;
+
+    void Establish() => _workspace = new AdhocWorkspace();
+
+    async Task Because()
+    {
+        var root = Path.Combine(Path.GetTempPath(), $"screenplay-direct-{Guid.NewGuid():N}");
+        _projectPath = Path.Combine(root, "Application.csproj");
+        var documentPath = Path.Combine(root, "Features", "PlaceOrder.cs");
+        var project = AddProject(_projectPath, documentPath, ["Features"]);
+        var compilation = await project.GetCompilationAsync() ?? throw new SourceFixtureCompilationFailed();
+
+        (_authoredSyntaxTrees, _source) = await ScreenplayProjectSources.Create(
+            project,
+            compilation,
+            root,
+            isSolution: false,
+            CancellationToken.None);
+    }
+
+    [Fact] void should_keep_the_actual_project_path_for_internal_propagation() => _source.ProjectPath.ShouldEqual(_projectPath);
+    [Fact] void should_use_a_relocation_safe_logical_project_path() => _source.LogicalProjectPath.ShouldEqual("Application.csproj");
+    [Fact] void should_derive_identity_without_the_project_extension() => _source.SourceContext.ProjectIdentity.ShouldEqual("Application");
+    [Fact] void should_use_the_project_display_root() => _source.SourceContext.Policy.DisplayRoot.ShouldEqual(DotNetSourceDisplayRoot.Project);
+    [Fact] void should_use_ordinal_case_policy() => _source.SourceContext.Policy.CasePolicy.ShouldEqual(DotNetSourcePathCasePolicy.Ordinal);
+    [Fact] void should_map_the_authored_tree_once() => _source.SourceContext.Files.Keys.ShouldContainOnly(_authoredSyntaxTrees);
+    [Fact] void should_display_the_document_from_its_logical_project_folder() => _source.SourceContext.Files.Values.Single().DisplayPath.ShouldEqual("Features/PlaceOrder.cs");
+    [Fact] void should_use_the_logical_project_path_for_file_identity() => _source.SourceContext.Files.Values.Single().Identity.Path.ShouldEqual("Features/PlaceOrder.cs");
+
+    void Destroy() => _workspace.Dispose();
+
+    Project AddProject(string projectPath, string documentPath, IReadOnlyList<string> folders)
+    {
+        var project = _workspace.AddProject(ProjectInfo.Create(
+            ProjectId.CreateNewId(),
+            VersionStamp.Create(),
+            "Application",
+            "Application",
+            LanguageNames.CSharp,
+            filePath: projectPath));
+        var solution = project.Solution.AddDocument(
+            DocumentId.CreateNewId(project.Id),
+            "PlaceOrder.cs",
+            SourceText.From("public record PlaceOrder;"),
+            folders,
+            documentPath);
+        return solution.GetProject(project.Id)!;
+    }
+}
+
+sealed class SourceFixtureCompilationFailed : Exception;

--- a/Source/Cli.Specs/for_ScreenplayProjectSources/when_creating/from_a_solution_with_a_linked_document.cs
+++ b/Source/Cli.Specs/for_ScreenplayProjectSources/when_creating/from_a_solution_with_a_linked_document.cs
@@ -1,0 +1,64 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Screenplay.Generation.DotNet;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Cratis.Cli.for_ScreenplayProjectSources.when_creating;
+
+public class from_a_solution_with_a_linked_document : Specification
+{
+    List<AdhocWorkspace> _workspaces;
+    ScreenplayProjectSource _first;
+    ScreenplayProjectSource _relocated;
+
+    void Establish() => _workspaces = [];
+
+    async Task Because()
+    {
+        _first = await SourceFrom(Path.Combine(Path.GetTempPath(), $"screenplay-solution-a-{Guid.NewGuid():N}"));
+        _relocated = await SourceFrom(Path.Combine(Path.GetTempPath(), $"screenplay-solution-b-{Guid.NewGuid():N}"));
+    }
+
+    [Fact] void should_use_the_workspace_display_root() => _first.SourceContext.Policy.DisplayRoot.ShouldEqual(DotNetSourceDisplayRoot.Workspace);
+    [Fact] void should_keep_the_workspace_relative_project_path() => _first.LogicalProjectPath.ShouldEqual("Source/Application/Application.csproj");
+    [Fact] void should_derive_identity_from_the_logical_project_path() => _first.SourceContext.ProjectIdentity.ShouldEqual("Source/Application/Application");
+    [Fact] void should_display_the_linked_document_from_the_workspace() => _first.SourceContext.Files.Values.Single().DisplayPath.ShouldEqual("Shared/PlaceOrder.cs");
+    [Fact] void should_identify_the_linked_document_from_folders_and_name() => _first.SourceContext.Files.Values.Single().Identity.Path.ShouldEqual("Links/SharedOrder.cs");
+    [Fact] void should_preserve_logical_metadata_after_relocation() => LogicalDescription(_relocated).ShouldEqual(LogicalDescription(_first));
+    [Fact] void should_change_only_the_internal_actual_project_path_after_relocation() => _relocated.ProjectPath.ShouldNotEqual(_first.ProjectPath);
+
+    void Destroy() => _workspaces.ForEach(workspace => workspace.Dispose());
+
+    async Task<ScreenplayProjectSource> SourceFrom(string root)
+    {
+        var workspace = new AdhocWorkspace();
+        _workspaces.Add(workspace);
+        var projectPath = Path.Combine(root, "Source", "Application", "Application.csproj");
+        var linkedPath = Path.Combine(root, "Shared", "PlaceOrder.cs");
+        var project = workspace.AddProject(ProjectInfo.Create(
+            ProjectId.CreateNewId(),
+            VersionStamp.Create(),
+            "Application",
+            "Application",
+            LanguageNames.CSharp,
+            filePath: projectPath));
+        var solution = project.Solution.AddDocument(
+            DocumentId.CreateNewId(project.Id),
+            "SharedOrder.cs",
+            SourceText.From("public record PlaceOrder;"),
+            ["Links"],
+            linkedPath);
+        project = solution.GetProject(project.Id)!;
+        var compilation = await project.GetCompilationAsync() ?? throw new SourceFixtureCompilationFailed();
+
+        return (await ScreenplayProjectSources.Create(project, compilation, root, isSolution: true, CancellationToken.None)).Source;
+    }
+
+    static string LogicalDescription(ScreenplayProjectSource source)
+    {
+        var file = source.SourceContext.Files.Values.Single();
+        return $"{source.LogicalProjectPath}|{source.SourceContext.ProjectIdentity}|{source.SourceContext.Policy.Version}|{source.SourceContext.Policy.DisplayRoot}|{source.SourceContext.Policy.CasePolicy}|{file.Identity}|{file.DisplayPath}";
+    }
+}

--- a/Source/Cli.Specs/for_ScreenplayProjectSources/when_creating/from_an_msbuild_workspace_with_a_linked_document_and_canonical_root_alias.cs
+++ b/Source/Cli.Specs/for_ScreenplayProjectSources/when_creating/from_an_msbuild_workspace_with_a_linked_document_and_canonical_root_alias.cs
@@ -3,7 +3,6 @@
 
 using System.Runtime.CompilerServices;
 using Microsoft.CodeAnalysis.MSBuild;
-using Xunit.Sdk;
 
 namespace Cratis.Cli.for_ScreenplayProjectSources.when_creating;
 
@@ -12,7 +11,7 @@ namespace Cratis.Cli.for_ScreenplayProjectSources.when_creating;
 /// </summary>
 /// <remarks>
 /// The host gate is intentional: non-macOS agents, or macOS hosts whose temporary path has no symbolic-link alias,
-/// cannot exercise the canonical-root mismatch and report this characterization as skipped rather than simulating it.
+/// cannot exercise the canonical-root mismatch, so this characterization makes no assertions rather than simulating it.
 /// </remarks>
 [Collection(CliSpecsCollection.Name)]
 public class from_an_msbuild_workspace_with_a_linked_document_and_canonical_root_alias : Specification
@@ -20,6 +19,7 @@ public class from_an_msbuild_workspace_with_a_linked_document_and_canonical_root
     string _aliasRoot;
     string _canonicalRoot;
     ScreenplayProjectSource _source;
+    bool _isApplicable;
 
     void Establish() => ScreenplayCompilationLoader.RegisterMSBuild();
 
@@ -28,12 +28,17 @@ public class from_an_msbuild_workspace_with_a_linked_document_and_canonical_root
     {
         if (!OperatingSystem.IsMacOS())
         {
-            throw SkipException.ForSkip("This characterization requires a macOS temporary-root alias");
+            return;
         }
 
         var aliasTemporaryRoot = Path.TrimEndingDirectorySeparator(Path.GetTempPath());
-        var canonicalTemporaryRoot = CanonicalTemporaryRootOf(aliasTemporaryRoot) ??
-            throw SkipException.ForSkip("The host temporary root does not expose a symbolic-link alias");
+        var canonicalTemporaryRoot = CanonicalTemporaryRootOf(aliasTemporaryRoot);
+        if (canonicalTemporaryRoot is null)
+        {
+            return;
+        }
+
+        _isApplicable = true;
 
         var fixture = $"screenplay-msbuild-{Guid.NewGuid():N}";
         _aliasRoot = Path.Combine(aliasTemporaryRoot, fixture);
@@ -70,9 +75,29 @@ public class from_an_msbuild_workspace_with_a_linked_document_and_canonical_root
             CancellationToken.None)).Source;
     }
 
-    [Fact] void should_map_the_canonical_project_through_the_alias_root() => _source.LogicalProjectPath.ShouldEqual("Source/Application/Application.csproj");
-    [Fact] void should_display_the_linked_document_from_the_workspace_root() => _source.SourceContext.Files.Values.Select(_ => _.DisplayPath).ShouldContain("Shared/PlaceOrder.cs");
-    [Fact] void should_preserve_the_linked_document_identity() => _source.SourceContext.Files.Values.Select(_ => _.Identity.Path).ShouldContain("Links/SharedOrder.cs");
+    [Fact] void should_map_the_canonical_project_through_the_alias_root()
+    {
+        if (_isApplicable)
+        {
+            _source.LogicalProjectPath.ShouldEqual("Source/Application/Application.csproj");
+        }
+    }
+
+    [Fact] void should_display_the_linked_document_from_the_workspace_root()
+    {
+        if (_isApplicable)
+        {
+            _source.SourceContext.Files.Values.Select(_ => _.DisplayPath).ShouldContain("Shared/PlaceOrder.cs");
+        }
+    }
+
+    [Fact] void should_preserve_the_linked_document_identity()
+    {
+        if (_isApplicable)
+        {
+            _source.SourceContext.Files.Values.Select(_ => _.Identity.Path).ShouldContain("Links/SharedOrder.cs");
+        }
+    }
 
     void Destroy()
     {

--- a/Source/Cli.Specs/for_ScreenplayProjectSources/when_creating/from_an_msbuild_workspace_with_a_linked_document_and_canonical_root_alias.cs
+++ b/Source/Cli.Specs/for_ScreenplayProjectSources/when_creating/from_an_msbuild_workspace_with_a_linked_document_and_canonical_root_alias.cs
@@ -1,0 +1,96 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Runtime.CompilerServices;
+using Microsoft.CodeAnalysis.MSBuild;
+using Xunit.Sdk;
+
+namespace Cratis.Cli.for_ScreenplayProjectSources.when_creating;
+
+/// <summary>
+/// Characterizes the macOS temporary-root alias through a real MSBuild workspace without naming either physical root.
+/// </summary>
+/// <remarks>
+/// The host gate is intentional: non-macOS agents, or macOS hosts whose temporary path has no symbolic-link alias,
+/// cannot exercise the canonical-root mismatch and report this characterization as skipped rather than simulating it.
+/// </remarks>
+[Collection(CliSpecsCollection.Name)]
+public class from_an_msbuild_workspace_with_a_linked_document_and_canonical_root_alias : Specification
+{
+    string _aliasRoot;
+    string _canonicalRoot;
+    ScreenplayProjectSource _source;
+
+    void Establish() => ScreenplayCompilationLoader.RegisterMSBuild();
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    async Task Because()
+    {
+        if (!OperatingSystem.IsMacOS())
+        {
+            throw SkipException.ForSkip("This characterization requires a macOS temporary-root alias");
+        }
+
+        var aliasTemporaryRoot = Path.TrimEndingDirectorySeparator(Path.GetTempPath());
+        var canonicalTemporaryRoot = CanonicalTemporaryRootOf(aliasTemporaryRoot) ??
+            throw SkipException.ForSkip("The host temporary root does not expose a symbolic-link alias");
+
+        var fixture = $"screenplay-msbuild-{Guid.NewGuid():N}";
+        _aliasRoot = Path.Combine(aliasTemporaryRoot, fixture);
+        _canonicalRoot = Path.Combine(canonicalTemporaryRoot, fixture);
+        var projectDirectory = Path.Combine(_canonicalRoot, "Source", "Application");
+        var sharedDirectory = Path.Combine(_canonicalRoot, "Shared");
+        Directory.CreateDirectory(projectDirectory);
+        Directory.CreateDirectory(sharedDirectory);
+        var projectPath = Path.Combine(projectDirectory, "Application.csproj");
+        await File.WriteAllTextAsync(
+            projectPath,
+            string.Join(
+                Environment.NewLine,
+                [
+                    "<Project Sdk=\"Microsoft.NET.Sdk\">",
+                    "  <PropertyGroup>",
+                    "    <TargetFramework>net10.0</TargetFramework>",
+                    "  </PropertyGroup>",
+                    "  <ItemGroup>",
+                    "    <Compile Include=\"../../Shared/PlaceOrder.cs\" Link=\"Links/SharedOrder.cs\" />",
+                    "  </ItemGroup>",
+                    "</Project>"
+                ]));
+        await File.WriteAllTextAsync(Path.Combine(sharedDirectory, "PlaceOrder.cs"), "public record PlaceOrder;");
+
+        using var workspace = MSBuildWorkspace.Create();
+        var project = await workspace.OpenProjectAsync(projectPath);
+        var compilation = await project.GetCompilationAsync() ?? throw new SourceFixtureCompilationFailed();
+        _source = (await ScreenplayProjectSources.Create(
+            project,
+            compilation,
+            _aliasRoot,
+            isSolution: true,
+            CancellationToken.None)).Source;
+    }
+
+    [Fact] void should_map_the_canonical_project_through_the_alias_root() => _source.LogicalProjectPath.ShouldEqual("Source/Application/Application.csproj");
+    [Fact] void should_display_the_linked_document_from_the_workspace_root() => _source.SourceContext.Files.Values.Select(_ => _.DisplayPath).ShouldContain("Shared/PlaceOrder.cs");
+    [Fact] void should_preserve_the_linked_document_identity() => _source.SourceContext.Files.Values.Select(_ => _.Identity.Path).ShouldContain("Links/SharedOrder.cs");
+
+    void Destroy()
+    {
+        if (!string.IsNullOrEmpty(_aliasRoot) && Directory.Exists(_aliasRoot))
+        {
+            Directory.Delete(_aliasRoot, recursive: true);
+        }
+    }
+
+    static string? CanonicalTemporaryRootOf(string aliasTemporaryRoot)
+    {
+        var root = Path.GetPathRoot(aliasTemporaryRoot)!;
+        var parts = aliasTemporaryRoot[root.Length..].Split(
+            [Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar],
+            StringSplitOptions.RemoveEmptyEntries);
+        var target = new DirectoryInfo(Path.Combine(root, parts[0])).ResolveLinkTarget(returnFinalTarget: true);
+        return target is null
+            ? null
+            : parts.Skip(1).Aggregate(target.FullName, Path.Combine);
+    }
+}

--- a/Source/Cli.Specs/for_ScreenplayProjectSources/when_creating/with_invalid_paths.cs
+++ b/Source/Cli.Specs/for_ScreenplayProjectSources/when_creating/with_invalid_paths.cs
@@ -1,0 +1,109 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Cratis.Cli.for_ScreenplayProjectSources.when_creating;
+
+public class with_invalid_paths : Specification
+{
+    List<AdhocWorkspace> _workspaces;
+    Exception _rooted;
+    Exception _traversing;
+    Exception _outsideRoot;
+    Exception _duplicate;
+    Exception _unmapped;
+
+    void Establish() => _workspaces = [];
+
+    async Task Because()
+    {
+        _rooted = await FailureFrom([Path.DirectorySeparatorChar.ToString()], "Rooted.cs", "Rooted.cs");
+        _traversing = await FailureFrom([".."], "Traversing.cs", "Traversing.cs");
+        _outsideRoot = await FailureFrom([], "Outside.cs", Path.Combine("..", "Outside.cs"));
+        _duplicate = await DuplicateFailure();
+        _unmapped = await UnmappedFailure();
+    }
+
+    [Fact] void should_reject_a_rooted_logical_path() => _rooted.ShouldBeOfExactType<InvalidScreenplayProjectSource>();
+    [Fact] void should_reject_a_traversing_logical_path() => _traversing.ShouldBeOfExactType<InvalidScreenplayProjectSource>();
+    [Fact] void should_reject_a_document_outside_the_workspace_root() => _outsideRoot.ShouldBeOfExactType<InvalidScreenplayProjectSource>();
+    [Fact] void should_reject_a_duplicate_file_identity() => _duplicate.ShouldBeOfExactType<InvalidScreenplayProjectSource>();
+    [Fact] void should_reject_an_unmapped_authored_tree() => _unmapped.ShouldBeOfExactType<InvalidScreenplayProjectSource>();
+
+    void Destroy() => _workspaces.ForEach(workspace => workspace.Dispose());
+
+    async Task<Exception> FailureFrom(IReadOnlyList<string> folders, string name, string relativePhysicalPath)
+    {
+        var (project, root) = ProjectWithDocument(folders, name, relativePhysicalPath);
+        var compilation = await project.GetCompilationAsync() ?? throw new SourceFixtureCompilationFailed();
+        return await FailureFrom(project, compilation, root);
+    }
+
+    async Task<Exception> DuplicateFailure()
+    {
+        var (project, root) = ProjectWithDocument(["Links"], "Shared.cs", Path.Combine("Shared", "First.cs"));
+        var solution = project.Solution.AddDocument(
+            DocumentId.CreateNewId(project.Id),
+            "Shared.cs",
+            SourceText.From("public record Second;"),
+            ["Links"],
+            Path.Combine(root, "Shared", "Second.cs"));
+        project = solution.GetProject(project.Id)!;
+        var compilation = await project.GetCompilationAsync() ?? throw new SourceFixtureCompilationFailed();
+        return await FailureFrom(project, compilation, root);
+    }
+
+    async Task<Exception> UnmappedFailure()
+    {
+        var (project, root) = ProjectWithDocument([], "First.cs", "First.cs");
+        var compilation = await project.GetCompilationAsync() ?? throw new SourceFixtureCompilationFailed();
+        var solution = project.Solution.AddDocument(
+            DocumentId.CreateNewId(project.Id),
+            "Second.cs",
+            SourceText.From("public record Second;"),
+            filePath: Path.Combine(root, "Second.cs"));
+        project = solution.GetProject(project.Id)!;
+        return await FailureFrom(project, compilation, root);
+    }
+
+    async Task<Exception> FailureFrom(Project project, Compilation compilation, string root)
+    {
+        try
+        {
+            await ScreenplayProjectSources.Create(project, compilation, root, isSolution: true, CancellationToken.None);
+            return new SourcePathFailureWasNotReported();
+        }
+        catch (InvalidScreenplayProjectSource exception)
+        {
+            return exception;
+        }
+    }
+
+    (Project Project, string Root) ProjectWithDocument(
+        IReadOnlyList<string> folders,
+        string name,
+        string relativePhysicalPath)
+    {
+        var workspace = new AdhocWorkspace();
+        _workspaces.Add(workspace);
+        var root = Path.Combine(Path.GetTempPath(), $"screenplay-invalid-{Guid.NewGuid():N}");
+        var project = workspace.AddProject(ProjectInfo.Create(
+            ProjectId.CreateNewId(),
+            VersionStamp.Create(),
+            "Application",
+            "Application",
+            LanguageNames.CSharp,
+            filePath: Path.Combine(root, "Application.csproj")));
+        var solution = project.Solution.AddDocument(
+            DocumentId.CreateNewId(project.Id),
+            name,
+            SourceText.From("public record First;"),
+            folders,
+            Path.GetFullPath(relativePhysicalPath, root));
+        return (solution.GetProject(project.Id)!, root);
+    }
+}
+
+sealed class SourcePathFailureWasNotReported : Exception;

--- a/Source/Cli.Specs/for_ScreenplayWorkspaceProjectSelection/when_selecting/with_duplicate_project_names.cs
+++ b/Source/Cli.Specs/for_ScreenplayWorkspaceProjectSelection/when_selecting/with_duplicate_project_names.cs
@@ -1,0 +1,37 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.CodeAnalysis;
+
+namespace Cratis.Cli.for_ScreenplayWorkspaceProjectSelection.when_selecting;
+
+public class with_duplicate_project_names : Specification
+{
+    AdhocWorkspace _workspace;
+    IReadOnlyList<Project> _result;
+    IReadOnlyList<ScreenplayDiagnostic> _diagnostics;
+
+    void Establish() => _workspace = new AdhocWorkspace();
+
+    void Because()
+    {
+        var root = Path.Combine(Path.GetTempPath(), $"screenplay-duplicate-names-{Guid.NewGuid():N}");
+        var first = AddProject(Path.Combine(root, "First", "Shared.csproj"));
+        var second = AddProject(Path.Combine(root, "Second", "Shared.csproj"));
+        (_result, _diagnostics) = ScreenplayWorkspaceProjectSelection.Select([first, second], null, Path.Combine(root, "Application.slnx"));
+    }
+
+    [Fact] void should_keep_both_distinct_projects() => _result.Count.ShouldEqual(2);
+    [Fact] void should_keep_both_distinct_project_paths() => _result.Select(_ => _.FilePath).Distinct(StringComparer.Ordinal).Count().ShouldEqual(2);
+    [Fact] void should_not_treat_duplicate_names_as_target_framework_variants() => _diagnostics.ShouldBeEmpty();
+
+    void Destroy() => _workspace.Dispose();
+
+    Project AddProject(string filePath) => _workspace.AddProject(ProjectInfo.Create(
+        ProjectId.CreateNewId(),
+        VersionStamp.Create(),
+        "Shared",
+        Path.GetDirectoryName(filePath)!,
+        LanguageNames.CSharp,
+        filePath: filePath));
+}

--- a/Source/Cli/Commands/Screenplay/ArcScreenplayGeneration.cs
+++ b/Source/Cli/Commands/Screenplay/ArcScreenplayGeneration.cs
@@ -33,6 +33,11 @@ public sealed class ArcScreenplayGeneration : IScreenplayGeneration
     /// </remarks>
     internal static GeneratedScreenplay GenerateFrom(LoadedCompilation loaded, string targetPath, ScreenplayGenerationOptions options)
     {
+        if (loaded.ProjectSourceAlignmentFailureResultFor(targetPath) is { } alignmentFailure)
+        {
+            return alignmentFailure;
+        }
+
         if (loaded.Compilations.Count == 0)
         {
             return new GeneratedScreenplay(string.Empty, loaded.Diagnostics);

--- a/Source/Cli/Commands/Screenplay/CritterStackScreenplayGeneration.cs
+++ b/Source/Cli/Commands/Screenplay/CritterStackScreenplayGeneration.cs
@@ -34,6 +34,11 @@ public sealed class CritterStackScreenplayGeneration : IScreenplayGeneration
         string targetPath,
         ScreenplayGenerationOptions options)
     {
+        if (loaded.ProjectSourceAlignmentFailureResultFor(targetPath) is { } alignmentFailure)
+        {
+            return alignmentFailure;
+        }
+
         if (loaded.Compilations.Count == 0)
         {
             return new GeneratedScreenplay(string.Empty, loaded.Diagnostics);
@@ -48,19 +53,7 @@ public sealed class CritterStackScreenplayGeneration : IScreenplayGeneration
             };
         }
 
-        var sourceRoot = Path.GetDirectoryName(targetPath);
-        var projects = loaded.Compilations
-            .Select((compilation, index) => new DotNetProjectCompilation
-            {
-                Name = loaded.ProjectNames[index],
-                ProjectPath = targetPath,
-                SourceRoot = sourceRoot,
-                Compilation = compilation,
-                AuthoredSyntaxTrees = loaded.AuthoredSyntaxTrees.Count > index
-                    ? loaded.AuthoredSyntaxTrees[index]
-                    : new HashSet<Microsoft.CodeAnalysis.SyntaxTree>()
-            })
-            .ToArray();
+        var projects = ProjectsFrom(loaded, targetPath);
         var optionDiagnostics = options.ModulesFromNamespaceRoots
             ?
             [
@@ -86,6 +79,32 @@ public sealed class CritterStackScreenplayGeneration : IScreenplayGeneration
         {
             Projects = loaded.ProjectNames
         };
+    }
+
+    /// <summary>
+    /// Maps loaded compilations to the project contract consumed by the Critter Stack facade.
+    /// </summary>
+    /// <param name="loaded">The loaded compilations and aligned source metadata.</param>
+    /// <param name="targetPath">The originally targeted solution or project path.</param>
+    /// <returns>The project compilation contracts.</returns>
+    internal static IReadOnlyList<DotNetProjectCompilation> ProjectsFrom(LoadedCompilation loaded, string targetPath)
+    {
+        var sourceRoot = Path.GetDirectoryName(targetPath);
+        var projectSources = loaded.ProjectSources.Count == 0 ? null : loaded.ProjectSources;
+        return
+        [
+            .. loaded.Compilations.Select((compilation, index) => new DotNetProjectCompilation
+            {
+                Name = loaded.ProjectNames[index],
+                ProjectPath = projectSources is null ? targetPath : projectSources[index].ProjectPath,
+                SourceRoot = sourceRoot,
+                SourceContext = projectSources?[index].SourceContext,
+                Compilation = compilation,
+                AuthoredSyntaxTrees = loaded.AuthoredSyntaxTrees.Count > index
+                    ? loaded.AuthoredSyntaxTrees[index]
+                    : new HashSet<Microsoft.CodeAnalysis.SyntaxTree>()
+            })
+        ];
     }
 
     static IReadOnlyList<ScreenplayDiagnostic> SourceErrors(LoadedCompilation loaded) =>

--- a/Source/Cli/Commands/Screenplay/LoadedCompilation.cs
+++ b/Source/Cli/Commands/Screenplay/LoadedCompilation.cs
@@ -24,6 +24,11 @@ public record LoadedCompilation(IReadOnlyList<Compilation> Compilations, IReadOn
     public IReadOnlyList<ScreenplayProjectProvenance> ProjectProvenance { get; init; } = [];
 
     /// <summary>
+    /// Gets physical and relocation-safe logical source metadata in compilation order.
+    /// </summary>
+    public IReadOnlyList<ScreenplayProjectSource> ProjectSources { get; init; } = [];
+
+    /// <summary>
     /// Gets a failed outcome carrying a single error diagnostic.
     /// </summary>
     /// <param name="code">The stable diagnostic code.</param>
@@ -36,4 +41,28 @@ public record LoadedCompilation(IReadOnlyList<Compilation> Compilations, IReadOn
             [],
             [],
             [.. warnings ?? [], new ScreenplayDiagnostic(ScreenplayDiagnosticSeverity.Error, code, message, location)]);
+
+    /// <summary>
+    /// Gets the fail-closed diagnostic when project source metadata is not aligned with the compilations it describes.
+    /// </summary>
+    /// <param name="location">The solution or project the failure applies to.</param>
+    /// <returns>The alignment diagnostic, or <see langword="null"/> when metadata is absent or exactly aligned.</returns>
+    internal ScreenplayDiagnostic? ProjectSourceAlignmentFailureFor(string? location) =>
+        ProjectSources.Count is 0 || ProjectSources.Count == Compilations.Count
+            ? null
+            : new ScreenplayDiagnostic(
+                ScreenplayDiagnosticSeverity.Error,
+                ScreenplayDiagnosticCodes.InvalidSourceMetadata,
+                $"Project source metadata contains {ProjectSources.Count} entries for {Compilations.Count} compilations; it must be empty or contain exactly one entry per compilation",
+                location);
+
+    /// <summary>
+    /// Gets a fail-closed generation result when project source metadata is not aligned.
+    /// </summary>
+    /// <param name="location">The solution or project the failure applies to.</param>
+    /// <returns>The failed generation result, or <see langword="null"/> when metadata is absent or exactly aligned.</returns>
+    internal GeneratedScreenplay? ProjectSourceAlignmentFailureResultFor(string location) =>
+        ProjectSourceAlignmentFailureFor(location) is { } diagnostic
+            ? new GeneratedScreenplay(string.Empty, [.. Diagnostics, diagnostic]) { Projects = ProjectNames }
+            : null;
 }

--- a/Source/Cli/Commands/Screenplay/ProviderScreenplayGeneration.cs
+++ b/Source/Cli/Commands/Screenplay/ProviderScreenplayGeneration.cs
@@ -51,6 +51,11 @@ public sealed class ProviderScreenplayGeneration : IScreenplayGeneration
         }
 
         var loaded = await _load(targetPath, options.TargetFramework, cancellationToken);
+        if (loaded.ProjectSourceAlignmentFailureResultFor(targetPath) is { } alignmentFailure)
+        {
+            return alignmentFailure;
+        }
+
         if (loaded.Compilations.Count == 0)
         {
             return new GeneratedScreenplay(string.Empty, loaded.Diagnostics)

--- a/Source/Cli/Commands/Screenplay/ScreenplayCompilationLoader.cs
+++ b/Source/Cli/Commands/Screenplay/ScreenplayCompilationLoader.cs
@@ -137,11 +137,8 @@ public static class ScreenplayCompilationLoader
                 failures);
         }
 
-        var frameworkSelection = ScreenplayTargetFrameworkSelector.Select(
-            candidates.Select(project => project.Name),
-            targetFramework,
-            targetPath);
-        if (!frameworkSelection.IsSuccessful)
+        var frameworkSelection = ScreenplayWorkspaceProjectSelection.Select(candidates, targetFramework, targetPath);
+        if (frameworkSelection.Diagnostics.Count > 0)
         {
             return new LoadedCompilation(
                 [],
@@ -149,9 +146,7 @@ public static class ScreenplayCompilationLoader
                 [.. failures, .. frameworkSelection.Diagnostics]);
         }
 
-        var selected = frameworkSelection.ProjectNames
-            .Select(name => candidates.First(project => string.Equals(project.Name, name, StringComparison.Ordinal)))
-            .ToArray();
+        var selected = frameworkSelection.Projects;
 
         var unrestored = selected
             .Where(project => !ProjectRestoreState.IsRestored(project.FilePath, project.CompilationOutputInfo.AssemblyPath))
@@ -199,6 +194,8 @@ public static class ScreenplayCompilationLoader
         var names = new List<string>();
         var authoredSyntaxTrees = new List<IReadOnlySet<SyntaxTree>>();
         var projectProvenance = new List<ScreenplayProjectProvenance>();
+        var projectSources = new List<ScreenplayProjectSource>();
+        var workspaceRoot = Path.GetDirectoryName(targetPath)!;
 
         // A project that yields no compilation is left out of the document rather than ending the run, so that a
         // solution still describes the projects that did load - and is reported as an error, because a document
@@ -207,15 +204,6 @@ public static class ScreenplayCompilationLoader
 
         foreach (var loaded in selected)
         {
-            var authoredTrees = new HashSet<SyntaxTree>();
-            foreach (var document in loaded.Documents)
-            {
-                if (await document.GetSyntaxTreeAsync(cancellationToken) is { } syntaxTree)
-                {
-                    authoredTrees.Add(syntaxTree);
-                }
-            }
-
             var project = GeneratedResourceSources.AddMissingTo(loaded);
             var name = ScreenplayProjectSelection.WithoutTargetFramework(project.Name);
             var compilation = await project.GetCompilationAsync(cancellationToken);
@@ -236,17 +224,41 @@ public static class ScreenplayCompilationLoader
                 continue;
             }
 
+            (IReadOnlySet<SyntaxTree> AuthoredSyntaxTrees, ScreenplayProjectSource Source) sourceMapping;
+            try
+            {
+                sourceMapping = await ScreenplayProjectSources.Create(loaded, compilation, workspaceRoot, isSolution, cancellationToken);
+            }
+            catch (InvalidScreenplayProjectSource)
+            {
+                return LoadedCompilation.Failed(
+                    ScreenplayDiagnosticCodes.InvalidSourcePath,
+                    $"Source paths for project '{name}' cannot be mapped to stable portable identities",
+                    targetPath,
+                    [.. failures, .. unloadable]);
+            }
+
             var targetFramework = ScreenplayFrameworkReferences.TargetFrameworkOf(project);
             var assetsFile = ProjectRestoreState.AssetsFileFor(project.FilePath, project.CompilationOutputInfo.AssemblyPath);
+            var sourcePolicy = sourceMapping.Source.SourceContext.Policy;
             compilations.Add(compilation);
             names.Add(name);
-            authoredSyntaxTrees.Add(authoredTrees);
+            authoredSyntaxTrees.Add(sourceMapping.AuthoredSyntaxTrees);
+            projectSources.Add(sourceMapping.Source);
             projectProvenance.Add(new ScreenplayProjectProvenance(
                 name,
                 targetFramework,
                 ScreenplayPackageProvenance.PackagesFrom(assetsFile, targetFramework),
                 ScreenplayPackageProvenance.AssembliesFrom(compilation),
-                ScreenplayFrameworkCapabilities.From(compilation)));
+                ScreenplayFrameworkCapabilities.From(compilation))
+            {
+                SourcePolicy = new ScreenplaySourcePolicyProvenance(
+                    sourceMapping.Source.LogicalProjectPath,
+                    sourceMapping.Source.SourceContext.ProjectIdentity,
+                    sourcePolicy.Version,
+                    sourcePolicy.DisplayRoot.ToString(),
+                    sourcePolicy.CasePolicy.ToString())
+            });
         }
 
         if (compilations.Count == 0)
@@ -267,7 +279,8 @@ public static class ScreenplayCompilationLoader
         return new LoadedCompilation(compilations, names, [.. failures, .. unloadable])
         {
             AuthoredSyntaxTrees = authoredSyntaxTrees,
-            ProjectProvenance = projectProvenance
+            ProjectProvenance = projectProvenance,
+            ProjectSources = projectSources
         };
     }
 }

--- a/Source/Cli/Commands/Screenplay/ScreenplayDiagnosticCodes.cs
+++ b/Source/Cli/Commands/Screenplay/ScreenplayDiagnosticCodes.cs
@@ -90,4 +90,14 @@ public static class ScreenplayDiagnosticCodes
     /// A requested target framework is not available for a multi-targeted project.
     /// </summary>
     public const string UnavailableTargetFramework = "CLI0016";
+
+    /// <summary>
+    /// Workspace source paths cannot be represented as safe, stable project and display identities.
+    /// </summary>
+    public const string InvalidSourcePath = "CLI0017";
+
+    /// <summary>
+    /// Project source metadata is neither absent for legacy callers nor aligned one-to-one with loaded compilations.
+    /// </summary>
+    public const string InvalidSourceMetadata = "CLI0018";
 }

--- a/Source/Cli/Commands/Screenplay/ScreenplayDiagnosticsWriter.cs
+++ b/Source/Cli/Commands/Screenplay/ScreenplayDiagnosticsWriter.cs
@@ -117,7 +117,17 @@ public static class ScreenplayDiagnosticsWriter
                         project.TargetFramework,
                         project.Packages,
                         project.Assemblies,
-                        project.Capabilities
+                        project.Capabilities,
+                        SourcePolicy = project.SourcePolicy is null
+                            ? null
+                            : new
+                            {
+                                project.SourcePolicy.LogicalProjectPath,
+                                project.SourcePolicy.ProjectIdentity,
+                                project.SourcePolicy.PolicyVersion,
+                                project.SourcePolicy.DisplayRoot,
+                                project.SourcePolicy.CasePolicy
+                            }
                     }),
                     Compatibility = provenance.Compatibility is null
                         ? null
@@ -181,6 +191,12 @@ public static class ScreenplayDiagnosticsWriter
             Console.Error.WriteLine($"    packages: {Describe(project.Packages.Select(package => $"{package.Id} {package.Version}"))}");
             Console.Error.WriteLine($"    assemblies: {Describe(project.Assemblies.Select(assembly => $"{assembly.Name} {assembly.Version}"))}");
             Console.Error.WriteLine($"    capabilities: {Describe(project.Capabilities)}");
+            if (project.SourcePolicy is { } sourcePolicy)
+            {
+                Console.Error.WriteLine($"    logical project: {sourcePolicy.LogicalProjectPath}");
+                Console.Error.WriteLine($"    project identity: {sourcePolicy.ProjectIdentity}");
+                Console.Error.WriteLine($"    source policy: version {sourcePolicy.PolicyVersion}, {sourcePolicy.DisplayRoot} display root, {sourcePolicy.CasePolicy} case policy");
+            }
         }
 
         if (provenance.Compatibility is { } compatibility)

--- a/Source/Cli/Commands/Screenplay/ScreenplayGenerationProvenance.cs
+++ b/Source/Cli/Commands/Screenplay/ScreenplayGenerationProvenance.cs
@@ -134,7 +134,13 @@ public record ScreenplayProjectProvenance(
     string? TargetFramework,
     IReadOnlyList<ResolvedScreenplayPackage> Packages,
     IReadOnlyList<ScreenplayAssemblyIdentity> Assemblies,
-    IReadOnlyList<string> Capabilities);
+    IReadOnlyList<string> Capabilities)
+{
+    /// <summary>
+    /// Gets the relocation-safe source-path policy used for this project, when supplied by the workspace host.
+    /// </summary>
+    public ScreenplaySourcePolicyProvenance? SourcePolicy { get; init; }
+}
 
 /// <summary>
 /// Represents compatibility evidence separately from recognition, semantic review, and lowering fidelity.

--- a/Source/Cli/Commands/Screenplay/ScreenplayProjectSource.cs
+++ b/Source/Cli/Commands/Screenplay/ScreenplayProjectSource.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Screenplay.Generation.DotNet;
+
+namespace Cratis.Cli.Commands.Screenplay;
+
+/// <summary>
+/// Represents the physical and logical source metadata for one loaded project compilation.
+/// </summary>
+/// <param name="ProjectPath">The actual project file path used internally when invoking source adapters.</param>
+/// <param name="LogicalProjectPath">The relocation-safe workspace-relative project path.</param>
+/// <param name="SourceContext">The stable source identity and display-path context.</param>
+public record ScreenplayProjectSource(
+    string ProjectPath,
+    string LogicalProjectPath,
+    DotNetProjectSourceContext SourceContext);

--- a/Source/Cli/Commands/Screenplay/ScreenplayProjectSources.cs
+++ b/Source/Cli/Commands/Screenplay/ScreenplayProjectSources.cs
@@ -1,0 +1,227 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Screenplay.Generation.DotNet;
+using Microsoft.CodeAnalysis;
+
+namespace Cratis.Cli.Commands.Screenplay;
+
+/// <summary>
+/// Creates stable source metadata for projects loaded through a Roslyn workspace.
+/// </summary>
+static class ScreenplayProjectSources
+{
+    /// <summary>
+    /// Creates the authored-tree set and source metadata for one project compilation.
+    /// </summary>
+    /// <param name="project">The workspace project.</param>
+    /// <param name="compilation">The final compilation adapters will analyze.</param>
+    /// <param name="workspaceRoot">The physical root used only while deriving relative paths.</param>
+    /// <param name="isSolution">Whether the workspace represents a solution.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The aligned authored trees and source metadata.</returns>
+    /// <exception cref="InvalidScreenplayProjectSource">Thrown when source paths cannot be mapped safely.</exception>
+    internal static async Task<(IReadOnlySet<SyntaxTree> AuthoredSyntaxTrees, ScreenplayProjectSource Source)> Create(
+        Project project,
+        Compilation compilation,
+        string workspaceRoot,
+        bool isSolution,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var projectPath = FullyQualified(project.FilePath);
+            var root = FullyQualified(workspaceRoot);
+            var logicalProjectPath = RelativeTo(root, projectPath);
+            var documents = new List<DotNetSourceDocument>();
+            var authoredSyntaxTrees = new HashSet<SyntaxTree>();
+
+            foreach (var document in project.Documents)
+            {
+                var syntaxTree = await document.GetSyntaxTreeAsync(cancellationToken) ??
+                    throw new InvalidScreenplayProjectSource("An authored document did not map to a syntax tree");
+                if (!compilation.SyntaxTrees.Contains(syntaxTree))
+                {
+                    throw new InvalidScreenplayProjectSource("An authored syntax tree was not present in the project compilation");
+                }
+
+                authoredSyntaxTrees.Add(syntaxTree);
+                documents.Add(new DotNetSourceDocument
+                {
+                    SyntaxTree = syntaxTree,
+                    ProjectRelativePath = ProjectRelativePathOf(document),
+                    WorkspaceRelativePath = RelativeTo(root, FullyQualified(document.FilePath))
+                });
+            }
+
+            var policy = new DotNetSourcePathPolicy
+            {
+                DisplayRoot = isSolution ? DotNetSourceDisplayRoot.Workspace : DotNetSourceDisplayRoot.Project,
+                CasePolicy = DotNetSourcePathCasePolicy.Ordinal
+            };
+            var identity = Path.ChangeExtension(logicalProjectPath, null)?.Replace('\\', '/') ?? logicalProjectPath;
+            var context = DotNetSourcePaths.Create(identity, policy, documents);
+            if (context.Files.Count != authoredSyntaxTrees.Count || authoredSyntaxTrees.Any(tree => !context.Files.ContainsKey(tree)))
+            {
+                throw new InvalidScreenplayProjectSource("An authored syntax tree was not mapped by the source context");
+            }
+
+            return (authoredSyntaxTrees, new ScreenplayProjectSource(projectPath, logicalProjectPath, context));
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (InvalidScreenplayProjectSource)
+        {
+            throw;
+        }
+        catch (Exception exception) when (IsSourcePathFailure(exception))
+        {
+            throw new InvalidScreenplayProjectSource("The project contains a source path that cannot be represented safely", exception);
+        }
+    }
+
+    /// <summary>
+    /// Builds the project-relative identity path from Roslyn's logical folders and document name.
+    /// </summary>
+    /// <param name="document">The workspace document.</param>
+    /// <returns>The logical project-relative path.</returns>
+    static string ProjectRelativePathOf(Document document) =>
+        string.Join('/', document.Folders.Append(document.Name).Select(PortablePart));
+
+    /// <summary>
+    /// Ensures a logical document path part cannot introduce a root or traversal.
+    /// </summary>
+    /// <param name="part">The logical path part.</param>
+    /// <returns>The validated path part.</returns>
+    /// <exception cref="InvalidScreenplayProjectSource">Thrown when the path part is malformed.</exception>
+    static string PortablePart(string part)
+    {
+        if (string.IsNullOrWhiteSpace(part) ||
+            string.Equals(part, ".", StringComparison.Ordinal) ||
+            string.Equals(part, "..", StringComparison.Ordinal) ||
+            Path.IsPathFullyQualified(part) ||
+            part.Contains('/') ||
+            part.Contains('\\') ||
+            part.Any(char.IsControl))
+        {
+            throw new InvalidScreenplayProjectSource("A logical document path is rooted, traversing, or malformed");
+        }
+
+        return part;
+    }
+
+    /// <summary>
+    /// Ensures a physical path is present and fully qualified.
+    /// </summary>
+    /// <param name="path">The physical path.</param>
+    /// <returns>The canonical full path.</returns>
+    /// <exception cref="InvalidScreenplayProjectSource">Thrown when the path is missing or relative.</exception>
+    static string FullyQualified(string? path)
+    {
+        if (string.IsNullOrWhiteSpace(path) || !Path.IsPathFullyQualified(path))
+        {
+            throw new InvalidScreenplayProjectSource("A workspace source path is missing or is not fully qualified");
+        }
+
+        return Path.GetFullPath(path);
+    }
+
+    /// <summary>
+    /// Produces a portable relative path and rejects anything outside the declared workspace root.
+    /// </summary>
+    /// <param name="root">The physical workspace root.</param>
+    /// <param name="path">The physical path.</param>
+    /// <returns>The portable path beneath the root.</returns>
+    /// <exception cref="InvalidScreenplayProjectSource">Thrown when the path is outside the root.</exception>
+    static string RelativeTo(string root, string path)
+    {
+        var relative = Path.GetRelativePath(root, path).Replace('\\', '/');
+        if (IsOutside(relative))
+        {
+            relative = Path.GetRelativePath(CanonicalPathOf(root), CanonicalPathOf(path)).Replace('\\', '/');
+        }
+
+        if (IsOutside(relative))
+        {
+            throw new InvalidScreenplayProjectSource("A workspace source path is outside the declared display root");
+        }
+
+        return relative;
+    }
+
+    /// <summary>
+    /// Resolves existing symbolic-link path components without requiring the complete path to be a link itself.
+    /// </summary>
+    /// <param name="path">The fully qualified physical path.</param>
+    /// <returns>The canonical physical path.</returns>
+    static string CanonicalPathOf(string path)
+    {
+        var root = Path.GetPathRoot(path)!;
+        var current = root;
+        foreach (var part in path[root.Length..].Split(
+                     [Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar],
+                     StringSplitOptions.RemoveEmptyEntries))
+        {
+            current = Path.Combine(current, part);
+            FileSystemInfo fileSystemInfo = Directory.Exists(current)
+                ? new DirectoryInfo(current)
+                : new FileInfo(current);
+            if (fileSystemInfo.ResolveLinkTarget(returnFinalTarget: true) is { } target)
+            {
+                current = target.FullName;
+            }
+        }
+
+        return Path.GetFullPath(current);
+    }
+
+    static bool IsOutside(string relative) =>
+        Path.IsPathFullyQualified(relative) ||
+        string.Equals(relative, ".", StringComparison.Ordinal) ||
+        string.Equals(relative, "..", StringComparison.Ordinal) ||
+        relative.StartsWith("../", StringComparison.Ordinal);
+
+    /// <summary>
+    /// Determines whether an exception represents a source-path contract failure.
+    /// </summary>
+    /// <param name="exception">The exception to classify.</param>
+    /// <returns><see langword="true"/> when the exception represents a source-path contract failure.</returns>
+    static bool IsSourcePathFailure(Exception exception) =>
+        exception is InvalidDotNetSourcePath or
+            InvalidDotNetProjectIdentity or
+            UnsupportedDotNetSourcePathPolicy or
+            DuplicateDotNetSourceIdentity or
+            DuplicateDotNetSourceTree or
+            DotNetSourceTreeNotMapped or
+            ArgumentException or
+            IOException or
+            NotSupportedException or
+            UnauthorizedAccessException;
+}
+
+/// <summary>
+/// The exception that is thrown when workspace source paths cannot be represented safely.
+/// </summary>
+sealed class InvalidScreenplayProjectSource : Exception
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="InvalidScreenplayProjectSource"/> class.
+    /// </summary>
+    /// <param name="message">The failure description.</param>
+    internal InvalidScreenplayProjectSource(string message)
+        : base(message)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="InvalidScreenplayProjectSource"/> class.
+    /// </summary>
+    /// <param name="message">The failure description.</param>
+    /// <param name="innerException">The source-path contract failure.</param>
+    internal InvalidScreenplayProjectSource(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+}

--- a/Source/Cli/Commands/Screenplay/ScreenplaySourcePolicyProvenance.cs
+++ b/Source/Cli/Commands/Screenplay/ScreenplaySourcePolicyProvenance.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Cli.Commands.Screenplay;
+
+/// <summary>
+/// Represents the relocation-safe source-path policy used for one project.
+/// </summary>
+/// <param name="LogicalProjectPath">The workspace-relative logical project path.</param>
+/// <param name="ProjectIdentity">The stable project identity.</param>
+/// <param name="PolicyVersion">The source-path policy version.</param>
+/// <param name="DisplayRoot">Whether source locations display from the project or workspace root.</param>
+/// <param name="CasePolicy">The case policy used for stable source identities.</param>
+public record ScreenplaySourcePolicyProvenance(
+    string LogicalProjectPath,
+    string ProjectIdentity,
+    int PolicyVersion,
+    string DisplayRoot,
+    string CasePolicy);

--- a/Source/Cli/Commands/Screenplay/ScreenplaySourceProviders.cs
+++ b/Source/Cli/Commands/Screenplay/ScreenplaySourceProviders.cs
@@ -62,27 +62,31 @@ sealed class ArcSourceProvider : IScreenplaySourceProvider
 
     static LoadedCompilation Narrow(LoadedCompilation loaded)
     {
-        var selected = loaded.Compilations
-            .Select((compilation, index) => new
-            {
-                Compilation = compilation,
-                Name = loaded.ProjectNames[index],
-                AuthoredSyntaxTrees = loaded.AuthoredSyntaxTrees.Count > index ? loaded.AuthoredSyntaxTrees[index] : null,
-                Provenance = loaded.ProjectProvenance.Count > index ? loaded.ProjectProvenance[index] : null
-            })
+        if (loaded.ProjectSourceAlignmentFailureFor(null) is { } alignmentFailure)
+        {
+            return new LoadedCompilation([], [], [.. loaded.Diagnostics, alignmentFailure]);
+        }
+
+        var selectedIndices = loaded.Compilations
+            .Select((compilation, index) => new { Compilation = compilation, Index = index })
             .Where(_ => ScreenplayProjectSelection.CanDeclareAnArtifact(_.Compilation))
+            .Select(_ => _.Index)
             .ToArray();
-        return selected.Length == loaded.Compilations.Count
+        return selectedIndices.Length == loaded.Compilations.Count
             ? loaded
             : new LoadedCompilation(
-                [.. selected.Select(_ => _.Compilation)],
-                [.. selected.Select(_ => _.Name)],
+                [.. selectedIndices.Select(index => loaded.Compilations[index])],
+                [.. selectedIndices.Select(index => loaded.ProjectNames[index])],
                 loaded.Diagnostics)
             {
-                AuthoredSyntaxTrees = [.. selected.Where(_ => _.AuthoredSyntaxTrees is not null).Select(_ => _.AuthoredSyntaxTrees!)],
-                ProjectProvenance = [.. selected.Where(_ => _.Provenance is not null).Select(_ => _.Provenance!)]
+                AuthoredSyntaxTrees = SelectedFrom(loaded.AuthoredSyntaxTrees, selectedIndices, loaded.Compilations.Count),
+                ProjectProvenance = SelectedFrom(loaded.ProjectProvenance, selectedIndices, loaded.Compilations.Count),
+                ProjectSources = SelectedFrom(loaded.ProjectSources, selectedIndices, loaded.Compilations.Count)
             };
     }
+
+    static IReadOnlyList<T> SelectedFrom<T>(IReadOnlyList<T> values, IEnumerable<int> selectedIndices, int compilationCount) =>
+        values.Count == compilationCount ? [.. selectedIndices.Select(index => values[index])] : [];
 }
 
 sealed class MartenSourceProvider : IScreenplaySourceProvider

--- a/Source/Cli/Commands/Screenplay/ScreenplayWorkspaceProjectSelection.cs
+++ b/Source/Cli/Commands/Screenplay/ScreenplayWorkspaceProjectSelection.cs
@@ -1,0 +1,55 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.CodeAnalysis;
+
+namespace Cratis.Cli.Commands.Screenplay;
+
+/// <summary>
+/// Selects one target-framework variant of each distinct workspace project without conflating duplicate display names.
+/// </summary>
+static class ScreenplayWorkspaceProjectSelection
+{
+    /// <summary>
+    /// Selects workspace projects by their project-file identity and requested target framework.
+    /// </summary>
+    /// <param name="candidates">The workspace projects to select from.</param>
+    /// <param name="requestedFramework">The requested target framework, if any.</param>
+    /// <param name="targetPath">The target path used as a diagnostic location.</param>
+    /// <returns>The selected projects and target-framework diagnostics.</returns>
+    internal static (IReadOnlyList<Project> Projects, IReadOnlyList<ScreenplayDiagnostic> Diagnostics) Select(
+        IEnumerable<Project> candidates,
+        string? requestedFramework,
+        string targetPath)
+    {
+        var selected = new List<Project>();
+        var diagnostics = new List<ScreenplayDiagnostic>();
+        var groups = candidates
+            .GroupBy(ProjectIdentity, StringComparer.Ordinal)
+            .OrderBy(group => ScreenplayProjectSelection.WithoutTargetFramework(group.First().Name), StringComparer.Ordinal)
+            .ThenBy(group => group.Key, StringComparer.Ordinal);
+
+        foreach (var group in groups)
+        {
+            var variants = group.OrderBy(project => project.Name, StringComparer.Ordinal).ToArray();
+            var selection = ScreenplayTargetFrameworkSelector.Select(
+                variants.Select(project => project.Name),
+                requestedFramework,
+                targetPath);
+            diagnostics.AddRange(selection.Diagnostics);
+            if (selection.IsSuccessful)
+            {
+                selected.AddRange(selection.ProjectNames.Select(name => variants.Single(project => string.Equals(project.Name, name, StringComparison.Ordinal))));
+            }
+        }
+
+        return (selected, diagnostics);
+    }
+
+    /// <summary>
+    /// Gets the physical project-file identity used only while the workspace remains loaded.
+    /// </summary>
+    /// <param name="project">The workspace project.</param>
+    /// <returns>The physical project identity.</returns>
+    static string ProjectIdentity(Project project) => project.FilePath ?? project.Id.Id.ToString("D");
+}


### PR DESCRIPTION
# Summary

Adopt Screenplay Generation 0.9 source contexts so the CLI preserves stable project-qualified source identity independently from direct-project or workspace display paths, without changing generated Screenplay bytes.

## Added
- Preserve aligned actual/logical project metadata and linked-document source contexts through provider, Arc, and Critter generation. (#102)
- Report explicit source display/case policy without exposing physical workspace roots. (#102)
- Fail closed on malformed source mappings or partial/extra project metadata. (#102)

## Changed
- Update all four Generation packages to 0.9.0 while retaining Arc 22.1.0, Critter Stack 0.19.0, and no target Vogen runtime. (#102)