### PR TITLE
Consume the published Stage Cratis rendering facade

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -24,8 +24,8 @@
     <PackageVersion Include="Cratis.Prologue.Interpreter.Contracts" Version="2.0.0" />
     <PackageVersion Include="Cratis.Prologue.Screenplay" Version="2.0.0" />
     <PackageVersion Include="Cratis.Screenplay" Version="4.6.0" />
-    <PackageVersion Include="Cratis.Stage.Contracts" Version="3.9.2" />
-    <PackageVersion Include="Cratis.Stage.Rendering.Cratis" Version="3.9.2" />
+    <PackageVersion Include="Cratis.Stage.Contracts" Version="3.10.0" />
+    <PackageVersion Include="Cratis.Stage.Rendering.Cratis" Version="3.10.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.11" />
     <!-- CLI -->
     <PackageVersion Include="MongoDB.Driver" Version="3.11.0" />

--- a/Source/Cli.Specs/for_CratisRenderTarget/given/a_cratis_render_target.cs
+++ b/Source/Cli.Specs/for_CratisRenderTarget/given/a_cratis_render_target.cs
@@ -1,0 +1,97 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Screenplay.Semantics;
+using Cratis.Screenplay.Semantics.Execution;
+using Cratis.Stage.Contracts.Rendering;
+using Cratis.Stage.Rendering.Cratis;
+
+namespace Cratis.Cli.for_CratisRenderTarget.given;
+
+/// <summary>
+/// Base context that compiles a Screenplay document straight to an admitted execution plan, without going
+/// through <see cref="ScreenplayPlanning"/>, so the bundled <see cref="CratisRenderTarget"/> can be exercised
+/// in isolation against the published <see cref="CratisRendering"/> facade.
+/// </summary>
+public class a_cratis_render_target : Specification
+{
+    /// <summary>
+    /// A slice the published Cratis facade can render: a state-change slice and a paired state-view slice.
+    /// </summary>
+    protected static readonly string SupportedSource = Lines(
+        "concept ProjectId : Uuid",
+        "concept ProjectName : String",
+        "module Projects",
+        "  feature Registration",
+        "    slice StateChange RegisterProject",
+        "      command RegisterProject",
+        "        projectId ProjectId identifier",
+        "        name ProjectName",
+        "        produces ProjectRegistered",
+        "          for projectId",
+        "          projectId = projectId",
+        "          name = name",
+        "      event ProjectRegistered",
+        "        projectId ProjectId",
+        "        name ProjectName",
+        "    slice StateView ProjectLookup",
+        "      readmodel ProjectSummary",
+        "        projectId ProjectId",
+        "        name ProjectName",
+        "      query ProjectById => ProjectSummary?",
+        "        by projectId ProjectId",
+        "      projection ProjectSummaryProjection => ProjectSummary",
+        "        from ProjectRegistered key projectId",
+        "          name = name");
+
+    /// <summary>
+    /// A slice the model compiler and execution planner admit, but the published Cratis facade cannot render:
+    /// a produced event with no affected-instance mapping (missing "for projectId").
+    /// </summary>
+    protected static readonly string UnsupportedSource = Lines(
+        "concept ProjectId : Uuid",
+        "module Projects",
+        "  feature Registration",
+        "    slice StateChange RegisterProject",
+        "      command RegisterProject",
+        "        projectId ProjectId identifier",
+        "        produces ProjectRegistered",
+        "          projectId = projectId",
+        "      event ProjectRegistered",
+        "        projectId ProjectId");
+
+    private protected CratisRenderTarget _target = null!;
+
+    void Establish() => _target = new();
+
+    static string Lines(params string[] lines) => string.Join('\n', lines);
+
+    /// <summary>
+    /// Compiles a document straight to an admitted execution plan.
+    /// </summary>
+    /// <param name="source">The Screenplay document source.</param>
+    /// <param name="applicationName">The application name.</param>
+    /// <returns>The compiled model and its admitted execution plan.</returns>
+    private protected static (ExecutableSemanticModel Model, SemanticExecutionPlan ExecutionPlan) Compile(string source, string applicationName = "Projects")
+    {
+        var catalog = SemanticIdentityCatalog.Empty(ApplicationIdentity.Create(applicationName));
+        var document = SemanticSourceDocument.Create(catalog.ResolveDocument("Projects.play"), "Projects.play", "Projects.play", source);
+        var compilation = new SemanticModelCompiler().Compile(applicationName, SemanticDocumentSet.Create([document], catalog));
+        var model = compilation.Value!.Model;
+        var executionPlan = SemanticExecutionPlan.Compile(model).Plan!;
+        return (model, executionPlan);
+    }
+
+    /// <summary>
+    /// Plans the exact same request directly through the published facade, for comparison against the CLI target.
+    /// </summary>
+    /// <param name="model">The compiled model.</param>
+    /// <param name="executionPlan">The admitted execution plan.</param>
+    /// <returns>The facade's own plan.</returns>
+    private protected static ArtifactRenderPlan PlanWithFacade(ExecutableSemanticModel model, SemanticExecutionPlan executionPlan) =>
+        CratisRendering.Plan(
+            model,
+            executionPlan,
+            new ArtifactRenderScope(ArtifactRenderScopeKind.Application, model.Application.Id),
+            new CratisRenderingOptions(model.Application.Name, model.Application.Name));
+}

