### PR TITLE
feat: validate Screenplay folders as one application and support single-file input

### DIFF
--- a/Documentation/reference/run.md
+++ b/Documentation/reference/run.md
@@ -1,13 +1,13 @@
 # Run
 
-`cratis run` boots a local [Stage](https://github.com/Cratis/Stage) sandbox from the Screenplay (`.play`) files in a folder. It packages a Chronicle kernel, the Stage engine, and an in-memory event store into a single throwaway container so you can play with an event model straight from its `.play` source — no server to set up, nothing to clean up afterward.
+`cratis run` accepts a Screenplay (`.play`) file or a folder of Screenplay files for a local [Stage](https://github.com/Cratis/Stage) sandbox. It packages a Chronicle kernel, the Stage engine, and an in-memory event store into a single throwaway container so you can play with an event model straight from its `.play` source — no server to set up, nothing to clean up afterward.
 
 ```bash
 cratis run [PATH]
 ```
 
 ```text
-  Running the Screenplay files in /work/invoicing
+  Running Screenplay from /work/invoicing
 
   Stage API           http://localhost:9090
   API reference       http://localhost:9090/scalar/v1
@@ -18,7 +18,14 @@ cratis run [PATH]
   Press Ctrl+C to stop
 ```
 
-You point it at a folder of `.play` files (or run it from inside one), and it hands that folder to the Stage container, which compiles every `.play` file it finds and exposes a live API you can drive — plus the Chronicle Workbench, for looking at what the model does to the event store.
+Point it at one `.play` file, a folder of `.play` files, or omit the path to use the current folder. The selected file or folder is mounted read-only. File input does not mount its parent folder, include sibling files, or follow implementation-file references.
+
+```bash
+cratis run ./screenplays
+cratis run "./screenplays/invoicing model.play"
+```
+
+Single-file input requires a Stage image whose entrypoint accepts the supplied input path. This CLI input change alone does **not** establish support in a live published image; verify the actual image before relying on file input. Folder input searches recursively for `*.play` with case-insensitive matching on every platform.
 
 The container's own output is kept out of the way. While it boots you get a
 progress line — pulling the image, starting Chronicle, compiling the Screenplay
@@ -35,7 +42,7 @@ point on is actually served.
 
 | Argument | Description |
 |---|---|
-| `PATH` | Folder containing the Screenplay (`.play`) files to run. Searched recursively. Defaults to the current directory. |
+| `PATH` | Screenplay (`.play`) file or folder to run. File extensions are checked case-insensitively. Folders are searched recursively using case-insensitive `*.play` matching on every platform. Defaults to the current directory. |
 
 ## Options
 
@@ -50,17 +57,28 @@ Global options such as `-o/--output` are also accepted — see [Global Options](
 
 ## What it does
 
-The command mounts the folder into the Stage container and publishes both of the container's ports to your host:
+For a folder, the command mounts it read-only and publishes both of the container's ports to your host:
 
 ```bash
-docker run --rm --name cratis-stage-a1b2c3d4 -p 9090:9090 -p 35000:35000 -v "$PWD":/eventmodel cratis/stage:latest
+docker run --rm --name cratis-stage-a1b2c3d4 -p 9090:9090 -p 35000:35000 -v "$PWD":/eventmodel:ro cratis/stage:latest
 ```
 
-- The folder is mounted at `/eventmodel` inside the container; Stage globs `**/*.play` beneath it and compiles them.
+For one file, the invocation instead mounts only that exact host file at a fixed path and passes the container path after the image:
+
+```bash
+docker run --rm --name cratis-stage-a1b2c3d4 -p 9090:9090 -p 35000:35000 -v "$PWD/invoicing.play":/eventmodel/input.play:ro cratis/stage:latest /eventmodel/input.play
+```
+
+Paths with spaces remain one process argument; the CLI does not use a shell. Commas in host names remain literal under the existing `-v` syntax. Colons in file or folder names are rejected before Docker rather than escaped or reinterpreted; a native Windows drive prefix is preserved. No new mount parser is introduced.
+
+- A folder is mounted read-only at `/eventmodel` inside the container; Stage globs `**/*.play` beneath it and compiles them.
+- A file is mounted read-only at `/eventmodel/input.play`; the host parent folder is never mounted, even if an older image ignores the input argument. This is not a claim of compatibility with such images.
 - The Stage API is published on `http://localhost:9090` (change the host side with `--port`). Its API reference is at `http://localhost:9090/scalar/v1`.
 - The **Chronicle Workbench** is published on `https://localhost:35000` (change the host side with `--workbench-port`), so you can inspect the session's events, observers and read models while it runs.
 - The container is named `cratis-stage-<random>`, so a running sandbox is recognizable in `docker ps` and several can run side by side on different ports.
 - `--rm` removes the container when it exits, so every run starts from a clean, in-memory store.
+
+This input fix does not address image version pinning or sandbox runtime gaps. The default image tag remains the mutable `latest`; read-only input mounts are not a general isolation guarantee. Existing ports, readiness, cancellation, and session behavior are unchanged.
 
 The Workbench is **HTTPS only** — open `https://localhost:35000`, not `http://`. The Chronicle port multiplexes
 HTTP/1.1 and HTTP/2 through ALPN, which requires TLS, so a plain `http://` request to it returns nothing at all
@@ -110,5 +128,7 @@ container failed.
 | Condition | Result |
 |---|---|
 | The folder contains no `.play` files | Validation error — nothing is started. |
-| The folder does not exist | Validation error. |
+| The file or folder does not exist, or the path is invalid | Validation error — nothing is started. |
+| An existing file does not have a `.play` extension | Validation error — nothing is started. |
+| A file or folder name contains a colon unsupported by `-v` | Validation error — nothing is started. Native Windows drive prefixes are allowed. |
 | `docker` is not installed or not on `PATH` | Connection error with a hint to install Docker. |

--- a/Documentation/reference/screenplay.md
+++ b/Documentation/reference/screenplay.md
@@ -287,7 +287,11 @@ Standard output is the exception: whatever consumes `cratis screenplay generate 
 
 Compiles Screenplay documents and reports everything the compiler found. It does not care what wrote them — `screenplay generate`, [`cratis prologue`](prologue.md), or a person designing a system before any code exists.
 
-`PATH` is a Screenplay (`.play`) file, or a folder — in which case every `.play` file beneath it is compiled. It defaults to the current directory.
+`PATH` is a Screenplay (`.play`) file, or a folder. It defaults to the current directory. A folder compiles every `.play` file beneath it **together as one application**, including nested folders. Concepts and events declared in one file can be referenced from another; you do not need to repeat their declarations. The summary's `Files` count is the number of discovered `.play` files, not the number of applications.
+
+Files are processed in ordinal relative-path order. Modules and features with the same name are combined. Declarations that must be unique across the application are not silently overwritten: duplicate concepts, types, or slices report `PLAY0173`, and more than one domain or authentication block reports `PLAY0172`. Conflicting module or feature descriptions report warning `PLAY0174`; the first description is retained.
+
+A single-file target still compiles only that document; sibling files are not included. Validation checks the Screenplay language, not renderer support or execution-plan admission. Successful validation does not guarantee that `cratis render` supports every construct.
 
 ```bash
 cratis screenplay validate                 # every .play file beneath the current folder
@@ -306,6 +310,8 @@ errors (1):
 warnings (1):
   warning PLAY0166: [MyApp.play(787,11)] Unknown event 'InvitationToJoinAdaAccepted' - declare it with 'event InvitationToJoinAdaAccepted'
 ```
+
+For folder targets, each diagnostic identifies its originating file relative to the selected folder, including its original line and column — positions are never offsets into concatenated source. Compiler `PLAY` codes, messages, and severity are preserved.
 
 With `-o json` or `-o json-compact` the same diagnostics are written to standard error as a JSON object instead.
 

--- a/Source/Cli.Specs/for_RunCommand/given/a_run_command.cs
+++ b/Source/Cli.Specs/for_RunCommand/given/a_run_command.cs
@@ -1,0 +1,51 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Cli.for_RunCommand.given;
+
+/// <summary>
+/// Runs command admission against real temporary inputs with Docker unavailable on PATH.
+/// </summary>
+public class a_run_command : Specification
+{
+    protected string _folder;
+    protected RunSettings _settings;
+    protected StringWriter _error;
+
+    string _previousDirectory;
+    string? _previousPath;
+    TextWriter _previousError;
+
+    void Establish()
+    {
+        _previousDirectory = Directory.GetCurrentDirectory();
+        _previousPath = Environment.GetEnvironmentVariable("PATH");
+        _previousError = Console.Error;
+        _folder = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString())).FullName;
+        Directory.SetCurrentDirectory(_folder);
+        _folder = Directory.GetCurrentDirectory();
+        Environment.SetEnvironmentVariable("PATH", _folder);
+        _error = new StringWriter();
+        Console.SetError(_error);
+        _settings = new RunSettings { Path = _folder, Output = OutputFormats.JsonCompact };
+    }
+
+    /// <summary>
+    /// Executes the run command through its established command interface.
+    /// </summary>
+    /// <returns>The exit code.</returns>
+    protected Task<int> Execute() =>
+        ((ICommand<RunSettings>)new RunCommand()).ExecuteAsync(
+            new CommandContext([], Substitute.For<IRemainingArguments>(), "run", null),
+            _settings,
+            CancellationToken.None);
+
+    void Destroy()
+    {
+        Console.SetError(_previousError);
+        Environment.SetEnvironmentVariable("PATH", _previousPath);
+        Directory.SetCurrentDirectory(_previousDirectory);
+        _error.Dispose();
+        Directory.Delete(_folder, true);
+    }
+}

--- a/Source/Cli.Specs/for_RunCommand/when_invoking_the_cli/with_a_non_play_file.cs
+++ b/Source/Cli.Specs/for_RunCommand/when_invoking_the_cli/with_a_non_play_file.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Cli.for_RunCommand.when_invoking_the_cli;
+
+[Collection(CliSpecsCollection.Name)]
+public class with_a_non_play_file : given.a_run_command
+{
+    int _result;
+
+    void Establish()
+    {
+        _settings.Path = Path.Combine(_folder, "not a screenplay.txt");
+        File.WriteAllText(_settings.Path, "not a screenplay");
+    }
+
+    async Task Because()
+    {
+        // PATH contains only the temporary input folder, with no Docker executable. Reaching Docker would
+        // return ConnectionError instead; exercise real registration and argument binding, not a string helper.
+        _result = await CliApp.Create().RunAsync(["run", _settings.Path!, "--output", OutputFormats.JsonCompact]);
+    }
+
+    [Fact] void should_reject_the_input_before_attempting_docker() => _result.ShouldEqual(ExitCodes.ValidationError);
+    [Fact] void should_report_the_file_admission_error() => _error.ToString().ShouldContain("is not a Screenplay (.play) file");
+}

--- a/Source/Cli.Specs/for_RunCommand/when_running/with_a_colon_in_the_file_name.cs
+++ b/Source/Cli.Specs/for_RunCommand/when_running/with_a_colon_in_the_file_name.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Cli.for_RunCommand.when_running;
+
+[Collection(CliSpecsCollection.Name)]
+public class with_a_colon_in_the_file_name : given.a_run_command
+{
+    int _result;
+
+    void Establish()
+    {
+        _settings.Path = Path.Combine(_folder, "model:part.play");
+        if (!OperatingSystem.IsWindows())
+        {
+            File.WriteAllText(_settings.Path, "domain Selected\n");
+        }
+    }
+
+    async Task Because() => _result = await Execute();
+
+    [Fact] void should_reject_the_path_before_attempting_docker() => _result.ShouldEqual(ExitCodes.ValidationError);
+    [Fact] void should_explain_the_bounded_mount_syntax() => _error.ToString().ShouldContain("cannot represent");
+}

--- a/Source/Cli.Specs/for_RunCommand/when_running/with_a_missing_file.cs
+++ b/Source/Cli.Specs/for_RunCommand/when_running/with_a_missing_file.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Cli.for_RunCommand.when_running;
+
+[Collection(CliSpecsCollection.Name)]
+public class with_a_missing_file : given.a_run_command
+{
+    int _result;
+
+    void Establish()
+    {
+        _settings.Path = Path.Combine(_folder, "missing.play");
+        File.WriteAllText(Path.Combine(_folder, "sibling.play"), "domain Sibling\n");
+    }
+
+    async Task Because() => _result = await Execute();
+
+    [Fact] void should_reject_the_missing_file_before_attempting_docker() => _result.ShouldEqual(ExitCodes.ValidationError);
+    [Fact] void should_report_that_the_path_does_not_exist() => _error.ToString().ShouldContain("does not exist");
+}

--- a/Source/Cli.Specs/for_RunCommand/when_running/with_a_non_play_file.cs
+++ b/Source/Cli.Specs/for_RunCommand/when_running/with_a_non_play_file.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Cli.for_RunCommand.when_running;
+
+[Collection(CliSpecsCollection.Name)]
+public class with_a_non_play_file : given.a_run_command
+{
+    int _result;
+
+    void Establish()
+    {
+        _settings.Path = Path.Combine(_folder, "implementation.cs");
+        File.WriteAllText(_settings.Path, "// Not a Screenplay document");
+        File.WriteAllText(Path.Combine(_folder, "sibling.play"), "domain Sibling\n");
+    }
+
+    async Task Because() => _result = await Execute();
+
+    [Fact] void should_reject_the_file_before_attempting_docker() => _result.ShouldEqual(ExitCodes.ValidationError);
+    [Fact] void should_not_use_the_parent_folder_instead() => _error.ToString().ShouldContain("is not a Screenplay (.play) file");
+}

--- a/Source/Cli.Specs/for_RunCommand/when_running/with_an_empty_folder_named_like_a_play_file.cs
+++ b/Source/Cli.Specs/for_RunCommand/when_running/with_an_empty_folder_named_like_a_play_file.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Cli.for_RunCommand.when_running;
+
+[Collection(CliSpecsCollection.Name)]
+public class with_an_empty_folder_named_like_a_play_file : given.a_run_command
+{
+    int _result;
+
+    void Establish() => _settings.Path = Directory.CreateDirectory(Path.Combine(_folder, "empty.play")).FullName;
+
+    async Task Because() => _result = await Execute();
+
+    [Fact] void should_reject_the_empty_folder_before_attempting_docker() => _result.ShouldEqual(ExitCodes.ValidationError);
+    [Fact] void should_classify_it_as_a_folder() => _error.ToString().ShouldContain("No Screenplay files (.play) found in the folder");
+}

--- a/Source/Cli.Specs/for_RunCommand/when_running/with_an_invalid_path.cs
+++ b/Source/Cli.Specs/for_RunCommand/when_running/with_an_invalid_path.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Cli.for_RunCommand.when_running;
+
+[Collection(CliSpecsCollection.Name)]
+public class with_an_invalid_path : given.a_run_command
+{
+    int _result;
+
+    void Establish() => _settings.Path = "invalid\0.play";
+
+    async Task Because() => _result = await Execute();
+
+    [Fact] void should_reject_the_invalid_path_before_attempting_docker() => _result.ShouldEqual(ExitCodes.ValidationError);
+    [Fact] void should_report_the_invalid_path() => _error.ToString().ShouldContain("path is invalid");
+}

--- a/Source/Cli.Specs/for_RunCommand/when_running/without_a_path_in_an_empty_current_folder.cs
+++ b/Source/Cli.Specs/for_RunCommand/when_running/without_a_path_in_an_empty_current_folder.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Cli.for_RunCommand.when_running;
+
+[Collection(CliSpecsCollection.Name)]
+public class without_a_path_in_an_empty_current_folder : given.a_run_command
+{
+    int _result;
+
+    void Establish() => _settings.Path = null;
+
+    async Task Because() => _result = await Execute();
+
+    [Fact] void should_reject_the_empty_folder_before_attempting_docker() => _result.ShouldEqual(ExitCodes.ValidationError);
+    [Fact] void should_use_the_current_folder() => _error.ToString().ShouldContain("No Screenplay files (.play) found in the folder");
+}

--- a/Source/Cli.Specs/for_RunInput/given/a_temporary_folder.cs
+++ b/Source/Cli.Specs/for_RunInput/given/a_temporary_folder.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Cli.for_RunInput.given;
+
+public class a_temporary_folder : Specification
+{
+    protected string _folder;
+
+    void Establish() => _folder = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString())).FullName;
+
+    void Destroy() => Directory.Delete(_folder, true);
+}

--- a/Source/Cli.Specs/for_RunInput/when_resolving/with_a_comma_in_the_file_name.cs
+++ b/Source/Cli.Specs/for_RunInput/when_resolving/with_a_comma_in_the_file_name.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Cli.for_RunInput.when_resolving;
+
+public class with_a_comma_in_the_file_name : given.a_temporary_folder
+{
+    string _path;
+    RunInput _result;
+
+    void Establish()
+    {
+        _path = Path.Combine(_folder, "model,selected.play");
+        File.WriteAllText(_path, "domain Selected\n");
+    }
+
+    void Because() => _result = RunInput.Resolve(_path);
+
+    [Fact] void should_admit_the_file() => _result.Error.ShouldBeNull();
+    [Fact] void should_preserve_the_literal_comma() => _result.Target!.FullName.ShouldEqual(_path);
+}

--- a/Source/Cli.Specs/for_RunInput/when_resolving/with_a_mixed_case_extension.cs
+++ b/Source/Cli.Specs/for_RunInput/when_resolving/with_a_mixed_case_extension.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Cli.for_RunInput.when_resolving;
+
+public class with_a_mixed_case_extension : given.a_temporary_folder
+{
+    string _path;
+    RunInput _result;
+
+    void Establish()
+    {
+        _path = Path.Combine(_folder, "selected.PlAy");
+        File.WriteAllText(_path, "domain Selected\n");
+    }
+
+    void Because() => _result = RunInput.Resolve(_path);
+
+    [Fact] void should_admit_the_file() => _result.Error.ShouldBeNull();
+    [Fact] void should_classify_it_as_a_file() => _result.Target.ShouldBeOfExactType<FileInfo>();
+    [Fact] void should_preserve_the_host_path_case() => _result.Target!.FullName.ShouldEqual(_path);
+}

--- a/Source/Cli.Specs/for_RunInput/when_resolving/with_a_mixed_case_file_in_a_folder.cs
+++ b/Source/Cli.Specs/for_RunInput/when_resolving/with_a_mixed_case_file_in_a_folder.cs
@@ -1,0 +1,50 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Cli.for_RunInput.when_resolving;
+
+public class with_a_mixed_case_file_in_a_folder : given.a_temporary_folder
+{
+    string _selectedFolder;
+    string _file;
+    string _invalidSibling;
+    string _emptyFolder;
+    RunInput _fileResult;
+    RunInput _folderResult;
+    RunInput _invalidSiblingResult;
+    RunInput _emptyFolderResult;
+    RunInput _missingFileResult;
+    bool _folderContainsPlayFiles;
+
+    void Establish()
+    {
+        _selectedFolder = Directory.CreateDirectory(Path.Combine(_folder, "selected")).FullName;
+        _file = Path.Combine(_selectedFolder, "input.PLAY");
+        _invalidSibling = Path.Combine(_selectedFolder, "sibling.play.txt");
+        _emptyFolder = Directory.CreateDirectory(Path.Combine(_selectedFolder, "empty")).FullName;
+        File.WriteAllText(_file, "domain Selected\n");
+        File.WriteAllText(_invalidSibling, "not a screenplay");
+        File.WriteAllText(Path.Combine(_folder, "parent.play"), "domain Parent\n");
+    }
+
+    void Because()
+    {
+        _fileResult = RunInput.Resolve(_file);
+        _folderResult = RunInput.Resolve(_selectedFolder);
+        _folderContainsPlayFiles = PlayFiles.ExistIn(_selectedFolder);
+        _invalidSiblingResult = RunInput.Resolve(_invalidSibling);
+        _emptyFolderResult = RunInput.Resolve(_emptyFolder);
+        _missingFileResult = RunInput.Resolve(Path.Combine(_selectedFolder, "missing.play"));
+    }
+
+    [Fact] void should_admit_the_selected_file() => _fileResult.Error.ShouldBeNull();
+    [Fact] void should_classify_the_selected_file_as_a_file() => _fileResult.Target.ShouldBeOfExactType<FileInfo>();
+    [Fact] void should_select_only_the_exact_file_not_its_parent_or_sibling() => _fileResult.Target!.FullName.ShouldEqual(_file);
+    [Fact] void should_admit_the_selected_folder() => _folderResult.Error.ShouldBeNull();
+    [Fact] void should_classify_the_selected_folder_as_a_directory() => _folderResult.Target.ShouldBeOfExactType<DirectoryInfo>();
+    [Fact] void should_select_only_the_exact_folder_not_its_parent() => _folderResult.Target!.FullName.ShouldEqual(_selectedFolder);
+    [Fact] void should_discover_the_uppercase_play_file_in_the_folder() => _folderContainsPlayFiles.ShouldBeTrue();
+    [Fact] void should_not_admit_the_invalid_sibling_using_the_valid_file() => _invalidSiblingResult.Target.ShouldBeNull();
+    [Fact] void should_not_admit_the_empty_folder_using_its_parent_files() => _emptyFolderResult.Target.ShouldBeNull();
+    [Fact] void should_not_admit_a_missing_file_using_its_siblings() => _missingFileResult.Target.ShouldBeNull();
+}

--- a/Source/Cli.Specs/for_RunInput/when_resolving/with_a_play_file.cs
+++ b/Source/Cli.Specs/for_RunInput/when_resolving/with_a_play_file.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Cli.for_RunInput.when_resolving;
+
+public class with_a_play_file : given.a_temporary_folder
+{
+    string _path;
+    RunInput _result;
+
+    void Establish()
+    {
+        _path = Path.Combine(_folder, "selected model.play");
+        File.WriteAllText(_path, "domain Selected\n");
+        File.WriteAllText(Path.Combine(_folder, "sibling.play"), "domain Sibling\n");
+    }
+
+    void Because() => _result = RunInput.Resolve(_path);
+
+    [Fact] void should_admit_the_file() => _result.Error.ShouldBeNull();
+    [Fact] void should_classify_it_as_a_file() => _result.Target.ShouldBeOfExactType<FileInfo>();
+    [Fact] void should_select_only_the_exact_file() => _result.Target!.FullName.ShouldEqual(_path);
+}

--- a/Source/Cli.Specs/for_RunInput/when_resolving/with_a_play_named_folder_and_a_nested_file.cs
+++ b/Source/Cli.Specs/for_RunInput/when_resolving/with_a_play_named_folder_and_a_nested_file.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Cli.for_RunInput.when_resolving;
+
+public class with_a_play_named_folder_and_a_nested_file : given.a_temporary_folder
+{
+    string _path;
+    RunInput _result;
+
+    void Establish()
+    {
+        _path = Directory.CreateDirectory(Path.Combine(_folder, "models.play")).FullName;
+        var nested = Directory.CreateDirectory(Path.Combine(_path, "nested")).FullName;
+        File.WriteAllText(Path.Combine(nested, "model.play"), "domain Nested\n");
+    }
+
+    void Because() => _result = RunInput.Resolve(_path);
+
+    [Fact] void should_admit_the_folder_using_recursive_discovery() => _result.Error.ShouldBeNull();
+    [Fact] void should_classify_it_as_a_directory() => _result.Target.ShouldBeOfExactType<DirectoryInfo>();
+    [Fact] void should_keep_the_selected_folder() => _result.Target!.FullName.ShouldEqual(_path);
+}

--- a/Source/Cli.Specs/for_ScreenplayValidation/given/a_folder_with_documents.cs
+++ b/Source/Cli.Specs/for_ScreenplayValidation/given/a_folder_with_documents.cs
@@ -11,6 +11,22 @@ public class a_folder_with_documents : Specification
     protected const string ValidSource = "domain Library\n\nmodule Library\n";
     protected const string InvalidSource = "domain Library\n\nmodule Library\n  feature Lending\n    slice Reserving\n";
 
+    protected const string ConceptsSource = "concept BookId : Uuid\n";
+    protected static readonly string CommandSource = string.Join('\n',
+        "module Library",
+        "  feature Lending",
+        "    slice StateChange Reserving",
+        "      command ReserveBook",
+        "        bookId BookId",
+        "        produces BookReserved",
+        "          bookId = bookId");
+    protected static readonly string EventSource = string.Join('\n',
+        "module Library",
+        "  feature Lending",
+        "    slice StateChange Reservations",
+        "      event BookReserved",
+        "        bookId BookId");
+
     protected string _folder;
     protected ScreenplayValidation _validation;
 

--- a/Source/Cli.Specs/for_ScreenplayValidation/when_validating/and_a_nested_document_has_an_error.cs
+++ b/Source/Cli.Specs/for_ScreenplayValidation/when_validating/and_a_nested_document_has_an_error.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Cli.for_ScreenplayValidation.when_validating;
+
+public class and_a_nested_document_has_an_error : given.a_folder_with_documents
+{
+    ValidatedScreenplay _result;
+
+    void Establish()
+    {
+        WriteDocument("Concepts.play", ConceptsSource);
+        WriteDocument("nested/Broken.play", InvalidSource);
+    }
+
+    void Because() => _result = _validation.Validate(_folder);
+
+    [Fact] void should_count_the_rejected_document() => _result.FileCount.ShouldEqual(2);
+    [Fact] void should_report_the_original_code() => _result.Diagnostics.Single().Code.ShouldEqual("PLAY0027");
+    [Fact] void should_report_the_original_severity() => _result.Diagnostics.Single().Severity.ShouldEqual(ScreenplayDiagnosticSeverity.Error);
+    [Fact] void should_report_the_originating_file_and_position() => _result.Diagnostics.Single().Location.ShouldEqual("nested/Broken.play(5,5)");
+    [Fact] void should_preserve_the_compiler_message() => _result.Diagnostics.Single().Message.ShouldEqual("Invalid slice declaration 'slice Reserving' - expected 'slice <Type> <Name>'");
+}

--- a/Source/Cli.Specs/for_ScreenplayValidation/when_validating/and_concepts_are_declared_in_multiple_files.cs
+++ b/Source/Cli.Specs/for_ScreenplayValidation/when_validating/and_concepts_are_declared_in_multiple_files.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Cli.for_ScreenplayValidation.when_validating;
+
+public class and_concepts_are_declared_in_multiple_files : given.a_folder_with_documents
+{
+    ValidatedScreenplay _result;
+
+    void Establish()
+    {
+        WriteDocument("z.play", "\nconcept BookId : String\n");
+        WriteDocument("B.play", ConceptsSource);
+        WriteDocument("A.play", ConceptsSource);
+    }
+
+    void Because() => _result = _validation.Validate(_folder);
+
+    [Fact] void should_count_all_discovered_files() => _result.FileCount.ShouldEqual(3);
+    [Fact] void should_report_duplicate_and_conflicting_declarations() => _result.Diagnostics.Select(diagnostic => diagnostic.Code).ToArray().ShouldEqual(["PLAY0173", "PLAY0173"]);
+    [Fact] void should_fail_validation() => ScreenplayDiagnostics.ExitCodeFor(_result.Diagnostics).ShouldEqual(ExitCodes.ValidationError);
+    [Fact] void should_order_diagnostics_by_ordinal_path_not_creation_order() => _result.Diagnostics.Select(diagnostic => diagnostic.Location).ToArray().ShouldEqual(["B.play(1,1)", "z.play(2,1)"]);
+    [Fact] void should_identify_the_first_declaration() => _result.Diagnostics.Select(diagnostic => diagnostic.Message).Distinct().Single().ShouldEqual("Duplicate declaration of 'BookId' - already declared in 'A.play'");
+}

--- a/Source/Cli.Specs/for_ScreenplayValidation/when_validating/and_multiple_documents_declare_a_domain.cs
+++ b/Source/Cli.Specs/for_ScreenplayValidation/when_validating/and_multiple_documents_declare_a_domain.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Cli.for_ScreenplayValidation.when_validating;
+
+public class and_multiple_documents_declare_a_domain : given.a_folder_with_documents
+{
+    ValidatedScreenplay _result;
+
+    void Establish()
+    {
+        WriteDocument("First.play", ValidSource);
+        WriteDocument("nested/Second.play", "\ndomain Lending\n");
+    }
+
+    void Because() => _result = _validation.Validate(_folder);
+
+    [Fact] void should_count_both_files() => _result.FileCount.ShouldEqual(2);
+    [Fact] void should_report_the_compiler_conflict_code() => _result.Diagnostics.Single().Code.ShouldEqual("PLAY0172");
+    [Fact] void should_point_to_the_conflicting_domain() => _result.Diagnostics.Single().Location.ShouldEqual("nested/Second.play(2,1)");
+    [Fact] void should_fail_validation() => ScreenplayDiagnostics.ExitCodeFor(_result.Diagnostics).ShouldEqual(ExitCodes.ValidationError);
+}

--- a/Source/Cli.Specs/for_ScreenplayValidation/when_validating/and_the_document_is_valid.cs
+++ b/Source/Cli.Specs/for_ScreenplayValidation/when_validating/and_the_document_is_valid.cs
@@ -8,10 +8,15 @@ public class and_the_document_is_valid : given.a_folder_with_documents
     string _document;
     ValidatedScreenplay _result;
 
-    void Establish() => _document = WriteDocument("MyApp.play", ValidSource);
+    void Establish()
+    {
+        _document = WriteDocument("MyApp.play", ValidSource);
+        WriteDocument("Broken.play", InvalidSource);
+    }
 
     void Because() => _result = _validation.Validate(_document);
 
     [Fact] void should_compile_the_document() => _result.FileCount.ShouldEqual(1);
     [Fact] void should_not_report_anything() => _result.Diagnostics.ShouldBeEmpty();
+    [Fact] void should_produce_one_application_without_reading_siblings() => _result.Applications.Count.ShouldEqual(1);
 }

--- a/Source/Cli.Specs/for_ScreenplayValidation/when_validating/and_the_folder_holds_no_documents.cs
+++ b/Source/Cli.Specs/for_ScreenplayValidation/when_validating/and_the_folder_holds_no_documents.cs
@@ -11,4 +11,5 @@ public class and_the_folder_holds_no_documents : given.a_folder_with_documents
 
     [Fact] void should_compile_nothing() => _result.FileCount.ShouldEqual(0);
     [Fact] void should_not_report_anything() => _result.Diagnostics.ShouldBeEmpty();
+    [Fact] void should_not_fabricate_an_application() => _result.Applications.ShouldBeEmpty();
 }

--- a/Source/Cli.Specs/for_ScreenplayValidation/when_validating/and_the_folder_holds_several_documents.cs
+++ b/Source/Cli.Specs/for_ScreenplayValidation/when_validating/and_the_folder_holds_several_documents.cs
@@ -9,13 +9,18 @@ public class and_the_folder_holds_several_documents : given.a_folder_with_docume
 
     void Establish()
     {
-        WriteDocument("MyApp.play", ValidSource);
-        WriteDocument(Path.Combine("nested", "Broken.play"), InvalidSource);
+        WriteDocument("MyApp.play", CommandSource);
+        WriteDocument(Path.Combine("nested", "Events.play"), EventSource);
+        WriteDocument("Concepts.play", ConceptsSource);
+        WriteDocument("ignored.txt", InvalidSource);
     }
 
     void Because() => _result = _validation.Validate(_folder);
 
-    [Fact] void should_compile_every_document_beneath_it() => _result.FileCount.ShouldEqual(2);
-    [Fact] void should_report_the_error_in_the_nested_document() => ScreenplayDiagnostics.HasErrors(_result.Diagnostics).ShouldBeTrue();
-    [Fact] void should_point_at_the_document_relative_to_the_folder() => _result.Diagnostics[0].Location.ShouldEqual("nested/Broken.play(5,5)");
+    [Fact] void should_count_every_discovered_play_file() => _result.FileCount.ShouldEqual(3);
+    [Fact] void should_resolve_cross_file_events_and_concepts() => _result.Diagnostics.ShouldBeEmpty();
+    [Fact] void should_produce_one_application() => _result.Applications.Count.ShouldEqual(1);
+    [Fact] void should_merge_the_shared_module() => _result.Applications.Single().Modules.Count().ShouldEqual(1);
+    [Fact] void should_merge_the_shared_feature() => _result.Applications.Single().Modules.Single().Features.Single().Slices.Count().ShouldEqual(2);
+    [Fact] void should_retain_the_concept() => _result.Applications.Single().Concepts.Single().Name.ShouldEqual("BookId");
 }

--- a/Source/Cli.Specs/for_StageContainer/when_building_run_arguments/with_matching_ports.cs
+++ b/Source/Cli.Specs/for_StageContainer/when_building_run_arguments/with_matching_ports.cs
@@ -14,6 +14,6 @@ public class with_matching_ports : Specification
     [Fact] void should_name_the_container() => _arguments.ShouldContain("cratis-stage-abc123");
     [Fact] void should_publish_the_host_port_to_the_api_port() => _arguments.ShouldContain("9090:9090");
     [Fact] void should_publish_the_host_port_to_the_workbench_port() => _arguments.ShouldContain("35000:35000");
-    [Fact] void should_mount_the_folder_at_the_model_path() => _arguments.ShouldContain("/work/space:/eventmodel");
+    [Fact] void should_mount_the_folder_read_only_at_the_model_path() => _arguments.ShouldContain("/work/space:/eventmodel:ro");
     [Fact] void should_run_the_tagged_image() => _arguments.ShouldContain("cratis/stage:latest");
 }

--- a/Source/Cli.Specs/for_StageContainer/when_building_run_arguments/with_spaces_in_the_folder_path.cs
+++ b/Source/Cli.Specs/for_StageContainer/when_building_run_arguments/with_spaces_in_the_folder_path.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Cli.for_StageContainer.when_building_run_arguments;
+
+public class with_spaces_in_the_folder_path : Specification
+{
+    IReadOnlyList<string> _arguments;
+
+    void Because() => _arguments = StageContainer.BuildRunArguments("/work/my models", "1.2.0", 9191, 35001, "cratis-stage-abc123");
+
+    [Fact] void should_preserve_the_folder_invocation_order_except_for_read_only_mounting() => _arguments.SequenceEqual(["run", "--rm", "--name", "cratis-stage-abc123", "-p", "9191:9090", "-p", "35001:35000", "-v", "/work/my models:/eventmodel:ro", "cratis/stage:1.2.0"]).ShouldBeTrue();
+    [Fact] void should_keep_the_mount_in_one_unquoted_argument() => _arguments[9].ShouldEqual("/work/my models:/eventmodel:ro");
+    [Fact] void should_keep_the_image_as_the_last_argument() => _arguments[^1].ShouldEqual("cratis/stage:1.2.0");
+}

--- a/Source/Cli.Specs/for_StageContainer/when_building_run_arguments_for_file/with_a_windows_drive_path.cs
+++ b/Source/Cli.Specs/for_StageContainer/when_building_run_arguments_for_file/with_a_windows_drive_path.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Cli.for_StageContainer.when_building_run_arguments_for_file;
+
+public class with_a_windows_drive_path : Specification
+{
+    IReadOnlyList<string> _arguments;
+
+    void Because() => _arguments = StageContainer.BuildRunArgumentsForFile(@"C:\work\my models\selected.play", "latest", 9090, 35000, "cratis-stage-abc123");
+
+    [Fact] void should_preserve_the_drive_prefix_and_backslashes_without_shell_escaping() => _arguments[9].ShouldEqual(@"C:\work\my models\selected.play:/eventmodel/input.play:ro");
+    [Fact] void should_keep_the_default_ports_and_argument_order() => _arguments.SequenceEqual(["run", "--rm", "--name", "cratis-stage-abc123", "-p", "9090:9090", "-p", "35000:35000", "-v", @"C:\work\my models\selected.play:/eventmodel/input.play:ro", "cratis/stage:latest", "/eventmodel/input.play"]).ShouldBeTrue();
+}

--- a/Source/Cli.Specs/for_StageContainer/when_building_run_arguments_for_file/with_spaces_and_a_comma_in_the_file_path.cs
+++ b/Source/Cli.Specs/for_StageContainer/when_building_run_arguments_for_file/with_spaces_and_a_comma_in_the_file_path.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Cli.for_StageContainer.when_building_run_arguments_for_file;
+
+public class with_spaces_and_a_comma_in_the_file_path : Specification
+{
+    IReadOnlyList<string> _arguments;
+
+    void Because() => _arguments = StageContainer.BuildRunArgumentsForFile("/work/my models/selected,model.PlAy", "1.2.0", 9191, 35001, "cratis-stage-abc123");
+
+    [Fact] void should_build_the_exact_ordered_invocation() => _arguments.SequenceEqual(["run", "--rm", "--name", "cratis-stage-abc123", "-p", "9191:9090", "-p", "35001:35000", "-v", "/work/my models/selected,model.PlAy:/eventmodel/input.play:ro", "cratis/stage:1.2.0", "/eventmodel/input.play"]).ShouldBeTrue();
+    [Fact] void should_mount_only_the_exact_file_read_only_in_one_argument() => _arguments[9].ShouldEqual("/work/my models/selected,model.PlAy:/eventmodel/input.play:ro");
+    [Fact] void should_place_the_container_input_path_immediately_after_the_image() => _arguments.Skip(10).SequenceEqual(["cratis/stage:1.2.0", "/eventmodel/input.play"]).ShouldBeTrue();
+    [Fact] void should_not_mount_the_host_parent_folder() => _arguments.ShouldNotContain("/work/my models:/eventmodel:ro");
+    [Fact] void should_have_only_one_mount() => _arguments.Count(argument => argument == "-v").ShouldEqual(1);
+}

--- a/Source/Cli.Specs/for_StageContainer/when_building_stop_arguments.cs
+++ b/Source/Cli.Specs/for_StageContainer/when_building_stop_arguments.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Cli.for_StageContainer;
+
+public class when_building_stop_arguments : Specification
+{
+    IReadOnlyList<string> _arguments;
+
+    void Because() => _arguments = StageContainer.BuildStopArguments("cratis-stage-abc123");
+
+    [Fact] void should_stop_only_the_named_container() => _arguments.SequenceEqual(["stop", "cratis-stage-abc123"]).ShouldBeTrue();
+}

--- a/Source/Cli.Specs/for_ValidateScreenplayCommand/when_validating/and_real_documents_reference_each_other.cs
+++ b/Source/Cli.Specs/for_ValidateScreenplayCommand/when_validating/and_real_documents_reference_each_other.cs
@@ -1,0 +1,53 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text.Json;
+
+namespace Cratis.Cli.for_ValidateScreenplayCommand.when_validating;
+
+[Collection(CliSpecsCollection.Name)]
+public class and_real_documents_reference_each_other : for_ScreenplayValidation.given.a_folder_with_documents
+{
+    TextWriter _previousOutput;
+    TextWriter _previousError;
+    StringWriter _output;
+    StringWriter _error;
+    JsonDocument _summary;
+    int _result;
+
+    void Establish()
+    {
+        WriteDocument("Commands.play", CommandSource);
+        WriteDocument("nested/Events.play", EventSource);
+        WriteDocument("Concepts.play", ConceptsSource);
+        _previousOutput = Console.Out;
+        _previousError = Console.Error;
+        _output = new StringWriter();
+        _error = new StringWriter();
+        Console.SetOut(_output);
+        Console.SetError(_error);
+    }
+
+    async Task Because()
+    {
+        _result = await ((ICommand<ValidateScreenplaySettings>)new ValidateScreenplayCommand()).ExecuteAsync(
+            new CommandContext([], Substitute.For<IRemainingArguments>(), "validate", null),
+            new ValidateScreenplaySettings { Path = _folder, Output = OutputFormats.JsonCompact },
+            CancellationToken.None);
+        _summary = JsonDocument.Parse(_output.ToString());
+    }
+
+    [Fact] void should_succeed() => _result.ShouldEqual(ExitCodes.Success);
+    [Fact] void should_report_the_discovered_file_count() => _summary.RootElement.GetProperty("files").GetInt32().ShouldEqual(3);
+    [Fact] void should_report_no_diagnostics() => _summary.RootElement.GetProperty("diagnostics").GetInt32().ShouldEqual(0);
+    [Fact] void should_not_write_unresolved_reference_warnings() => _error.ToString().ShouldBeEmpty();
+
+    void Destroy()
+    {
+        Console.SetOut(_previousOutput);
+        Console.SetError(_previousError);
+        _output.Dispose();
+        _error.Dispose();
+        _summary?.Dispose();
+    }
+}

--- a/Source/Cli/Commands/Run/PlayFiles.cs
+++ b/Source/Cli/Commands/Run/PlayFiles.cs
@@ -15,11 +15,18 @@ public static class PlayFiles
 
     /// <summary>
     /// Determines whether the given folder contains at least one Screenplay (<c>.play</c>) file,
-    /// searching recursively through all subfolders.
+    /// searching recursively through all subfolders with case-insensitive matching.
     /// </summary>
     /// <param name="path">The folder to search.</param>
     /// <returns>True if one or more <c>.play</c> files are present; otherwise false.</returns>
     public static bool ExistIn(string path) =>
         Directory.Exists(path) &&
-        Directory.EnumerateFiles(path, SearchPattern, SearchOption.AllDirectories).Any();
+        Directory.EnumerateFiles(path, SearchPattern, new EnumerationOptions
+        {
+            RecurseSubdirectories = true,
+            MatchCasing = MatchCasing.CaseInsensitive,
+            MatchType = MatchType.Win32,
+            AttributesToSkip = FileAttributes.None,
+            IgnoreInaccessible = false
+        }).Any();
 }

--- a/Source/Cli/Commands/Run/RunCommand.cs
+++ b/Source/Cli/Commands/Run/RunCommand.cs
@@ -7,12 +7,13 @@ using System.Diagnostics;
 namespace Cratis.Cli.Commands.Run;
 
 /// <summary>
-/// Runs the Screenplay (.play) files in a folder in a local Stage sandbox using Docker.
+/// Runs a Screenplay (.play) file or folder in a local Stage sandbox using Docker.
 /// </summary>
-[LlmDescription("Runs the current folder's Screenplay (.play) files in a local Stage sandbox via Docker. Errors if no .play files are present. The Stage API (default port 9090) and the Chronicle Workbench (default port 35000) are published on the host. The container's output is hidden while it starts; progress is reported until the Stage answers, and the command keeps running until stopped.")]
-[CliCommand("run", "Run the Screenplay (.play) files in the current folder in a local Stage sandbox")]
+[LlmDescription("Runs a Screenplay (.play) file or a folder's Screenplay files in a local Stage sandbox via Docker. Defaults to the current folder, searched recursively with case-insensitive *.play matching on every platform. Mounts only the selected file or folder, read-only. Errors for missing paths, non-.play files, or folders without .play files. File input requires a Stage image that accepts an input path argument; published image compatibility must be verified. The Stage API (default port 9090) and the Chronicle Workbench (default port 35000) are published on the host. The container's output is hidden while it starts; progress is reported until the Stage answers, and the command keeps running until stopped.")]
+[CliCommand("run", "Run a Screenplay (.play) file or folder in a local Stage sandbox")]
 [CliExample("run")]
 [CliExample("run", "./screenplays")]
+[CliExample("run", "./screenplays/invoicing.play")]
 [CliExample("run", "--port", "9191")]
 [LlmOption("--tag", "string", "The cratis/stage image tag to run (default: latest).")]
 [LlmOption("--port", "int", "Host port to publish the Stage API on (default: 9090).")]
@@ -35,24 +36,19 @@ public class RunCommand : AsyncCommand<RunSettings>
     protected override async Task<int> ExecuteAsync(CommandContext context, RunSettings settings, CancellationToken cancellationToken)
     {
         var format = settings.ResolveOutputFormat();
-        var path = Path.GetFullPath(settings.Path ?? Directory.GetCurrentDirectory());
+        var input = RunInput.Resolve(settings.Path ?? Directory.GetCurrentDirectory());
 
-        if (!Directory.Exists(path))
+        if (input.Target is not { } target)
         {
-            OutputFormatter.WriteError(format, $"Folder '{path}' does not exist", "Run this command from a folder that contains one or more .play files, or pass the path to one", ExitCodes.ValidationErrorCode);
+            OutputFormatter.WriteError(format, input.Error!, "Pass an existing .play file or a folder containing .play files; colons in names are not supported", ExitCodes.ValidationErrorCode);
             return ExitCodes.ValidationError;
         }
 
-        if (!PlayFiles.ExistIn(path))
-        {
-            OutputFormatter.WriteError(format, "No Screenplay files (.play) found in the folder", "Run this command from a folder that contains one or more .play files, or pass the path to one", ExitCodes.ValidationErrorCode);
-            return ExitCodes.ValidationError;
-        }
-
+        var path = target.FullName;
         var endpoints = StageEndpoints.For(settings.Port, settings.WorkbenchPort);
         RunOutput.WriteHeader(format, path, endpoints);
 
-        using var session = Start(path, settings);
+        using var session = Start(target, settings);
         if (session is null)
         {
             OutputFormatter.WriteError(format, "Failed to start Docker", "Ensure Docker is installed and the 'docker' command is on your PATH", ExitCodes.ConnectionErrorCode);
@@ -99,10 +95,12 @@ public class RunCommand : AsyncCommand<RunSettings>
         }
     }
 
-    static StageSession? Start(string path, RunSettings settings)
+    static StageSession? Start(FileSystemInfo input, RunSettings settings)
     {
         var name = StageContainer.GenerateName();
-        var arguments = StageContainer.BuildRunArguments(path, settings.Tag, settings.Port, settings.WorkbenchPort, name);
+        var arguments = input is FileInfo
+            ? StageContainer.BuildRunArgumentsForFile(input.FullName, settings.Tag, settings.Port, settings.WorkbenchPort, name)
+            : StageContainer.BuildRunArguments(input.FullName, settings.Tag, settings.Port, settings.WorkbenchPort, name);
 
         try
         {

--- a/Source/Cli/Commands/Run/RunInput.cs
+++ b/Source/Cli/Commands/Run/RunInput.cs
@@ -1,0 +1,53 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Cli.Commands.Run;
+
+/// <summary>
+/// The admitted Screenplay file or folder, or the reason it cannot be run.
+/// </summary>
+/// <param name="Target">The existing file or folder to mount, when admitted.</param>
+/// <param name="Error">The validation error, when the input cannot be admitted.</param>
+internal sealed record RunInput(FileSystemInfo? Target, string? Error)
+{
+    /// <summary>
+    /// Resolves and classifies an input without searching outside it or starting Docker.
+    /// </summary>
+    /// <param name="path">The file or folder path to resolve.</param>
+    /// <returns>The admitted input or its validation error.</returns>
+    public static RunInput Resolve(string path)
+    {
+        try
+        {
+            path = Path.GetFullPath(path);
+        }
+        catch (Exception exception) when (exception is ArgumentException or NotSupportedException or PathTooLongException)
+        {
+            return new(null, "The Screenplay file or folder path is invalid");
+        }
+
+        // Docker's -v syntax uses colons as delimiters. Preserve native Windows drive prefixes, but
+        // do not reinterpret or attempt to escape colons in host file or folder names. Commas are literal here.
+        var source = OperatingSystem.IsWindows() && path.Length > 2 && path[1] == ':' ? path[2..] : path;
+        if (source.Contains(':', StringComparison.Ordinal))
+        {
+            return new(null, "The Screenplay file or folder path contains a colon that Docker's -v syntax cannot represent");
+        }
+
+        if (File.Exists(path))
+        {
+            return string.Equals(Path.GetExtension(path), ".play", StringComparison.OrdinalIgnoreCase)
+                ? new(new FileInfo(path), null)
+                : new(null, $"'{path}' is not a Screenplay (.play) file");
+        }
+
+        if (!Directory.Exists(path))
+        {
+            return new(null, $"File or folder '{path}' does not exist");
+        }
+
+        return PlayFiles.ExistIn(path)
+            ? new(new DirectoryInfo(path), null)
+            : new(null, "No Screenplay files (.play) found in the folder");
+    }
+}

--- a/Source/Cli/Commands/Run/RunOutput.cs
+++ b/Source/Cli/Commands/Run/RunOutput.cs
@@ -19,7 +19,7 @@ public static class RunOutput
     /// Writes the endpoints the session will be reachable on, before it starts.
     /// </summary>
     /// <param name="format">The output format.</param>
-    /// <param name="path">The folder of Screenplay files being run.</param>
+    /// <param name="path">The Screenplay file or folder being run.</param>
     /// <param name="endpoints">The endpoints the session is published on.</param>
     public static void WriteHeader(string format, string path, StageEndpoints endpoints)
     {
@@ -39,7 +39,7 @@ public static class RunOutput
 
         var muted = OutputFormatter.Muted.ToMarkup();
         AnsiConsole.WriteLine();
-        AnsiConsole.MarkupLine($"  [{muted}]Running the Screenplay files in {path.EscapeMarkup()}[/]");
+        AnsiConsole.MarkupLine($"  [{muted}]Running Screenplay from {path.EscapeMarkup()}[/]");
         AnsiConsole.WriteLine();
         OutputFormatter.WriteLabel("Stage API", endpoints.Api, LabelWidth);
         OutputFormatter.WriteLabel("API reference", endpoints.ApiReference, LabelWidth);
@@ -62,7 +62,7 @@ public static class RunOutput
     /// </summary>
     /// <param name="format">The output format.</param>
     /// <param name="startup">The startup the container reported.</param>
-    /// <param name="path">The folder of Screenplay files being run.</param>
+    /// <param name="path">The Screenplay file or folder being run.</param>
     /// <param name="endpoints">The endpoints the session is published on.</param>
     public static void WriteReady(string format, StageStartup startup, string path, StageEndpoints endpoints)
     {

--- a/Source/Cli/Commands/Run/RunSettings.cs
+++ b/Source/Cli/Commands/Run/RunSettings.cs
@@ -9,10 +9,10 @@ namespace Cratis.Cli.Commands.Run;
 public class RunSettings : GlobalSettings
 {
     /// <summary>
-    /// Gets or sets the folder containing the Screenplay files to run. Defaults to the current directory.
+    /// Gets or sets the Screenplay file or folder to run. Defaults to the current directory.
     /// </summary>
     [CommandArgument(0, "[PATH]")]
-    [Description("Folder containing the Screenplay (.play) files to run. Defaults to the current directory.")]
+    [Description("Screenplay (.play) file or folder to run. Folders are searched recursively. Defaults to the current directory.")]
     public string? Path { get; set; }
 
     /// <summary>

--- a/Source/Cli/Commands/Run/StageContainer.cs
+++ b/Source/Cli/Commands/Run/StageContainer.cs
@@ -29,6 +29,11 @@ public static class StageContainer
     public const string MountPath = "/eventmodel";
 
     /// <summary>
+    /// The fixed path inside the container for a single Screenplay file.
+    /// </summary>
+    public const string FileMountPath = "/eventmodel/input.play";
+
+    /// <summary>
     /// The prefix of the name the container is given, so a running sandbox is recognizable in <c>docker ps</c>
     /// and can be stopped by name.
     /// </summary>
@@ -42,9 +47,9 @@ public static class StageContainer
 
     /// <summary>
     /// Builds the argument list for <c>docker run</c> that launches the Stage container with the given
-    /// folder mounted and the Stage API and Chronicle Workbench published on the host.
+    /// folder mounted read-only and the Stage API and Chronicle Workbench published on the host.
     /// </summary>
-    /// <param name="path">The absolute path to the folder of Screenplay files to mount.</param>
+    /// <param name="path">The admitted absolute folder path, representable as a Docker <c>-v</c> source.</param>
     /// <param name="tag">The image tag to run.</param>
     /// <param name="hostPort">The host port to publish the Stage API on.</param>
     /// <param name="workbenchHostPort">The host port to publish the Chronicle Workbench on.</param>
@@ -61,8 +66,34 @@ public static class StageContainer
         "-p",
         $"{workbenchHostPort}:{WorkbenchPort}",
         "-v",
-        $"{path}:{MountPath}",
+        $"{path}:{MountPath}:ro",
         $"{Image}:{tag}"
+    ];
+
+    /// <summary>
+    /// Builds the argument list for <c>docker run</c> with only the selected file mounted read-only.
+    /// The Stage image must accept the container file path as its input argument.
+    /// </summary>
+    /// <param name="path">The admitted absolute file path, representable as a Docker <c>-v</c> source.</param>
+    /// <param name="tag">The image tag to run.</param>
+    /// <param name="hostPort">The host port to publish the Stage API on.</param>
+    /// <param name="workbenchHostPort">The host port to publish the Chronicle Workbench on.</param>
+    /// <param name="name">The name to give the container.</param>
+    /// <returns>The ordered argument list to pass to the <c>docker</c> executable.</returns>
+    public static IReadOnlyList<string> BuildRunArgumentsForFile(string path, string tag, int hostPort, int workbenchHostPort, string name) =>
+    [
+        "run",
+        "--rm",
+        "--name",
+        name,
+        "-p",
+        $"{hostPort}:{ApiPort}",
+        "-p",
+        $"{workbenchHostPort}:{WorkbenchPort}",
+        "-v",
+        $"{path}:{FileMountPath}:ro",
+        $"{Image}:{tag}",
+        FileMountPath
     ];
 
     /// <summary>

--- a/Source/Cli/Commands/Screenplay/ScreenplayValidation.cs
+++ b/Source/Cli/Commands/Screenplay/ScreenplayValidation.cs
@@ -12,9 +12,8 @@ namespace Cratis.Cli.Commands.Screenplay;
 /// Compiles Screenplay documents with the <c>Cratis.Screenplay</c> compiler.
 /// </summary>
 /// <remarks>
-/// This is the only place in the CLI that knows the compiler exists. Everything else is expressed against
-/// <see cref="IScreenplayValidation"/>, and the diagnostics the compiler reports are translated into the same shape
-/// generation reports, so both commands read identically.
+/// Validation compiles a folder as one application, independently of renderer admission. Compiler diagnostics
+/// are translated into the same shape generation reports, so both commands read identically.
 /// </remarks>
 /// <param name="playFileCompiler">Compiles every document beneath a folder.</param>
 /// <param name="compiler">Compiles the source of a single document.</param>
@@ -31,22 +30,20 @@ public sealed class ScreenplayValidation(IPlayFileCompiler playFileCompiler, ISc
     /// <inheritdoc/>
     public ValidatedScreenplay Validate(string targetPath)
     {
-        var compilations = File.Exists(targetPath)
-            ? [CompileFile(targetPath)]
-            : playFileCompiler.CompileIn(targetPath).ToArray();
-
-        return new(
-            compilations.Length,
-            [.. compilations.SelectMany(compilation => compilation.Result.Diagnostics.Select(diagnostic => Map(compilation.File, diagnostic)))])
+        if (File.Exists(targetPath))
         {
-            Applications = [.. compilations.Select(compilation => compilation.Result.Value).OfType<ApplicationSyntax>()]
-        };
+            var file = CompileFile(targetPath);
+            return Map(file.Result, 1, file.File.RelativePath);
+        }
+
+        var folder = playFileCompiler.CompileFolder(targetPath);
+        return Map(folder.Result, folder.Sources.Count(), "Screenplay");
     }
 
     /// <summary>
     /// Translates a compiler diagnostic into the shape the CLI reports.
     /// </summary>
-    /// <param name="file">The file the diagnostic belongs to.</param>
+    /// <param name="fallbackPath">The display path for a diagnostic without a source path.</param>
     /// <param name="diagnostic">The diagnostic the compiler reported.</param>
     /// <returns>The <see cref="ScreenplayDiagnostic"/>.</returns>
     /// <remarks>
@@ -54,12 +51,18 @@ public sealed class ScreenplayValidation(IPlayFileCompiler playFileCompiler, ISc
     /// diagnostic can be looked up, suppressed or matched on rather than only read. The location carries the file
     /// and the position within it, in the <c>file(line,column)</c> form editors and build logs already understand.
     /// </remarks>
-    static ScreenplayDiagnostic Map(PlayFile file, Diagnostic diagnostic) =>
+    static ScreenplayDiagnostic Map(string fallbackPath, Diagnostic diagnostic) =>
         new(
             (ScreenplayDiagnosticSeverity)(int)diagnostic.Severity,
             diagnostic.Code,
             diagnostic.Message,
-            $"{file.RelativePath}({diagnostic.Location.Line},{diagnostic.Location.Column})");
+            $"{diagnostic.Location.Path ?? fallbackPath}({diagnostic.Location.Line},{diagnostic.Location.Column})");
+
+    static ValidatedScreenplay Map(CompilationResult<ApplicationSyntax> result, int fileCount, string fallbackPath) =>
+        new(fileCount, [.. result.Diagnostics.Select(diagnostic => Map(fallbackPath, diagnostic))])
+        {
+            Applications = fileCount > 0 && result.Value is { } application ? [application] : []
+        };
 
     PlayFileCompilation CompileFile(string path)
     {

--- a/Source/Cli/Commands/Screenplay/ValidatedScreenplay.cs
+++ b/Source/Cli/Commands/Screenplay/ValidatedScreenplay.cs
@@ -13,8 +13,9 @@ namespace Cratis.Cli.Commands.Screenplay;
 public record ValidatedScreenplay(int FileCount, IReadOnlyList<ScreenplayDiagnostic> Diagnostics)
 {
     /// <summary>
-    /// Gets the applications the compiler produced — one per document it could compile, and none for a document
-    /// it rejected. Validation only counts them; rendering is what needs them.
+    /// Gets the syntax produced by validation: one application for a single file or a nonempty folder,
+    /// and none when no files were found or no syntax was produced. Syntax may be partial when diagnostics
+    /// contain errors; its presence does not imply successful validation or renderer admission.
     /// </summary>
     public IReadOnlyList<ApplicationSyntax> Applications { get; init; } = [];
 }


### PR DESCRIPTION
## Summary

Closes #65: Compile all `.play` files in a folder as one logical application
Closes #128: Accept a single `.play` file path in `cratis run` with read-only mount

## Changes

### Folder Validation (#65)
- `ScreenplayValidation` now compiles folder contents as one application
- Unified diagnostics across all documents in a folder
- Proper error aggregation and location reporting

### Single-File Input (#128)
- `RunInput` resolves file vs folder paths with validation
- `StageContainer` builds appropriate Docker mounts for files vs folders
- `PlayFiles` updated to handle both input modes
- Case-insensitive file discovery on all platforms

## Testing
- 23 new specs covering edge cases
- Spaces, commas, mixed case extensions
- Missing files, invalid paths, empty folders
- Cross-platform path handling (Windows drive letters)
- Documentation updates for `run.md` and `screenplay.md`

## Verification
- Fresh serialized gate at de90e33: 1,121/1,121 Cli.Specs passed; strict Debug and Release Rebuilds passed with warnings treated as errors; all 37 candidate-file hashes unchanged. Prior 17 failures did not recur, but their cause is unproven. Independent source review remains in progress.
- Clean Debug build
- Documentation linting passes (33 files, 39 links verified)