### PR TITLE
Link release announcements to the Cratis blog

### DIFF
--- a/README.md
+++ b/README.md
@@ -460,3 +460,5 @@ effects before merge.
 ## License
 
 MIT. See the [repository license](https://github.com/Cratis/cli/blob/main/LICENSE).
+
+Release notes and announcements: the [Cratis blog](https://blog.cratis.io).


### PR DESCRIPTION
One-line README addition pointing at the Cratis blog. Labeled `patch` so merging cuts a patch release that publishes the updated package metadata (descriptions/tags from the discoverability wave) to the registries.