### PR TITLE
Fix Screenplay generation for NuGet content files

### DIFF
--- a/Source/Cli.Specs/for_NuGetPackageContentFiles/when_reading/with_malformed_assets.cs
+++ b/Source/Cli.Specs/for_NuGetPackageContentFiles/when_reading/with_malformed_assets.cs
@@ -1,0 +1,51 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Cli.for_NuGetPackageContentFiles.when_reading;
+
+/// <summary>
+/// Characterizes fail-closed handling of syntactically valid assets with unexpected shapes.
+/// </summary>
+public class with_malformed_assets : Specification
+{
+    string _fixtureRoot;
+    IReadOnlySet<string> _nonObjectRoot;
+    IReadOnlySet<string> _malformedContainers;
+    IReadOnlySet<string> _malformedPackageMetadata;
+
+    void Establish()
+    {
+        _fixtureRoot = Path.Combine(Path.GetTempPath(), $"screenplay-malformed-assets-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_fixtureRoot);
+    }
+
+    void Because()
+    {
+        _nonObjectRoot = Read("[]", "non-object-root.json");
+        _malformedContainers = Read(
+            "{\"packageFolders\":[],\"libraries\":{},\"targets\":{}}",
+            "malformed-containers.json");
+        _malformedPackageMetadata = Read(
+            "{\"packageFolders\":{\"/packages\":{}},\"libraries\":{\"Package/1.0.0\":{\"path\":[]}},\"targets\":{\"net10.0\":{\"Package/1.0.0\":{\"type\":\"package\",\"contentFiles\":{\"contentFiles/cs/any/Content.cs\":{\"buildAction\":[]}}}}}}",
+            "malformed-package.json");
+    }
+
+    [Fact] void should_ignore_a_non_object_root() => _nonObjectRoot.ShouldBeEmpty();
+    [Fact] void should_ignore_malformed_root_containers() => _malformedContainers.ShouldBeEmpty();
+    [Fact] void should_ignore_malformed_package_metadata() => _malformedPackageMetadata.ShouldBeEmpty();
+
+    void Destroy()
+    {
+        if (!string.IsNullOrEmpty(_fixtureRoot) && Directory.Exists(_fixtureRoot))
+        {
+            Directory.Delete(_fixtureRoot, recursive: true);
+        }
+    }
+
+    IReadOnlySet<string> Read(string content, string fileName)
+    {
+        var path = Path.Combine(_fixtureRoot, fileName);
+        File.WriteAllText(path, content);
+        return NuGetPackageContentFiles.From(path);
+    }
+}

--- a/Source/Cli.Specs/for_ScreenplayProjectSources/when_creating/from_an_msbuild_workspace_with_a_nuget_content_file.cs
+++ b/Source/Cli.Specs/for_ScreenplayProjectSources/when_creating/from_an_msbuild_workspace_with_a_nuget_content_file.cs
@@ -1,0 +1,191 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Diagnostics;
+using System.IO.Compression;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.MSBuild;
+
+namespace Cratis.Cli.for_ScreenplayProjectSources.when_creating;
+
+/// <summary>
+/// Characterizes package-owned compile documents through a real MSBuild workspace.
+/// </summary>
+[Collection(CliSpecsCollection.Name)]
+public class from_an_msbuild_workspace_with_a_nuget_content_file : Specification
+{
+    string _fixtureRoot;
+    SourceFixture _first;
+    SourceFixture _relocated;
+
+    void Establish() => ScreenplayCompilationLoader.RegisterMSBuild();
+
+    async Task Because()
+    {
+        _fixtureRoot = Path.Combine(Path.GetTempPath(), $"screenplay-package-content-{Guid.NewGuid():N}");
+        var feed = Path.Combine(_fixtureRoot, "feed");
+        Directory.CreateDirectory(feed);
+        CreatePackage(feed);
+
+        _first = await SourceFrom(
+            Path.Combine(_fixtureRoot, "checkouts", "first"),
+            Path.Combine(_fixtureRoot, "packages", "first"),
+            feed);
+        _relocated = await SourceFrom(
+            Path.Combine(_fixtureRoot, "checkouts", "relocated"),
+            Path.Combine(_fixtureRoot, "packages", "relocated"),
+            feed);
+    }
+
+    [Fact] void should_keep_the_package_tree_in_the_compilation() => _first.CompilationContainsPackageTree.ShouldBeTrue();
+    [Fact] void should_compile_with_the_package_global_using() => _first.CompilationErrors.ShouldBeEmpty();
+    [Fact] void should_exclude_the_package_tree_from_authored_sources() => _first.AuthoredSyntaxTrees.ShouldNotContain(_first.PackageSyntaxTree);
+    [Fact] void should_map_the_application_document() => _first.Source.SourceContext.Files.Values.Select(_ => _.Identity.Path).ShouldContain("Order.cs");
+    [Fact] void should_not_expose_the_package_document() => _first.Source.SourceContext.Files.Values.Select(_ => _.Identity.Path).ShouldNotContain("GlobalUsings.cs");
+    [Fact] void should_use_a_different_physical_package_path_after_relocation() => _relocated.PackageDocumentPath.ShouldNotEqual(_first.PackageDocumentPath);
+    [Fact] void should_preserve_source_metadata_after_relocating_the_checkout_and_package_cache() => LogicalDescription(_relocated.Source).ShouldEqual(LogicalDescription(_first.Source));
+
+    void Destroy()
+    {
+        if (!string.IsNullOrEmpty(_fixtureRoot) && Directory.Exists(_fixtureRoot))
+        {
+            Directory.Delete(_fixtureRoot, recursive: true);
+        }
+    }
+
+    static void CreatePackage(string feed)
+    {
+        var packagePath = Path.Combine(feed, "Fixture.ContentFiles.1.0.0.nupkg");
+        using var archive = ZipFile.Open(packagePath, ZipArchiveMode.Create);
+        WriteEntry(
+            archive,
+            "Fixture.ContentFiles.nuspec",
+            string.Join(
+                Environment.NewLine,
+                [
+                    "<?xml version=\"1.0\" encoding=\"utf-8\"?>",
+                    "<package xmlns=\"http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd\">",
+                    "  <metadata>",
+                    "    <id>Fixture.ContentFiles</id>",
+                    "    <version>1.0.0</version>",
+                    "    <authors>Cratis</authors>",
+                    "    <description>Screenplay package content fixture</description>",
+                    "    <contentFiles>",
+                    "      <files include=\"cs/any/GlobalUsings.cs\" buildAction=\"Compile\" />",
+                    "    </contentFiles>",
+                    "  </metadata>",
+                    "</package>"
+                ]));
+        WriteEntry(archive, "contentFiles/cs/any/GlobalUsings.cs", "global using System;");
+    }
+
+    static void WriteEntry(ZipArchive archive, string path, string content)
+    {
+        using var writer = new StreamWriter(archive.CreateEntry(path).Open());
+        writer.Write(content);
+    }
+
+    static async Task<SourceFixture> SourceFrom(string checkout, string packageCache, string feed)
+    {
+        Directory.CreateDirectory(checkout);
+        var projectPath = Path.Combine(checkout, "Application.csproj");
+        await File.WriteAllTextAsync(
+            projectPath,
+            string.Join(
+                Environment.NewLine,
+                [
+                    "<Project Sdk=\"Microsoft.NET.Sdk\">",
+                    "  <PropertyGroup>",
+                    "    <TargetFramework>net10.0</TargetFramework>",
+                    "    <ImplicitUsings>disable</ImplicitUsings>",
+                    "  </PropertyGroup>",
+                    "  <ItemGroup>",
+                    "    <PackageReference Include=\"Fixture.ContentFiles\" Version=\"1.0.0\" />",
+                    "  </ItemGroup>",
+                    "</Project>"
+                ]));
+        await File.WriteAllTextAsync(Path.Combine(checkout, "Order.cs"), "public record Order(DateTime Occurred);");
+        var configurationPath = Path.Combine(checkout, "NuGet.Config");
+        await File.WriteAllTextAsync(
+            configurationPath,
+            string.Join(
+                Environment.NewLine,
+                [
+                    "<configuration>",
+                    "  <packageSources>",
+                    "    <clear />",
+                    $"    <add key=\"fixture\" value=\"{feed}\" />",
+                    "  </packageSources>",
+                    "</configuration>"
+                ]));
+        await Restore(projectPath, configurationPath, packageCache);
+
+        using var workspace = MSBuildWorkspace.Create();
+        var project = await workspace.OpenProjectAsync(projectPath);
+        var packageDocument = project.Documents.Single(document =>
+            string.Equals(Path.GetFileName(document.FilePath), "GlobalUsings.cs", StringComparison.Ordinal));
+        var packageSyntaxTree = await packageDocument.GetSyntaxTreeAsync() ?? throw new SourceFixtureCompilationFailed();
+        var compilation = await project.GetCompilationAsync() ?? throw new SourceFixtureCompilationFailed();
+        var (authoredSyntaxTrees, source) = await ScreenplayProjectSources.Create(
+            project,
+            compilation,
+            checkout,
+            isSolution: false,
+            CancellationToken.None);
+
+        return new SourceFixture(
+            source,
+            authoredSyntaxTrees,
+            packageSyntaxTree,
+            packageDocument.FilePath,
+            compilation.SyntaxTrees.Contains(packageSyntaxTree),
+            [.. compilation.GetDiagnostics().Where(diagnostic => diagnostic.Severity == DiagnosticSeverity.Error)]);
+    }
+
+    static async Task Restore(string projectPath, string configurationPath, string packageCache)
+    {
+        var startInfo = new ProcessStartInfo("dotnet")
+        {
+            WorkingDirectory = Path.GetDirectoryName(projectPath),
+            RedirectStandardError = true,
+            RedirectStandardOutput = true,
+            UseShellExecute = false
+        };
+        startInfo.ArgumentList.Add("restore");
+        startInfo.ArgumentList.Add(projectPath);
+        startInfo.ArgumentList.Add("--configfile");
+        startInfo.ArgumentList.Add(configurationPath);
+        startInfo.ArgumentList.Add("--packages");
+        startInfo.ArgumentList.Add(packageCache);
+
+        using var process = Process.Start(startInfo) ?? throw new PackageContentFixtureRestoreFailed("The fixture restore process could not be started");
+        var standardOutput = process.StandardOutput.ReadToEndAsync();
+        var standardError = process.StandardError.ReadToEndAsync();
+        await process.WaitForExitAsync();
+        await Task.WhenAll(standardOutput, standardError);
+        var output = await standardOutput;
+        var error = await standardError;
+        if (process.ExitCode != 0)
+        {
+            throw new PackageContentFixtureRestoreFailed($"The fixture restore failed: {output}{error}");
+        }
+    }
+
+    static string LogicalDescription(ScreenplayProjectSource source)
+    {
+        var files = source.SourceContext.Files.Values
+            .OrderBy(file => file.Identity.Path, StringComparer.Ordinal)
+            .Select(file => $"{file.Identity}|{file.DisplayPath}");
+        return $"{source.LogicalProjectPath}|{source.SourceContext.ProjectIdentity}|{source.SourceContext.Policy.Version}|{source.SourceContext.Policy.DisplayRoot}|{source.SourceContext.Policy.CasePolicy}|{string.Join(';', files)}";
+    }
+
+    sealed record SourceFixture(
+        ScreenplayProjectSource Source,
+        IReadOnlySet<SyntaxTree> AuthoredSyntaxTrees,
+        SyntaxTree PackageSyntaxTree,
+        string PackageDocumentPath,
+        bool CompilationContainsPackageTree,
+        IReadOnlyList<Diagnostic> CompilationErrors);
+}
+
+sealed class PackageContentFixtureRestoreFailed(string message) : Exception(message);

--- a/Source/Cli.Specs/for_ScreenplayProjectSources/when_creating/with_an_in_workspace_link_to_an_outside_document.cs
+++ b/Source/Cli.Specs/for_ScreenplayProjectSources/when_creating/with_an_in_workspace_link_to_an_outside_document.cs
@@ -1,0 +1,96 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Cratis.Cli.for_ScreenplayProjectSources.when_creating;
+
+/// <summary>
+/// Characterizes canonical workspace containment through a physical directory link.
+/// </summary>
+public class with_an_in_workspace_link_to_an_outside_document : Specification
+{
+    AdhocWorkspace _workspace;
+    string _fixtureRoot;
+    Exception _directLinkError;
+    Exception _parentTraversalError;
+    bool _isApplicable;
+
+    void Establish() => _workspace = new AdhocWorkspace();
+
+    async Task Because()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        _isApplicable = true;
+        _fixtureRoot = Path.Combine(Path.GetTempPath(), $"screenplay-linked-outside-{Guid.NewGuid():N}");
+        var workspaceRoot = Path.Combine(_fixtureRoot, "Workspace");
+        var outsideRoot = Path.Combine(_fixtureRoot, "Outside");
+        var nestedOutsideRoot = Path.Combine(outsideRoot, "Nested");
+        Directory.CreateDirectory(workspaceRoot);
+        Directory.CreateDirectory(nestedOutsideRoot);
+        await File.WriteAllTextAsync(Path.Combine(nestedOutsideRoot, "Outside.cs"), "public record Outside;");
+        await File.WriteAllTextAsync(Path.Combine(outsideRoot, "Escaped.cs"), "public record Escaped;");
+        var linkedRoot = Directory.CreateSymbolicLink(Path.Combine(workspaceRoot, "Linked"), nestedOutsideRoot).FullName;
+
+        _directLinkError = await FailureFrom(workspaceRoot, Path.Combine(linkedRoot, "Outside.cs"), "Outside");
+        _parentTraversalError = await FailureFrom(workspaceRoot, Path.Combine(linkedRoot, "..", "Escaped.cs"), "Escaped");
+    }
+
+    [Fact]
+    void should_reject_the_directly_linked_document()
+    {
+        if (_isApplicable)
+        {
+            _directLinkError.ShouldBeOfExactType<InvalidScreenplayProjectSource>();
+        }
+    }
+
+    [Fact]
+    void should_reject_parent_traversal_after_the_link()
+    {
+        if (_isApplicable)
+        {
+            _parentTraversalError.ShouldBeOfExactType<InvalidScreenplayProjectSource>();
+        }
+    }
+
+    void Destroy()
+    {
+        _workspace.Dispose();
+        if (!string.IsNullOrEmpty(_fixtureRoot) && Directory.Exists(_fixtureRoot))
+        {
+            Directory.Delete(_fixtureRoot, recursive: true);
+        }
+    }
+
+    async Task<Exception> FailureFrom(string workspaceRoot, string documentPath, string recordName)
+    {
+        var project = _workspace.AddProject(ProjectInfo.Create(
+            ProjectId.CreateNewId(),
+            VersionStamp.Create(),
+            recordName,
+            recordName,
+            LanguageNames.CSharp,
+            filePath: Path.Combine(workspaceRoot, $"{recordName}.csproj")));
+        var solution = project.Solution.AddDocument(
+            DocumentId.CreateNewId(project.Id),
+            $"{recordName}.cs",
+            SourceText.From($"public record {recordName};"),
+            ["Links"],
+            documentPath);
+        project = solution.GetProject(project.Id)!;
+        var compilation = await project.GetCompilationAsync() ?? throw new SourceFixtureCompilationFailed();
+
+        return await Catch.Exception(() => ScreenplayProjectSources.Create(
+            project,
+            compilation,
+            workspaceRoot,
+            isSolution: true,
+            CancellationToken.None));
+    }
+}

