### PR TITLE
Add event sourcing keywords and ecosystem links to public surfaces

### DIFF
--- a/.github/workflows/publish-native.yml
+++ b/.github/workflows/publish-native.yml
@@ -188,7 +188,7 @@ jobs:
           mkdir -p homebrew-cratis/Formula
           cat > homebrew-cratis/Formula/cratis.rb << EOF
           class Cratis < Formula
-            desc "Command-line tool for managing and exploring Chronicle event stores"
+            desc "CLI for inspecting and diagnosing Chronicle event-sourcing stores"
             homepage "https://github.com/Cratis/cli"
             version "${{ inputs.version }}"
 

--- a/Documentation/index.mdx
+++ b/Documentation/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Cratis CLI
-description: Terminal workflows for inspecting and diagnosing Chronicle.
+description: The event sourcing CLI for Cratis — terminal workflows for inspecting and diagnosing Chronicle events, observers, projections, read models, and failed partitions.
 ---
 
 import { CardGrid, Steps, Tabs, TabItem } from '@astrojs/starlight/components';
@@ -116,6 +116,12 @@ and documented operational procedure before a mutation command.
     Published .NET tool metadata and versions.
   </SimpleCard>
   <SimpleCard title="Chronicle" icon="seti:db" link="/chronicle/">
-    Kernel, protocol, Workbench, and runtime documentation.
+    The event-sourcing database and runtime the CLI inspects — kernel, protocol, and runtime documentation.
+  </SimpleCard>
+  <SimpleCard title="Chronicle Workbench" icon="laptop" link="/chronicle/workbench/">
+    The bundled browser surface for authorized inspection of Chronicle runtime state.
+  </SimpleCard>
+  <SimpleCard title="Arc" icon="puzzle" link="/arc/">
+    The CQRS application framework whose running commands and queries the `cratis arc` group inspects.
   </SimpleCard>
 </CardGrid>

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
   <h3 align="center">Cratis CLI</h3>
 
-  <p align="center"><b>The Cratis CLI provides terminal workflows for inspecting and diagnosing Chronicle.</b></p>
+  <p align="center"><b>Terminal workflows for inspecting and diagnosing Chronicle, the Cratis event-sourcing database — events, observers, projections, read models, and failed partitions.</b></p>
 
   <p align="center">
     <a href="https://www.nuget.org/packages/Cratis.Cli"><img src="https://img.shields.io/nuget/v/Cratis.Cli?logo=nuget" alt="NuGet"></a>
@@ -30,9 +30,9 @@
 
 ## Place in the Cratis ecosystem
 