--- a/Source/Cli.Specs/for_CratisRenderTarget/when_planning_a_supported_application.cs
+++ b/Source/Cli.Specs/for_CratisRenderTarget/when_planning_a_supported_application.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Screenplay.Semantics;
+using Cratis.Screenplay.Semantics.Execution;
+using Cratis.Stage.Contracts.Rendering;
+using Cratis.Stage.Rendering.Cratis;
+
+namespace Cratis.Cli.for_CratisRenderTarget;
+
+public class when_planning_a_supported_application : given.a_cratis_render_target
+{
+    ExecutableSemanticModel _model = null!;
+    SemanticExecutionPlan _executionPlan = null!;
+    ArtifactRenderPlan _result = null!;
+    ArtifactRenderPlan _expected = null!;
+
+    void Establish() => (_model, _executionPlan) = Compile(SupportedSource);
+
+    Task Because()
+    {
+        _result = _target.Plan(_model, _executionPlan);
+        _expected = PlanWithFacade(_model, _executionPlan);
+        return Task.CompletedTask;
+    }
+
+    [Fact] void should_expose_the_published_facade_target_id_as_its_name() => _target.Name.ShouldEqual(CratisRendering.TargetId);
+    [Fact] void should_succeed() => _result.Success.ShouldBeTrue();
+    [Fact] void should_plan_the_exact_facade_target() => _result.Target.ShouldEqual(_expected.Target);
+    [Fact] void should_plan_the_exact_facade_target_version() => _result.TargetVersion.ShouldEqual(_expected.TargetVersion);
+    [Fact] void should_plan_the_exact_facade_renderer() => _result.Renderer.ShouldEqual(_expected.Renderer);
+    [Fact] void should_plan_the_exact_facade_renderer_version() => _result.RendererVersion.ShouldEqual(_expected.RendererVersion);
+    [Fact] void should_plan_the_same_application_name() => _result.ApplicationName.ShouldEqual(_expected.ApplicationName);
+    [Fact] void should_plan_the_same_semantic_revision() => _result.SemanticRevision.ShouldEqual(_expected.SemanticRevision);
+    [Fact] void should_plan_the_exact_facade_artifacts() =>
+        _result.Artifacts.Select(_ => (_.Kind, _.RelativePath, _.Sha256))
+            .ShouldEqual(_expected.Artifacts.Select(_ => (_.Kind, _.RelativePath, _.Sha256)));
+    [Fact] void should_plan_the_exact_facade_diagnostics() =>
+        _result.Diagnostics.Select(_ => (_.Code, _.Severity, _.Message))
+            .ShouldEqual(_expected.Diagnostics.Select(_ => (_.Code, _.Severity, _.Message)));
+    [Fact] void should_plan_the_full_published_facade_scaffold_and_nothing_the_cli_authors_itself() =>
+        _result.Artifacts.Length.ShouldEqual(_expected.Artifacts.Length);
+}

