### PR TITLE
Add job timeouts and PR concurrency to workflows

### DIFF
--- a/.github/workflows/auto-approve-publish-deployments.yml
+++ b/.github/workflows/auto-approve-publish-deployments.yml
@@ -17,6 +17,7 @@ permissions:
 jobs:
   approve:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - name: Approve pending npm/nuget deployments
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,7 @@ on:
 jobs:
   dotnet-build:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/cleanup-pr-artifacts.yml
+++ b/.github/workflows/cleanup-pr-artifacts.yml
@@ -1,5 +1,9 @@
 name: Cleanup PR Artifacts
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   pull_request:
     types: [closed]

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -18,6 +18,7 @@ permissions:
 jobs:
   trigger:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Trigger Documentation Build
         uses: peter-evans/repository-dispatch@v3

--- a/.github/workflows/markdown-verification.yml
+++ b/.github/workflows/markdown-verification.yml
@@ -20,6 +20,7 @@ permissions:
 jobs:
   markdown-lint:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -31,6 +32,7 @@ jobs:
 
   link-verification:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/publish-native.yml
+++ b/.github/workflows/publish-native.yml
@@ -18,6 +18,7 @@ jobs:
   build-macos-arm64:
     name: Build macOS arm64
     runs-on: macos-latest
+    timeout-minutes: 60
 
     steps:
       - name: Checkout code
@@ -48,6 +49,7 @@ jobs:
   build-macos-x64:
     name: Build macOS x64
     runs-on: macos-latest
+    timeout-minutes: 60
 
     steps:
       - name: Checkout code
@@ -78,6 +80,7 @@ jobs:
   build-linux-x64:
     name: Build Linux x64
     runs-on: ubuntu-latest
+    timeout-minutes: 60
 
     steps:
       - name: Checkout code
@@ -108,6 +111,7 @@ jobs:
   build-linux-arm64:
     name: Build Linux arm64
     runs-on: ubuntu-latest
+    timeout-minutes: 60
 
     steps:
       - name: Checkout code
@@ -138,6 +142,7 @@ jobs:
   publish-homebrew:
     name: Publish to Homebrew
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     needs: [build-macos-arm64, build-macos-x64, build-linux-x64, build-linux-arm64]
 
     permissions:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -58,6 +58,7 @@ permissions:
 jobs:
   release:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     outputs:
       version: ${{ steps.release.outputs.version }}
       publish: ${{ steps.release.outputs.should-publish }}
@@ -83,6 +84,7 @@ jobs:
   publish:
     if: needs.release.outputs.publish == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     needs: [release]
 
     permissions:
@@ -139,6 +141,7 @@ jobs:
     # and failing on those would make this job noise that everyone learns to ignore.
     if: always() && needs.release.result == 'success' && contains(fromJSON('["no-label", "error"]'), needs.release.outputs.reason)
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     needs: [release]
 
     steps:

--- a/.github/workflows/verify-semver-label.yml
+++ b/.github/workflows/verify-semver-label.yml
@@ -29,6 +29,7 @@ permissions:
 jobs:
   verify:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
 
     steps:
       - name: Require exactly one release intent label


### PR DESCRIPTION
Part of the org-wide Actions throttling remediation. Mechanical, rule-based sweep:

- **timeout-minutes** on every job that had none (previously 6 h default): quick checks 15, builds 30, publish/release 60, integration/benchmarks 120.
- **concurrency + cancel-in-progress** only on pull-request-triggered verification workflows — never on publish/release/deploy, `pull_request_target`, `workflow_run` or reusable (`workflow_call`) workflows.

Every edited file re-parsed as YAML before commit. Files changed:
- .github/workflows/auto-approve-publish-deployments.yml
- .github/workflows/build.yml
- .github/workflows/cleanup-pr-artifacts.yml
- .github/workflows/documentation.yml
- .github/workflows/markdown-verification.yml
- .github/workflows/publish-native.yml
- .github/workflows/publish.yml
- .github/workflows/verify-semver-label.yml