-The CLI is the terminal surface for Chronicle inspection and diagnosis. Chronicle Workbench provides a bundled local browser surface for authorized inspection of Chronicle runtime state and preview of supported projection behavior; the CLI serves terminal workflows around the same product family.
+The CLI is the terminal surface for inspection and diagnosis of [Chronicle](https://github.com/Cratis/Chronicle) ([docs](https://cratis.io/chronicle/)), the Cratis event-sourcing database and runtime. [Chronicle Workbench](https://cratis.io/chronicle/workbench/) provides a bundled local browser surface for authorized inspection of Chronicle runtime state and preview of supported projection behavior; the CLI serves terminal workflows around the same product family. On macOS and Linux the CLI installs from the [homebrew-cratis](https://github.com/Cratis/homebrew-cratis) tap.
 
-The repository also contains separately documented command groups for inspecting a running Arc application's registered commands and queries. Arc remains an independent CQRS application framework; using the Arc command group does not require Chronicle.
+The repository also contains separately documented command groups for inspecting a running [Arc](https://github.com/Cratis/Arc) ([docs](https://cratis.io/arc/)) application's registered commands and queries. Arc remains an independent CQRS application framework; using the Arc command group does not require Chronicle.
 
 This README describes human-operated commands and current output behavior. It does not establish an unversioned stable machine contract. Check the current output-format documentation before automation, and re-create generated command context after upgrading the CLI.
 
@@ -392,7 +392,8 @@ event-store <name>` changes it later.
 
 The CLI repository carries additional command groups whose exact behavior and status belong to their owning product documentation. Their presence in the command tree does not establish product maturity, support, compatibility, or availability.
 
-- `cratis arc` inspects registered commands and queries in a running Arc application.
+- `cratis arc` inspects registered commands and queries in a running [Arc](https://github.com/Cratis/Arc) application.
+- `cratis screenplay` and `cratis render` work with Cratis Screenplay (`.play`) documents — generation, validation, and rendering from files, with nothing running. See the [Screenplay command reference](https://github.com/Cratis/cli/blob/main/Documentation/reference/screenplay.md).
 - The [canonical CLI page](https://cratis.io/cli/) carries the currently admitted command-group documentation.
 
 ## Platforms

--- a/Source/Cli.Specs/for_CliNuGetPackage/when_packing_a_sentinel_package.cs
+++ b/Source/Cli.Specs/for_CliNuGetPackage/when_packing_a_sentinel_package.cs
@@ -11,7 +11,7 @@ namespace Cratis.Cli.for_CliNuGetPackage;
 public class when_packing_a_sentinel_package : Specification
 {
     const string SentinelVersion = "0.0.0-package-metadata";
-    const string PackageDescription = "Command-line tool for managing and exploring Chronicle event stores";
+    const string PackageDescription = "Terminal workflows for inspecting and diagnosing Chronicle, the Cratis event-sourcing database — events, observers, projections, read models, and failed partitions";
 
     string _outputDirectory;
     XDocument _nuspec;

--- a/Source/Cli/Cli.csproj
+++ b/Source/Cli/Cli.csproj
@@ -10,7 +10,8 @@
         <TargetFramework>net10.0</TargetFramework>
         <RuntimeIdentifiers></RuntimeIdentifiers>
 
-        <PackageDescription>Command-line tool for managing and exploring Chronicle event stores</PackageDescription>
+        <PackageDescription>Terminal workflows for inspecting and diagnosing Chronicle, the Cratis event-sourcing database — events, observers, projections, read models, and failed partitions</PackageDescription>
+        <PackageTags>event-sourcing;event-store;cqrs;cli;chronicle;cratis;projections;diagnostics;dotnet-tool</PackageTags>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <PackageIcon>logo.png</PackageIcon>
         <PackageReadmeFile>README.md</PackageReadmeFile>


### PR DESCRIPTION
## What changed

- **README.md** — tagline now names Chronicle as the Cratis event-sourcing database and states what the CLI inspects (events, observers, projections, read models, failed partitions). "Place in the Cratis ecosystem" now links directly to the Chronicle repository and docs, Chronicle Workbench docs, the Arc repository and docs, and the homebrew-cratis tap. "Other command groups" now also names the shipped `cratis screenplay` / `cratis render` command group with a link to its command reference, inside the existing boundary language (presence in the command tree does not establish maturity, support, compatibility, or availability).
- **Documentation/index.mdx** — frontmatter description extended with event-sourcing phrasing; added ecosystem cross-link cards for Chronicle Workbench and Arc alongside the existing Chronicle card.
- **Source/Cli/Cli.csproj** — added `PackageTags` (event-sourcing, event-store, cqrs, cli, chronicle, cratis, projections, diagnostics, dotnet-tool) and aligned `PackageDescription` with the README tagline so NuGet search surfaces the tool for event-sourcing queries.
- **.github/workflows/publish-native.yml** — updated the templated Homebrew formula `desc` to "CLI for inspecting and diagnosing Chronicle event-sourcing stores" (the template, so the generated formula picks it up on the next release).

## Why

Better discoverability: the CLI's public surfaces (README, docs page, NuGet metadata, Homebrew formula) did not use the event-sourcing category terms people actually search for, and the ecosystem section named sibling products without linking to them. Wording stays factual and within existing boundary language; no maturity or support claims added.

## Verification

- `markdownlint-cli2` on README.md: 0 issues.
- All added links checked: Documentation/reference/screenplay.md exists in this repository; /chronicle/workbench/ and /arc/ are existing docs-site routes; icon names (`laptop`, `puzzle`) are Starlight icons already used on the docs site.

Docs/metadata only — labeled `no-release`.