--- a/Source/Cli.Specs/for_CratisRenderTarget/when_planning_unsupported_semantics.cs
+++ b/Source/Cli.Specs/for_CratisRenderTarget/when_planning_unsupported_semantics.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Screenplay.Semantics;
+using Cratis.Screenplay.Semantics.Execution;
+using Cratis.Stage.Contracts.Rendering;
+
+namespace Cratis.Cli.for_CratisRenderTarget;
+
+public class when_planning_unsupported_semantics : given.a_cratis_render_target
+{
+    ExecutableSemanticModel _model = null!;
+    SemanticExecutionPlan _executionPlan = null!;
+    ArtifactRenderPlan _result = null!;
+
+    void Establish() => (_model, _executionPlan) = Compile(UnsupportedSource);
+
+    Task Because()
+    {
+        _result = _target.Plan(_model, _executionPlan);
+        return Task.CompletedTask;
+    }
+
+    [Fact] void should_not_be_successful() => _result.Success.ShouldBeFalse();
+    [Fact] void should_report_the_facade_blocking_diagnostic() => _result.Diagnostics.Select(_ => _.Code).ShouldContain("STAGE-ESM-006");
+    [Fact] void should_plan_zero_artifacts() => _result.Artifacts.Length.ShouldEqual(0);
+}

--- a/Source/Cli/Commands/Render/CratisRenderTarget.cs
+++ b/Source/Cli/Commands/Render/CratisRenderTarget.cs
@@ -9,97 +9,19 @@ using Cratis.Stage.Rendering.Cratis;
 namespace Cratis.Cli.Commands.Render;
 
 /// <summary>
