### PR TITLE
Link the Cratis blog from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ The CLI shares the conviction the rest of Cratis is built on: event sourcing is 
 
 The repository also contains separately documented command groups for inspecting a running [Arc](https://github.com/Cratis/Arc) ([docs](https://cratis.io/arc/)) application's registered commands and queries. Arc remains an independent CQRS application framework; using the Arc command group does not require Chronicle.
 
+Blog: [blog.cratis.io](https://blog.cratis.io)
+
 This README describes human-operated commands and current output behavior. It does not establish an unversioned stable machine contract. Check the current output-format documentation before automation, and re-create generated command context after upgrading the CLI.
 
 ## When the read model is wrong


### PR DESCRIPTION
Founder-decided: link https://blog.cratis.io from all Cratis surfaces.

Adds a single Blog line to the README's ecosystem section pointing to blog.cratis.io.

Documentation-only; labeled no-release. Humans merge.