### PR TITLE
Let a README merge release the packed package readme

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -49,6 +49,10 @@ on:
       - "Source/**"
       - "*.props"
       - "*.targets"
+      # README.md is the package readme (PackageReadmeFile packs it from the repository root),
+      # so a README-only merge changes the published package and must be able to release.
+      # PR #122 was labeled patch for exactly that reason and silently released nothing.
+      - "README.md"
 
 permissions:
   contents: write


### PR DESCRIPTION
Cli.csproj packs the repository-root README.md as the NuGet package readme (PackageReadmeFile), but the publish workflow's paths filter did not include README.md. PR #122 merged with a patch label to ship the updated readme and silently released nothing — the workflow never triggered, so the label was never evaluated. Adding README.md to the paths filter closes that gap for future merges. Documentation-only merges remain unaffected: they carry no-release labels and resolve to a non-publishing reason. This PR itself changes only the workflow file, which is outside the paths filter, so merging it publishes nothing; the readme currently on NuGet remains one merge behind until the next release (noted for the owner).