-/// Represents the statically bundled Cratis ESM renderer target.
+/// Represents the statically bundled Cratis ESM renderer target, delegating to the published
+/// <see cref="CratisRendering"/> facade for the exact target profile and scaffold.
 /// </summary>
 internal sealed class CratisRenderTarget : IRenderTarget
 {
-    const string CratisVersion = "22.1.0";
-    const string RendererVersion = "3.9.1";
-    const string ScaffoldVersion = "1";
-
-    static readonly string _program = Lines(
-        "#if !DEBUG",
-        "var builder = WebApplication.CreateBuilder(args);",
-        "builder.AddCratis();",
-        string.Empty,
-        "var app = builder.Build();",
-        "app.UseRouting();",
-        "app.UseWebSockets();",
-        "app.UseCratis();",
-        "await app.RunAsync();",
-        "#endif");
-
     /// <inheritdoc/>
-    public string Name => CratisArtifactRenderPlanner.Target;
+    public string Name => CratisRendering.TargetId;
 
     /// <inheritdoc/>
     public ArtifactRenderPlan Plan(ExecutableSemanticModel model, SemanticExecutionPlan executionPlan)
     {
-        var profile = ArtifactRenderProfile.Create(
-            CratisArtifactRenderPlanner.Target,
-            CratisVersion,
-            CratisArtifactRenderPlanner.Renderer,
-            RendererVersion,
-            Scaffold(model.Application.Name));
-        var request = new ArtifactRenderRequest(
-            model,
-            executionPlan,
-            profile,
-            new(ArtifactRenderScopeKind.Application, model.Application.Id));
-        return new CratisArtifactRenderPlanner().Plan(request);
+        var options = new CratisRenderingOptions(model.Application.Name, model.Application.Name);
+        var scope = new ArtifactRenderScope(ArtifactRenderScopeKind.Application, model.Application.Id);
+        return CratisRendering.Plan(model, executionPlan, scope, options);
     }
-
-    static System.Collections.Immutable.ImmutableArray<ArtifactRenderInput> Scaffold(string applicationName) =>
-    [
-        CratisArtifactRenderInput.CreateText($"{applicationName}.csproj", ScaffoldVersion, Project(applicationName)),
-        CratisArtifactRenderInput.CreateText("Program.cs", ScaffoldVersion, _program),
-        CratisArtifactRenderInput.CreateText("appsettings.json", ScaffoldVersion, Settings(applicationName))
-    ];
-
-    static string Project(string applicationName) => Lines(
-        "<Project Sdk=\"Microsoft.NET.Sdk.Web\">",
-        "  <PropertyGroup>",
-        "    <TargetFramework>net10.0</TargetFramework>",
-        $"    <RootNamespace>{applicationName}</RootNamespace>",
-        "    <ImplicitUsings>enable</ImplicitUsings>",
-        "    <Nullable>enable</Nullable>",
-        "  </PropertyGroup>",
-        "  <ItemGroup>",
-        $"    <PackageReference Include=\"Cratis\" Version=\"{CratisVersion}\" />",
-        $"    <PackageReference Include=\"Cratis.Arc.MongoDB\" Version=\"{CratisVersion}\" />",
-        "  </ItemGroup>",
-        "  <ItemGroup Condition=\"'$(Configuration)' == 'Debug'\">",
-        $"    <PackageReference Include=\"Cratis.Arc.Chronicle.Testing\" Version=\"{CratisVersion}\" />",
-        "    <PackageReference Include=\"Cratis.Specifications\" Version=\"4.0.0\" />",
-        "    <PackageReference Include=\"Cratis.Specifications.XUnit\" Version=\"4.0.0\" />",
-        "    <PackageReference Include=\"Microsoft.NET.Test.Sdk\" Version=\"18.9.0\" />",
-        "    <PackageReference Include=\"NSubstitute\" Version=\"6.2.0\" />",
-        "    <PackageReference Include=\"xunit\" Version=\"2.9.3\" />",
-        "    <PackageReference Include=\"xunit.runner.visualstudio\" Version=\"4.0.0\" PrivateAssets=\"all\" />",
-        "  </ItemGroup>",
-        "</Project>");
-
-    static string Settings(string applicationName) => Lines(
-        "{",
-        "  \"AllowedHosts\": \"*\",",
-        "  \"Cratis\": {",
-        "    \"Arc\": {",
-        "      \"GeneratedApis\": {",
-        "        \"RoutePrefix\": \"api\",",
-        "        \"IncludeCommandNameInRoute\": false,",
-        "        \"SegmentsToSkipForRoute\": 1",
-        "      }",
-        "    },",
-        "    \"Chronicle\": {",
-        $"      \"EventStore\": \"{applicationName}\",",
-        "      \"ConnectionString\": \"chronicle://chronicle-dev-client:chronicle-dev-secret@localhost:35000\"",
-        "    },",
-        "    \"MongoDB\": {",
-        "      \"Server\": \"mongodb://localhost:27017\",",
-        $"      \"Database\": \"{applicationName}\"",
-        "    }",
-        "  }",
-        "}");
-
-    static string Lines(params string[] lines) => $"{string.Join('\n', lines)}\n";
 }


### PR DESCRIPTION
# Summary

Make `cratis render` consume Stage's package-owned Cratis target/scaffold policy instead of maintaining a stale CLI copy. CLI publication, recovery and rollback remain unchanged.

## Changed

- Upgraded Stage Contracts and Rendering.Cratis to 3.10.0 and delegated application planning to `CratisRendering`. (#124)
- Removed CLI-owned Cratis versions and hand-authored scaffold files. (#124)
- Added parity and fail-closed specs proving facade-identical plans and zero artifacts for unsupported semantics. (Cratis/Screenplay#173)