--- a/Source/Cli/Commands/Screenplay/NuGetPackageContentFiles.cs
+++ b/Source/Cli/Commands/Screenplay/NuGetPackageContentFiles.cs
@@ -1,0 +1,166 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.CodeAnalysis;
+
+namespace Cratis.Cli.Commands.Screenplay;
+
+/// <summary>
+/// Finds compile documents contributed by NuGet <c>contentFiles</c> packages.
+/// </summary>
+static class NuGetPackageContentFiles
+{
+    static readonly StringComparer _pathComparer = OperatingSystem.IsWindows()
+        ? StringComparer.OrdinalIgnoreCase
+        : StringComparer.Ordinal;
+
+    /// <summary>
+    /// Gets the physical package content files restored for a project.
+    /// </summary>
+    /// <param name="project">The workspace project.</param>
+    /// <returns>The fully qualified paths of package-owned compile documents.</returns>
+    internal static IReadOnlySet<string> From(Project project) =>
+        From(ProjectRestoreState.AssetsFileFor(project.FilePath, project.CompilationOutputInfo.AssemblyPath));
+
+    /// <summary>
+    /// Gets the physical package content files described by a NuGet assets file.
+    /// </summary>
+    /// <param name="assetsFile">The NuGet assets file.</param>
+    /// <returns>The fully qualified paths of package-owned compile documents.</returns>
+    internal static IReadOnlySet<string> From(string? assetsFile)
+    {
+        if (assetsFile is null)
+        {
+            return new HashSet<string>(_pathComparer);
+        }
+
+        try
+        {
+            using var document = JsonDocument.Parse(File.ReadAllBytes(assetsFile));
+            var root = document.RootElement;
+            if (root.ValueKind != JsonValueKind.Object ||
+                !root.TryGetProperty("packageFolders", out var packageFolders) ||
+                packageFolders.ValueKind != JsonValueKind.Object ||
+                !root.TryGetProperty("libraries", out var libraries) ||
+                libraries.ValueKind != JsonValueKind.Object ||
+                !root.TryGetProperty("targets", out var targets) ||
+                targets.ValueKind != JsonValueKind.Object)
+            {
+                return new HashSet<string>(_pathComparer);
+            }
+
+            var folders = packageFolders.EnumerateObject()
+                .Select(folder => folder.Name)
+                .Where(Path.IsPathFullyQualified)
+                .Select(Path.GetFullPath)
+                .ToArray();
+            var files = new HashSet<string>(_pathComparer);
+            foreach (var target in targets.EnumerateObject().Where(target => target.Value.ValueKind == JsonValueKind.Object))
+            {
+                AddFrom(target.Value, libraries, folders, files);
+            }
+
+            return files;
+        }
+        catch (JsonException)
+        {
+            return new HashSet<string>(_pathComparer);
+        }
+        catch (IOException)
+        {
+            return new HashSet<string>(_pathComparer);
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return new HashSet<string>(_pathComparer);
+        }
+    }
+
+    /// <summary>
+    /// Adds package content files from one restored target.
+    /// </summary>
+    /// <param name="target">The restored target.</param>
+    /// <param name="libraries">The restored library metadata.</param>
+    /// <param name="packageFolders">The configured package cache roots.</param>
+    /// <param name="files">The paths to populate.</param>
+    static void AddFrom(
+        JsonElement target,
+        JsonElement libraries,
+        IReadOnlyList<string> packageFolders,
+        HashSet<string> files)
+    {
+        foreach (var package in target.EnumerateObject())
+        {
+            if (package.Value.ValueKind != JsonValueKind.Object ||
+                !package.Value.TryGetProperty("type", out var type) ||
+                type.ValueKind != JsonValueKind.String ||
+                !string.Equals(type.GetString(), "package", StringComparison.OrdinalIgnoreCase) ||
+                !package.Value.TryGetProperty("contentFiles", out var contentFiles) ||
+                contentFiles.ValueKind != JsonValueKind.Object ||
+                !libraries.TryGetProperty(package.Name, out var library) ||
+                library.ValueKind != JsonValueKind.Object ||
+                !library.TryGetProperty("path", out var libraryPathElement) ||
+                libraryPathElement.ValueKind != JsonValueKind.String ||
+                !SafeRelativePath(libraryPathElement.GetString(), out var libraryPath))
+            {
+                continue;
+            }
+
+            foreach (var contentFile in contentFiles.EnumerateObject())
+            {
+                if (!IsCompile(contentFile.Value) || !SafeRelativePath(contentFile.Name, out var contentPath))
+                {
+                    continue;
+                }
+
+                foreach (var packageFolder in packageFolders)
+                {
+                    var path = Path.GetFullPath(Path.Combine(packageFolder, libraryPath, contentPath));
+                    if (File.Exists(path))
+                    {
+                        files.Add(path);
+                    }
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Determines whether restored content metadata represents a compile document.
+    /// </summary>
+    /// <param name="contentFile">The restored content metadata.</param>
+    /// <returns><see langword="true"/> when the content is compiled.</returns>
+    static bool IsCompile(JsonElement contentFile) =>
+        contentFile.ValueKind == JsonValueKind.Object &&
+        contentFile.TryGetProperty("buildAction", out var buildAction) &&
+        buildAction.ValueKind == JsonValueKind.String &&
+        string.Equals(buildAction.GetString(), "Compile", StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Validates and converts an assets-file path to the current platform's separators.
+    /// </summary>
+    /// <param name="path">The assets-file path.</param>
+    /// <param name="safePath">The validated relative path.</param>
+    /// <returns><see langword="true"/> when the path is relative and cannot traverse.</returns>
+    static bool SafeRelativePath(string? path, out string safePath)
+    {
+        safePath = string.Empty;
+        if (string.IsNullOrWhiteSpace(path) || Path.IsPathFullyQualified(path))
+        {
+            return false;
+        }
+
+        var parts = path.Replace('\\', '/').Split('/');
+        if (parts.Any(part =>
+                string.IsNullOrWhiteSpace(part) ||
+                string.Equals(part, ".", StringComparison.Ordinal) ||
+                string.Equals(part, "..", StringComparison.Ordinal) ||
+                part.Any(char.IsControl)))
+        {
+            return false;
+        }
+
+        safePath = Path.Combine(parts);
+        return true;
+    }
+}

--- a/Source/Cli/Commands/Screenplay/ScreenplayProjectSources.cs
+++ b/Source/Cli/Commands/Screenplay/ScreenplayProjectSources.cs
@@ -7,7 +7,7 @@ using Microsoft.CodeAnalysis;
 namespace Cratis.Cli.Commands.Screenplay;
 
 /// <summary>
-/// Creates stable source metadata for projects loaded through a Roslyn workspace.
+/// Creates stable authored-source metadata for projects loaded through a Roslyn workspace.
 /// </summary>
 static class ScreenplayProjectSources
 {
@@ -35,9 +35,16 @@ static class ScreenplayProjectSources
             var logicalProjectPath = RelativeTo(root, projectPath);
             var documents = new List<DotNetSourceDocument>();
             var authoredSyntaxTrees = new HashSet<SyntaxTree>();
+            var packageContentFiles = NuGetPackageContentFiles.From(project);
 
             foreach (var document in project.Documents)
             {
+                var documentPath = FullyQualified(document.FilePath);
+                if (packageContentFiles.Contains(documentPath))
+                {
+                    continue;
+                }
+
                 var syntaxTree = await document.GetSyntaxTreeAsync(cancellationToken) ??
                     throw new InvalidScreenplayProjectSource("An authored document did not map to a syntax tree");
                 if (!compilation.SyntaxTrees.Contains(syntaxTree))
@@ -50,7 +57,7 @@ static class ScreenplayProjectSources
                 {
                     SyntaxTree = syntaxTree,
                     ProjectRelativePath = ProjectRelativePathOf(document),
-                    WorkspaceRelativePath = RelativeTo(root, FullyQualified(document.FilePath))
+                    WorkspaceRelativePath = RelativeTo(root, documentPath)
                 });
             }
 
@@ -116,7 +123,7 @@ static class ScreenplayProjectSources
     /// Ensures a physical path is present and fully qualified.
     /// </summary>
     /// <param name="path">The physical path.</param>
-    /// <returns>The canonical full path.</returns>
+    /// <returns>The validated fully qualified path.</returns>
     /// <exception cref="InvalidScreenplayProjectSource">Thrown when the path is missing or relative.</exception>
     static string FullyQualified(string? path)
     {
@@ -125,7 +132,7 @@ static class ScreenplayProjectSources
             throw new InvalidScreenplayProjectSource("A workspace source path is missing or is not fully qualified");
         }
 
-        return Path.GetFullPath(path);
+        return path;
     }
 
     /// <summary>
@@ -138,17 +145,13 @@ static class ScreenplayProjectSources
     static string RelativeTo(string root, string path)
     {
         var relative = Path.GetRelativePath(root, path).Replace('\\', '/');
-        if (IsOutside(relative))
-        {
-            relative = Path.GetRelativePath(CanonicalPathOf(root), CanonicalPathOf(path)).Replace('\\', '/');
-        }
-
-        if (IsOutside(relative))
+        var canonicalRelative = Path.GetRelativePath(CanonicalPathOf(root), CanonicalPathOf(path)).Replace('\\', '/');
+        if (IsOutside(canonicalRelative))
         {
             throw new InvalidScreenplayProjectSource("A workspace source path is outside the declared display root");
         }
 
-        return relative;
+        return IsOutside(relative) ? canonicalRelative : relative;
     }
 
     /// <summary>
@@ -164,11 +167,22 @@ static class ScreenplayProjectSources
                      [Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar],
                      StringSplitOptions.RemoveEmptyEntries))
         {
+            if (string.Equals(part, ".", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            if (string.Equals(part, "..", StringComparison.Ordinal))
+            {
+                current = Path.GetDirectoryName(Path.TrimEndingDirectorySeparator(current)) ?? root;
+                continue;
+            }
+
             current = Path.Combine(current, part);
             FileSystemInfo fileSystemInfo = Directory.Exists(current)
                 ? new DirectoryInfo(current)
                 : new FileInfo(current);
-            if (fileSystemInfo.ResolveLinkTarget(returnFinalTarget: true) is { } target)
+            if (fileSystemInfo.Exists && fileSystemInfo.ResolveLinkTarget(returnFinalTarget: true) is { } target)
             {
                 current = target.FullName;
             }


### PR DESCRIPTION
## Fixed

- Generate Screenplays for projects that compile NuGet content files without exposing machine-specific package cache paths. (#104)