### PR TITLE
Upgrade to Chronicle 18 and latest packages

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -2,9 +2,9 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-    <CratisArcScreenplayVersion>22.3.0</CratisArcScreenplayVersion>
-    <CratisCritterStackScreenplayVersion>0.23.0</CratisCritterStackScreenplayVersion>
-    <CratisScreenplayGenerationVersion>0.13.2</CratisScreenplayGenerationVersion>
+    <CratisArcScreenplayVersion>22.13.1</CratisArcScreenplayVersion>
+    <CratisCritterStackScreenplayVersion>0.24.0</CratisCritterStackScreenplayVersion>
+    <CratisScreenplayGenerationVersion>0.18.0</CratisScreenplayGenerationVersion>
   </PropertyGroup>
   <ItemGroup>
     <!-- Cratis -->
@@ -14,28 +14,31 @@
     <PackageVersion Include="Cratis.Screenplay.Generation" Version="$(CratisScreenplayGenerationVersion)" />
     <PackageVersion Include="Cratis.Screenplay.Generation.DotNet" Version="$(CratisScreenplayGenerationVersion)" />
     <PackageVersion Include="Cratis.Screenplay.Generation.DotNet.Vogen" Version="$(CratisScreenplayGenerationVersion)" />
-    <PackageVersion Include="Cratis.Chronicle.Connections" Version="16.38.2" />
-    <PackageVersion Include="Cratis.Chronicle.Contracts" Version="16.38.2" />
-    <PackageVersion Include="Cratis.Fundamentals" Version="7.18.1" />
+    <PackageVersion Include="Cratis.Chronicle.Connections" Version="18.1.0" />
+    <PackageVersion Include="Cratis.Chronicle.Contracts" Version="18.1.0" />
+    <PackageVersion Include="Cratis.Fundamentals" Version="7.19.2" />
     <!-- Prologue -->
     <PackageVersion Include="Cratis.Prologue.Configuration" Version="2.0.0" />
     <PackageVersion Include="Cratis.Prologue.Contracts" Version="2.0.0" />
     <PackageVersion Include="Cratis.Prologue.Interpretation" Version="2.0.0" />
     <PackageVersion Include="Cratis.Prologue.Interpreter.Contracts" Version="2.0.0" />
     <PackageVersion Include="Cratis.Prologue.Screenplay" Version="2.0.0" />
+    <!-- Cratis.Arc.Screenplay 22.13.1 is built against Cratis.Screenplay 4.6.0 (its nuspec pins 4.6.0). Keep this
+         pinned to the exact shape the Arc emitter was compiled against: newer Cratis.Screenplay releases changed the
+         ApplicationSyntax record constructors, which the emitter calls directly and which would fail at runtime with a
+         MissingMethodException. Bump this only once Cratis.Arc.Screenplay itself moves past the 4.6.0-based emitter. -->
     <PackageVersion Include="Cratis.Screenplay" Version="4.6.0" />
-    <PackageVersion Include="Cratis.Stage.Contracts" Version="3.10.0" />
-    <PackageVersion Include="Cratis.Stage.Rendering.Cratis" Version="3.10.0" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.11" />
+    <PackageVersion Include="Cratis.Stage.Contracts" Version="3.11.0" />
+    <PackageVersion Include="Cratis.Stage.Rendering.Cratis" Version="3.11.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.12" />
     <!-- CLI -->
-    <PackageVersion Include="MongoDB.Driver" Version="3.11.0" />
+    <PackageVersion Include="MongoDB.Driver" Version="3.11.1" />
     <PackageVersion Include="Spectre.Console" Version="0.57.2" />
     <PackageVersion Include="Spectre.Console.Cli" Version="0.55.0" />
-    <PackageVersion Include="SharpConsoleUI" Version="2.6.2" />
-    <!-- Pin the SharpConsoleUI-transitive AngleSharp to a version without GHSA-pgww-w46g-26qg (NU1902). -->
-    <PackageVersion Include="AngleSharp" Version="1.7.2" />
+    <PackageVersion Include="SharpConsoleUI" Version="2.6.6" />
+    <PackageVersion Include="AngleSharp" Version="1.8.0" />
     <PackageVersion Include="Grpc.Net.Client" Version="2.83.0" />
-    <PackageVersion Include="System.Text.Json" Version="10.0.11" />
+    <PackageVersion Include="System.Text.Json" Version="10.0.12" />
     <!-- Source Generator -->
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.9.0" />
     <!-- Source reading — loading a solution or project into a Roslyn compilation for Screenplay generation. -->
@@ -48,20 +51,22 @@
     <!-- Analysis -->
     <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.556" NoWarn="NU5104" />
     <PackageVersion Include="Roslynator.Analyzers" Version="5.0.0" />
+    <!-- Keep Meziantou at the origin/main version: 3.0.235 re-enables MA0219 (XML doc language) repo-wide, which is a
+         separate cleanup from the Chronicle 18 upgrade. Bump it in its own PR once the corpus is updated. -->
     <PackageVersion Include="Meziantou.Analyzer" Version="3.0.177" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="5.9.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="5.9.0" />
     <!-- Transitive dependency overrides to address known vulnerabilities -->
     <PackageVersion Include="Snappier" Version="1.3.1" />
     <!-- Integration Testing -->
-    <PackageVersion Include="Testcontainers" Version="4.14.0" />
+    <PackageVersion Include="Testcontainers" Version="4.15.0" />
     <!-- Testing -->
-    <PackageVersion Include="Cratis.Specifications" Version="4.0.0" />
-    <PackageVersion Include="Cratis.Specifications.XUnit" Version="4.0.0" />
-    <PackageVersion Include="Cratis.Chronicle.XUnit.Integration" Version="16.38.2" />
+    <PackageVersion Include="Cratis.Specifications" Version="4.1.0" />
+    <PackageVersion Include="Cratis.Specifications.XUnit" Version="4.1.0" />
+    <PackageVersion Include="Cratis.Chronicle.XUnit.Integration" Version="18.1.0" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="4.0.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.10.0" />
     <PackageVersion Include="NSubstitute" Version="6.2.0" />
     <PackageVersion Include="coverlet.collector" Version="10.0.1" />
   </ItemGroup>

--- a/Source/Cli.Specs/for_CliNuGetPackage/when_packing_a_sentinel_package.cs
+++ b/Source/Cli.Specs/for_CliNuGetPackage/when_packing_a_sentinel_package.cs
@@ -97,12 +97,12 @@ public class when_packing_a_sentinel_package : Specification
     {
         RelevantDependencyLibraries().ShouldContainOnly(
         [
-            "Cratis.Arc.Screenplay/22.3.0",
-            "Cratis.CritterStack.Screenplay/0.23.0",
-            "Cratis.Screenplay.Generation.Contracts/0.13.2",
-            "Cratis.Screenplay.Generation.DotNet.Vogen/0.13.2",
-            "Cratis.Screenplay.Generation.DotNet/0.13.2",
-            "Cratis.Screenplay.Generation/0.13.2"
+            "Cratis.Arc.Screenplay/22.13.1",
+            "Cratis.CritterStack.Screenplay/0.24.0",
+            "Cratis.Screenplay.Generation.Contracts/0.18.0",
+            "Cratis.Screenplay.Generation.DotNet.Vogen/0.18.0",
+            "Cratis.Screenplay.Generation.DotNet/0.18.0",
+            "Cratis.Screenplay.Generation/0.18.0"
         ]);
     }
 

--- a/Source/Cli.Specs/for_ProviderScreenplayGeneration/when_generating/with_marten_only.cs
+++ b/Source/Cli.Specs/for_ProviderScreenplayGeneration/when_generating/with_marten_only.cs
@@ -11,7 +11,7 @@ public class with_marten_only : given.an_application_scope
         LoadedFrom(Project("Persistence", MartenPackages, false, MartenSource)));
 
     [Fact] void should_report_marten() => _result.Provenance.Provider.ShouldEqual(ScreenplayProviders.Marten);
-    [Fact] void should_report_the_critter_stack_facade_version_as_the_marten_provider_version() => _result.Provenance.ProviderVersion.ShouldEqual("0.23.0");
+    [Fact] void should_report_the_critter_stack_facade_version_as_the_marten_provider_version() => _result.Provenance.ProviderVersion.ShouldEqual("0.24.0");
     [Fact] void should_execute_the_complete_critter_stack_facade() => _result.Source.ShouldContain("reducer AccountSnapshot => Account");
     [Fact] void should_report_only_marten_package_evidence() => _result.Provenance.Projects.Single().Packages.ShouldContainOnly(MartenPackages);
 }

--- a/Source/Cli.Specs/for_ScreenplayCompatibility/when_assessing/and_the_critter_stack_package_set_is_canonical.cs
+++ b/Source/Cli.Specs/for_ScreenplayCompatibility/when_assessing/and_the_critter_stack_package_set_is_canonical.cs
@@ -15,7 +15,7 @@ public class and_the_critter_stack_package_set_is_canonical : given.compatibilit
             new ResolvedScreenplayPackage("WolverineFx.Marten", "6.29.1")));
 
     [Fact] void should_admit_generation() => _result.BlockingDiagnostic.ShouldBeNull();
-    [Fact] void should_report_the_bundled_provider_version() => _result.Provenance.ProviderVersion.ShouldEqual("0.23.0");
+    [Fact] void should_report_the_bundled_provider_version() => _result.Provenance.ProviderVersion.ShouldEqual("0.24.0");
     [Fact] void should_report_canonical_support() => _result.Provenance.Compatibility.SupportTier.ShouldEqual(ScreenplaySupportTier.Canonical);
     [Fact] void should_keep_recognition_separate() => _result.Provenance.Compatibility.RecognitionStatus.ShouldEqual(ScreenplayRecognitionStatus.Recognized);
     [Fact] void should_require_semantic_review() => _result.Provenance.Compatibility.SemanticConformance.ShouldEqual(ScreenplaySemanticConformance.RequiresHumanReview);

--- a/Source/Cli.Specs/for_ScreenplayCompatibility/when_assessing/and_the_vogen_package_set_is_canonical.cs
+++ b/Source/Cli.Specs/for_ScreenplayCompatibility/when_assessing/and_the_vogen_package_set_is_canonical.cs
@@ -19,5 +19,5 @@ public class and_the_vogen_package_set_is_canonical : given.compatibility_eviden
     [Fact] void should_keep_package_recognition_separate() => _result.Provenance.Compatibility.RecognitionStatus.ShouldEqual(ScreenplayRecognitionStatus.Recognized);
     [Fact] void should_keep_semantic_review_separate() => _result.Provenance.Compatibility.SemanticConformance.ShouldEqual(ScreenplaySemanticConformance.RequiresHumanReview);
     [Fact] void should_not_claim_lowering_before_generation() => _result.Provenance.Compatibility.LoweringFidelity.ShouldEqual(ScreenplayLoweringFidelity.NotEvaluated);
-    [Fact] void should_explain_the_exact_vogen_baseline() => _result.Provenance.Compatibility.Explanation.ShouldContain("Vogen 8.0.7 matches a pinned canonical package set for bundled provider 0.23.0");
+    [Fact] void should_explain_the_exact_vogen_baseline() => _result.Provenance.Compatibility.Explanation.ShouldContain("Vogen 8.0.7 matches a pinned canonical package set for bundled provider 0.24.0");
 }

--- a/Source/Cli/Cli.csproj
+++ b/Source/Cli/Cli.csproj
@@ -82,9 +82,9 @@
     <ItemGroup>
         <!-- Cratis -->
         <Using Include="Cratis.Chronicle.Contracts" />
+        <Using Include="Cratis.Chronicle.Contracts.Commands" />
         <Using Include="Cratis.Chronicle.Contracts.Primitives" />
         <Using Include="Cratis.Chronicle.Connections" />
-        <Using Include="Cratis.Chronicle.Contracts.EventSequences" />
         <Using Include="Cratis.Chronicle.Contracts.Events" />
         <Using Include="Cratis.Chronicle.Contracts.Observation" />
         <Using Include="Cratis.Chronicle.Contracts.Projections" />

--- a/Source/Cli/Commands/Chronicle/Applications/AddApplicationCommand.cs
+++ b/Source/Cli/Commands/Chronicle/Applications/AddApplicationCommand.cs
@@ -17,12 +17,17 @@ public class AddApplicationCommand : ChronicleCommand<AddApplicationSettings>
     /// <inheritdoc/>
     protected override async Task<int> ExecuteCommandAsync(IServices services, AddApplicationSettings settings, string format)
     {
-        await services.Applications.AddApplication(new AddApplicationRequest
+        var result = await services.Applications.AddApplication(new AddApplicationRequest
         {
             Id = Guid.NewGuid(),
             ClientId = settings.ClientId,
             ClientSecret = settings.ClientSecret
         });
+
+        if (HandleCommandResult(result, format) is { } exitCode)
+        {
+            return exitCode;
+        }
 
         OutputFormatter.WriteMessage(format, $"Application '{settings.ClientId}' added.");
         return ExitCodes.Success;

--- a/Source/Cli/Commands/Chronicle/Applications/RemoveApplicationCommand.cs
+++ b/Source/Cli/Commands/Chronicle/Applications/RemoveApplicationCommand.cs
@@ -20,10 +20,15 @@ public class RemoveApplicationCommand : ChronicleCommand<RemoveApplicationSettin
     /// <inheritdoc/>
     protected override async Task<int> ExecuteCommandAsync(IServices services, RemoveApplicationSettings settings, string format)
     {
-        await services.Applications.RemoveApplication(new RemoveApplicationRequest
+        var result = await services.Applications.RemoveApplication(new RemoveApplicationRequest
         {
             Id = settings.AppId
         });
+
+        if (HandleCommandResult(result, format) is { } exitCode)
+        {
+            return exitCode;
+        }
 
         OutputFormatter.WriteMessage(format, $"Application '{settings.AppId}' removed.");
         return ExitCodes.Success;

--- a/Source/Cli/Commands/Chronicle/ChronicleCommand.cs
+++ b/Source/Cli/Commands/Chronicle/ChronicleCommand.cs
@@ -25,6 +25,50 @@ public abstract partial class ChronicleCommand<TSettings> : AsyncCommand<TSettin
     static partial Regex ConnectionStringCredentialsRegex { get; }
 
     /// <summary>
+    /// Surfaces a server-side failure carried by a <see cref="CommandResult"/>, or reports success.
+    /// </summary>
+    /// <remarks>
+    /// Chronicle 18 command (write) RPCs report server-side failures through the returned
+    /// <see cref="CommandResult"/> instead of throwing an <see cref="RpcException"/> as pre-18 kernels did.
+    /// A call such as performing a recommendation that does not exist no longer surfaces an
+    /// <see cref="RpcException"/> to the connection-level handler — the command itself has to inspect the
+    /// result or a failure is silently reported as success. This inspects the result and, on failure, writes the
+    /// server's message to the error stream and returns <see cref="ExitCodes.ServerError"/>. On success it
+    /// returns <see langword="null"/> so the caller can continue with its normal success path.
+    /// </remarks>
+    /// <param name="result">The command result returned by the Chronicle server.</param>
+    /// <param name="format">The resolved output format.</param>
+    /// <returns><see cref="ExitCodes.ServerError"/> when the server reported a failure, otherwise <see langword="null"/>.</returns>
+    protected static int? HandleCommandResult(CommandResult result, string format)
+    {
+        if (result.IsSuccess)
+        {
+            return null;
+        }
+
+        string message;
+        if (result.ExceptionMessages.Count > 0)
+        {
+            message = string.Join("; ", result.ExceptionMessages);
+        }
+        else if (result.AuthorizationFailureReason is { Length: > 0 } authorizationFailure)
+        {
+            message = authorizationFailure;
+        }
+        else if (result.ValidationResults.Count > 0)
+        {
+            message = string.Join("; ", result.ValidationResults.Select(_ => _.Message));
+        }
+        else
+        {
+            message = "The server rejected the operation";
+        }
+
+        OutputFormatter.WriteError(format, $"Server error: {message}", errorCode: ExitCodes.ServerErrorCode);
+        return ExitCodes.ServerError;
+    }
+
+    /// <summary>
     /// Gets the destructive-operation confirmation prompt, or <see langword="null"/> when the command does not require confirmation.
     /// Confirmation is evaluated before connection setup so a declined or unavailable prompt cannot contact Chronicle or load connection credentials.
     /// </summary>

--- a/Source/Cli/Commands/Chronicle/Diagnose/DiagnoseCommand.cs
+++ b/Source/Cli/Commands/Chronicle/Diagnose/DiagnoseCommand.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Text.RegularExpressions;
+using Cratis.Chronicle.Contracts.Sequences;
 
 namespace Cratis.Cli.Commands.Chronicle.Diagnose;
 
@@ -85,7 +86,7 @@ public partial class DiagnoseCommand : ChronicleCommand<DiagnoseSettings>
         try
         {
             var result = await services.EventStores.AllEventStores();
-            eventStores = [.. result.Data ?? []];
+            eventStores = [.. (result.Data ?? []).Select(x => x.Name)];
         }
         catch { }
 
@@ -129,9 +130,9 @@ public partial class DiagnoseCommand : ChronicleCommand<DiagnoseSettings>
             {
                 EventStore = eventStore,
                 Namespace = ns
-            })).ToList();
+            })).Data;
 
-            pendingRecommendations = recs.Count;
+            pendingRecommendations = (recs ?? []).Count();
         }
         catch { }
 
@@ -139,14 +140,14 @@ public partial class DiagnoseCommand : ChronicleCommand<DiagnoseSettings>
         ulong? eventSequenceTail = null;
         try
         {
-            var tail = await services.EventSequences.GetTailSequenceNumber(new GetTailSequenceNumberRequest
+            var tail = await services.Sequences.TailSequenceNumber(new TailSequenceNumberRequest
             {
                 EventStore = eventStore,
                 Namespace = ns,
                 EventSequenceId = CliDefaults.DefaultEventSequenceId
             });
 
-            eventSequenceTail = tail.SequenceNumber == ulong.MaxValue ? null : tail.SequenceNumber;
+            eventSequenceTail = tail.Data.SequenceNumber == ulong.MaxValue ? null : tail.Data.SequenceNumber;
         }
         catch { }
 

--- a/Source/Cli/Commands/Chronicle/EventStoreSelector.cs
+++ b/Source/Cli/Commands/Chronicle/EventStoreSelector.cs
@@ -61,7 +61,7 @@ public static class EventStoreSelector
             {
                 using var client = await CliChronicleConnection.Connect(connectionString);
                 var result = await client.Services.EventStores.AllEventStores();
-                return (result.Data ?? []).ToList();
+                return (result.Data ?? []).Select(x => x.Name).ToList();
             }).GetAwaiter().GetResult();
         }
         catch

--- a/Source/Cli/Commands/Chronicle/EventStores/ListEventStoresCommand.cs
+++ b/Source/Cli/Commands/Chronicle/EventStores/ListEventStoresCommand.cs
@@ -16,7 +16,7 @@ public class ListEventStoresCommand : ChronicleCommand<ChronicleSettings>
     protected override async Task<int> ExecuteCommandAsync(IServices services, ChronicleSettings settings, string format)
     {
         var eventStores = await services.EventStores.AllEventStores();
-        var names = (eventStores.Data ?? []).ToList();
+        var names = (eventStores.Data ?? []).Select(x => x.Name).ToList();
 
         OutputFormatter.Write(
             format,

--- a/Source/Cli/Commands/Chronicle/EventTypes/ListEventTypesCommand.cs
+++ b/Source/Cli/Commands/Chronicle/EventTypes/ListEventTypesCommand.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Cratis.Chronicle.Contracts.EventTypes;
+
 namespace Cratis.Cli.Commands.Chronicle.EventTypes;
 
 /// <summary>
@@ -16,8 +18,8 @@ public class ListEventTypesCommand : ChronicleCommand<EventStoreSettings>
     /// <inheritdoc/>
     protected override async Task<int> ExecuteCommandAsync(IServices services, EventStoreSettings settings, string format)
     {
-        var registrations = await services.EventTypes.GetAllRegistrations(new GetAllEventTypesRequest { EventStore = settings.ResolveEventStore() });
-        var list = registrations.ToList();
+        var registrations = await services.EventTypes.AllEventTypes(new AllEventTypesRequest { EventStore = settings.ResolveEventStore() });
+        var list = (registrations.Data ?? []).ToList();
 
         if (string.Equals(format, OutputFormats.Json, StringComparison.Ordinal) || string.Equals(format, OutputFormats.JsonCompact, StringComparison.Ordinal))
         {

--- a/Source/Cli/Commands/Chronicle/EventTypes/ShowEventTypeCommand.cs
+++ b/Source/Cli/Commands/Chronicle/EventTypes/ShowEventTypeCommand.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Cratis.Chronicle.Contracts.EventTypes;
 using Cratis.Cli.Commands.Chronicle.Events;
 
 namespace Cratis.Cli.Commands.Chronicle.EventTypes;
@@ -21,12 +22,12 @@ public class ShowEventTypeCommand : ChronicleCommand<ShowEventTypeSettings>
     {
         var parsed = EventTypeParser.ParseEventType(settings.EventType);
 
-        var registrations = await services.EventTypes.GetAllRegistrations(new GetAllEventTypesRequest
+        var registrations = await services.EventTypes.AllEventTypes(new AllEventTypesRequest
         {
             EventStore = settings.ResolveEventStore()
         });
 
-        var match = registrations.FirstOrDefault(r =>
+        var match = (registrations.Data ?? []).FirstOrDefault(r =>
             string.Equals(r.Type.Id, parsed.Id, StringComparison.OrdinalIgnoreCase) &&
             r.Type.Generation == parsed.Generation);
 

--- a/Source/Cli/Commands/Chronicle/Events/CountEventsCommand.cs
+++ b/Source/Cli/Commands/Chronicle/Events/CountEventsCommand.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Cratis.Chronicle.Contracts.Sequences;
+
 namespace Cratis.Cli.Commands.Chronicle.Events;
 
 /// <summary>
@@ -15,7 +17,7 @@ public class CountEventsCommand : ChronicleCommand<CountEventsSettings>
     /// <inheritdoc/>
     protected override async Task<int> ExecuteCommandAsync(IServices services, CountEventsSettings settings, string format)
     {
-        var request = new GetTailSequenceNumberRequest
+        var request = new TailSequenceNumberRequest
         {
             EventStore = settings.ResolveEventStore(),
             Namespace = settings.ResolveNamespace(),
@@ -24,7 +26,7 @@ public class CountEventsCommand : ChronicleCommand<CountEventsSettings>
 
         if (!string.IsNullOrWhiteSpace(settings.EventType))
         {
-            request.EventTypes = EventTypeParser.ParseEventTypes(settings.EventType);
+            request.EventTypeIds = string.Join(',', EventTypeParser.ParseEventTypes(settings.EventType).Select(_ => _.Id));
         }
 
         if (!string.IsNullOrWhiteSpace(settings.EventSourceId))
@@ -32,17 +34,17 @@ public class CountEventsCommand : ChronicleCommand<CountEventsSettings>
             request.EventSourceId = settings.EventSourceId;
         }
 
-        var response = await services.EventSequences.GetTailSequenceNumber(request);
+        var response = await services.Sequences.TailSequenceNumber(request);
 
         if (string.Equals(format, OutputFormats.Json, StringComparison.Ordinal) || string.Equals(format, OutputFormats.JsonCompact, StringComparison.Ordinal))
         {
-            OutputFormatter.WriteObject(format, new { tailSequenceNumber = response.SequenceNumber });
+            OutputFormatter.WriteObject(format, new { tailSequenceNumber = response.Data.SequenceNumber });
         }
         else
         {
             OutputFormatter.Write(
                 format,
-                [response.SequenceNumber],
+                [response.Data.SequenceNumber],
                 ["TailSequenceNumber"],
                 n => [n.ToString()]);
         }

--- a/Source/Cli/Commands/Chronicle/Events/GetEventsCommand.cs
+++ b/Source/Cli/Commands/Chronicle/Events/GetEventsCommand.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Cratis.Chronicle.Contracts.Sequences;
+
 namespace Cratis.Cli.Commands.Chronicle.Events;
 
 /// <summary>
@@ -17,29 +19,31 @@ public class GetEventsCommand : ChronicleCommand<GetEventsSettings>
     /// <inheritdoc/>
     protected override async Task<int> ExecuteCommandAsync(IServices services, GetEventsSettings settings, string format)
     {
-        var request = new GetFromEventSequenceNumberRequest
+        var request = new FromSequenceNumberRequest
         {
             EventStore = settings.ResolveEventStore(),
             Namespace = settings.ResolveNamespace(),
             EventSequenceId = settings.EventSequenceId,
             FromEventSequenceNumber = settings.From,
-            ToEventSequenceNumber = settings.To,
             EventSourceId = settings.EventSourceId
         };
 
         if (!string.IsNullOrEmpty(settings.EventType))
         {
-            foreach (var parsed in EventTypeParser.ParseEventTypes(settings.EventType))
-            {
-                request.EventTypes.Add(parsed);
-            }
+            request.EventTypeIds = string.Join(',', EventTypeParser.ParseEventTypes(settings.EventType).Select(_ => _.Id));
         }
 
-        var response = await services.EventSequences.GetEventsFromEventSequenceNumber(request);
+        // Chronicle 18 has no server-side upper bound on the range, so the --to filter is applied client-side.
+        var response = await services.Sequences.FromSequenceNumber(request);
+        var events = (response.Data ?? []).AsEnumerable();
+        if (settings.To is { } to)
+        {
+            events = events.Where(evt => evt.Context.SequenceNumber <= to);
+        }
 
         if (string.Equals(format, OutputFormats.Json, StringComparison.Ordinal) || string.Equals(format, OutputFormats.JsonCompact, StringComparison.Ordinal))
         {
-            var dtos = response.Events.Select(evt =>
+            var dtos = events.Select(evt =>
             {
                 var ctx = evt.Context;
                 JsonElement? content = null;
@@ -67,7 +71,7 @@ public class GetEventsCommand : ChronicleCommand<GetEventsSettings>
         {
             OutputFormatter.Write(
                 format,
-                response.Events,
+                events,
                 ["Seq#", "EventType", "EventSourceId", "Occurred"],
                 evt =>
                 [

--- a/Source/Cli/Commands/Chronicle/Identities/ListIdentitiesCommand.cs
+++ b/Source/Cli/Commands/Chronicle/Identities/ListIdentitiesCommand.cs
@@ -23,7 +23,7 @@ public class ListIdentitiesCommand : ChronicleCommand<EventStoreSettings>
             Namespace = settings.ResolveNamespace()
         });
 
-        var list = identities.ToList();
+        var list = (identities.Data ?? []).ToList();
 
         OutputFormatter.Write(
             format,

--- a/Source/Cli/Commands/Chronicle/Jobs/ResumeJobCommand.cs
+++ b/Source/Cli/Commands/Chronicle/Jobs/ResumeJobCommand.cs
@@ -27,12 +27,17 @@ public class ResumeJobCommand : ChronicleCommand<JobCommandSettings>
             return ExitCodes.ValidationError;
         }
 
-        await services.Jobs.ResumeJob(new ResumeJobRequest
+        var result = await services.Jobs.ResumeJob(new ResumeJobRequest
         {
             EventStore = settings.ResolveEventStore(),
             Namespace = settings.ResolveNamespace(),
             JobId = jobId
         });
+
+        if (HandleCommandResult(result, format) is { } exitCode)
+        {
+            return exitCode;
+        }
 
         OutputFormatter.WriteMessage(format, $"Job {settings.JobId} resumed successfully");
         return ExitCodes.Success;

--- a/Source/Cli/Commands/Chronicle/Jobs/StopJobCommand.cs
+++ b/Source/Cli/Commands/Chronicle/Jobs/StopJobCommand.cs
@@ -27,12 +27,17 @@ public class StopJobCommand : ChronicleCommand<JobCommandSettings>
             return ExitCodes.ValidationError;
         }
 
-        await services.Jobs.StopJob(new StopJobRequest
+        var result = await services.Jobs.StopJob(new StopJobRequest
         {
             EventStore = settings.ResolveEventStore(),
             Namespace = settings.ResolveNamespace(),
             JobId = jobId
         });
+
+        if (HandleCommandResult(result, format) is { } exitCode)
+        {
+            return exitCode;
+        }
 
         OutputFormatter.WriteMessage(format, $"Job {settings.JobId} stopped successfully");
         return ExitCodes.Success;

--- a/Source/Cli/Commands/Chronicle/Namespaces/ListNamespacesCommand.cs
+++ b/Source/Cli/Commands/Chronicle/Namespaces/ListNamespacesCommand.cs
@@ -19,7 +19,7 @@ public class ListNamespacesCommand : ChronicleCommand<EventStoreSettings>
     protected override async Task<int> ExecuteCommandAsync(IServices services, EventStoreSettings settings, string format)
     {
         var namespaces = await services.Namespaces.AllNamespaces(new AllNamespacesRequest { EventStore = settings.ResolveEventStore() });
-        var names = (namespaces.Data ?? []).ToList();
+        var names = (namespaces.Data ?? []).Select(x => x.Name).ToList();
 
         OutputFormatter.Write(
             format,

--- a/Source/Cli/Commands/Chronicle/ReadModels/GetReadModelSnapshotsCommand.cs
+++ b/Source/Cli/Commands/Chronicle/ReadModels/GetReadModelSnapshotsCommand.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Cratis.Chronicle.Contracts.ReadModelExplorer;
+
 namespace Cratis.Cli.Commands.Chronicle.ReadModels;
 
 /// <summary>
@@ -17,16 +19,16 @@ public class GetReadModelSnapshotsCommand : ChronicleCommand<ReadModelKeySetting
     /// <inheritdoc/>
     protected override async Task<int> ExecuteCommandAsync(IServices services, ReadModelKeySettings settings, string format)
     {
-        var response = await services.ReadModels.GetSnapshotsByKey(new GetSnapshotsByKeyRequest
+        var response = await services.ReadModelExplorer.AllSnapshotsForReadModel(new AllSnapshotsForReadModelRequest
         {
             EventStore = settings.ResolveEventStore(),
             Namespace = settings.ResolveNamespace(),
-            ReadModelIdentifier = settings.ReadModel,
+            ReadModel = settings.ReadModel,
             EventSequenceId = settings.EventSequenceId,
             ReadModelKey = settings.Key
         });
 
-        var snapshots = (response.Snapshots ?? []).ToList();
+        var snapshots = (response.Data ?? []).ToList();
 
         if (snapshots.Count == 0)
         {
@@ -37,13 +39,13 @@ public class GetReadModelSnapshotsCommand : ChronicleCommand<ReadModelKeySetting
         OutputFormatter.Write(
             format,
             snapshots,
-            ["Occurred", "CorrelationId", "Events", "ReadModel"],
+            ["Occurred", "CorrelationId", "Events", "Instance"],
             snap =>
             [
                 snap.Occurred?.ToString() ?? string.Empty,
                 snap.CorrelationId.ToString(),
-                snap.Events.Count.ToString(),
-                snap.ReadModel.Length > 80 ? snap.ReadModel[..80] + "..." : snap.ReadModel
+                snap.Events.Count().ToString(),
+                snap.Instance.Length > 80 ? snap.Instance[..80] + "..." : snap.Instance
             ]);
 
         return ExitCodes.Success;

--- a/Source/Cli/Commands/Chronicle/Recommendations/IgnoreRecommendationCommand.cs
+++ b/Source/Cli/Commands/Chronicle/Recommendations/IgnoreRecommendationCommand.cs
@@ -19,13 +19,17 @@ public class IgnoreRecommendationCommand : ChronicleCommand<RecommendationAction
     /// <inheritdoc/>
     protected override async Task<int> ExecuteCommandAsync(IServices services, RecommendationActionSettings settings, string format)
     {
-        // The Ignore RPC reuses the Perform request message type per the protobuf contract.
-        await services.Recommendations.Ignore(new Perform
+        var result = await services.Recommendations.IgnoreRecommendation(new IgnoreRecommendationRequest
         {
             EventStore = settings.ResolveEventStore(),
             Namespace = settings.ResolveNamespace(),
             RecommendationId = settings.RecommendationId
         });
+
+        if (HandleCommandResult(result, format) is { } exitCode)
+        {
+            return exitCode;
+        }
 
         OutputFormatter.WriteMessage(format, $"Recommendation '{settings.RecommendationId}' ignored");
         return ExitCodes.Success;

--- a/Source/Cli/Commands/Chronicle/Recommendations/ListRecommendationsCommand.cs
+++ b/Source/Cli/Commands/Chronicle/Recommendations/ListRecommendationsCommand.cs
@@ -21,7 +21,7 @@ public class ListRecommendationsCommand : ChronicleCommand<EventStoreSettings>
             Namespace = settings.ResolveNamespace()
         });
 
-        var list = recommendations.ToList();
+        var list = (recommendations.Data ?? []).ToList();
 
         OutputFormatter.Write(
             format,

--- a/Source/Cli/Commands/Chronicle/Recommendations/PerformRecommendationCommand.cs
+++ b/Source/Cli/Commands/Chronicle/Recommendations/PerformRecommendationCommand.cs
@@ -19,12 +19,17 @@ public class PerformRecommendationCommand : ChronicleCommand<RecommendationActio
     /// <inheritdoc/>
     protected override async Task<int> ExecuteCommandAsync(IServices services, RecommendationActionSettings settings, string format)
     {
-        await services.Recommendations.Perform(new Perform
+        var result = await services.Recommendations.PerformRecommendation(new PerformRecommendationRequest
         {
             EventStore = settings.ResolveEventStore(),
             Namespace = settings.ResolveNamespace(),
             RecommendationId = settings.RecommendationId
         });
+
+        if (HandleCommandResult(result, format) is { } exitCode)
+        {
+            return exitCode;
+        }
 
         OutputFormatter.WriteMessage(format, $"Recommendation '{settings.RecommendationId}' performed");
         return ExitCodes.Success;

--- a/Source/Cli/Commands/Chronicle/Users/AddUserCommand.cs
+++ b/Source/Cli/Commands/Chronicle/Users/AddUserCommand.cs
@@ -18,13 +18,18 @@ public class AddUserCommand : ChronicleCommand<AddUserSettings>
     /// <inheritdoc/>
     protected override async Task<int> ExecuteCommandAsync(IServices services, AddUserSettings settings, string format)
     {
-        await services.Users.AddUser(new AddUserRequest
+        var result = await services.Users.AddUser(new AddUserRequest
         {
             UserId = Guid.NewGuid(),
             Username = settings.Username,
             Email = settings.Email,
             Password = settings.Password
         });
+
+        if (HandleCommandResult(result, format) is { } exitCode)
+        {
+            return exitCode;
+        }
 
         OutputFormatter.WriteMessage(format, $"User '{settings.Username}' added.");
         return ExitCodes.Success;

--- a/Source/Cli/Commands/Chronicle/Users/RemoveUserCommand.cs
+++ b/Source/Cli/Commands/Chronicle/Users/RemoveUserCommand.cs
@@ -20,10 +20,15 @@ public class RemoveUserCommand : ChronicleCommand<RemoveUserSettings>
     /// <inheritdoc/>
     protected override async Task<int> ExecuteCommandAsync(IServices services, RemoveUserSettings settings, string format)
     {
-        await services.Users.RemoveUser(new RemoveUserRequest
+        var result = await services.Users.RemoveUser(new RemoveUserRequest
         {
             UserId = settings.UserId
         });
+
+        if (HandleCommandResult(result, format) is { } exitCode)
+        {
+            return exitCode;
+        }
 
         OutputFormatter.WriteMessage(format, $"User '{settings.UserId}' removed.");
         return ExitCodes.Success;

--- a/Source/Cli/Commands/Chronicle/Workbench/WorkbenchData.cs
+++ b/Source/Cli/Commands/Chronicle/Workbench/WorkbenchData.cs
@@ -1,9 +1,11 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Cratis.Chronicle.Contracts.EventTypes;
 using Cratis.Chronicle.Contracts.Identities;
 using Cratis.Chronicle.Contracts.Jobs;
 using Cratis.Chronicle.Contracts.Observation.EventStoreSubscriptions;
+using Cratis.Chronicle.Contracts.Sequences;
 
 namespace Cratis.Cli.Commands.Chronicle.Workbench;
 
@@ -63,14 +65,14 @@ public record WorkbenchData(
     IReadOnlyList<ObserverInformation> Observers,
     IReadOnlyList<FailedPartition> FailedPartitions,
     IReadOnlyList<JobSummaryResponse> Jobs,
-    IReadOnlyList<Recommendation> Recommendations,
+    IReadOnlyList<RecommendationDetailsResponse> Recommendations,
     ulong? TailSequenceNumber,
     DateTimeOffset CapturedAt,
     string? FetchError,
-    IReadOnlyList<EventTypeRegistration> EventTypeRegistrations,
+    IReadOnlyList<EventTypeDetailsResponse> EventTypeRegistrations,
     IReadOnlyList<ProjectionDefinition> ProjectionDefinitions,
     IReadOnlyDictionary<string, string> ProjectionDeclarations,
-    IReadOnlyList<AppendedEvent> RecentEvents,
+    IReadOnlyList<AppendedEventResponse> RecentEvents,
     IReadOnlyList<WorkbenchReadModel> ReadModelDefinitions,
     IReadOnlyList<string> NamespaceNames,
     IReadOnlyList<string> ReadModelInstances,
@@ -78,7 +80,7 @@ public record WorkbenchData(
     string? ReadModelInstancesError,
     IReadOnlyList<ApplicationResponse> Applications,
     IReadOnlyList<UserResponse> Users,
-    IReadOnlyList<Identity> Identities,
+    IReadOnlyList<IdentityDetailsResponse> Identities,
     IReadOnlyList<EventStoreSubscriptionDefinition> EventStoreSubscriptions)
 {
     /// <summary>

--- a/Source/Cli/Commands/Chronicle/Workbench/WorkbenchDataService.cs
+++ b/Source/Cli/Commands/Chronicle/Workbench/WorkbenchDataService.cs
@@ -3,10 +3,12 @@
 
 using System.Reactive.Linq;
 using System.Text.Json;
+using Cratis.Chronicle.Contracts.EventTypes;
 using Cratis.Chronicle.Contracts.Identities;
 using Cratis.Chronicle.Contracts.Jobs;
 using Cratis.Chronicle.Contracts.Namespaces;
 using Cratis.Chronicle.Contracts.Observation.EventStoreSubscriptions;
+using Cratis.Chronicle.Contracts.Sequences;
 using Cratis.Cli.Commands.Chronicle.ReadModels;
 
 namespace Cratis.Cli.Commands.Chronicle.Workbench;
@@ -125,7 +127,7 @@ public class WorkbenchDataService(IServices services, WorkbenchSettings settings
     /// <param name="activeNamespace">Override for the active namespace (null uses settings default).</param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>New events ordered oldest-first, or an empty list if none.</returns>
-    public async Task<IReadOnlyList<AppendedEvent>> FetchNewEventsAsync(
+    public async Task<IReadOnlyList<AppendedEventResponse>> FetchNewEventsAsync(
         ulong afterSequenceNumber,
         string? activeEventStore,
         string? activeNamespace,
@@ -136,15 +138,15 @@ public class WorkbenchDataService(IServices services, WorkbenchSettings settings
 
         try
         {
-            var eventsResp = await services.EventSequences.GetEventsFromEventSequenceNumber(
-                new GetFromEventSequenceNumberRequest
+            var eventsResp = await services.Sequences.FromSequenceNumber(
+                new FromSequenceNumberRequest
                 {
                     EventStore = eventStore,
                     Namespace = ns,
                     EventSequenceId = CliDefaults.DefaultEventSequenceId,
                     FromEventSequenceNumber = afterSequenceNumber + 1
                 }).ConfigureAwait(false);
-            return [.. eventsResp.Events.OrderBy(e => e.Context.SequenceNumber)];
+            return [.. (eventsResp.Data ?? []).OrderBy(e => e.Context.SequenceNumber)];
         }
         catch
         {
@@ -170,7 +172,7 @@ public class WorkbenchDataService(IServices services, WorkbenchSettings settings
         try
         {
             var result = await services.EventStores.AllEventStores().ConfigureAwait(false);
-            return [.. result.Data ?? []];
+            return [.. (result.Data ?? []).Select(x => x.Name)];
         }
         catch { return []; }
     }
@@ -215,15 +217,16 @@ public class WorkbenchDataService(IServices services, WorkbenchSettings settings
         catch { return []; }
     }
 
-    async Task<IReadOnlyList<Recommendation>> FetchRecommendationsAsync(string eventStore, string ns)
+    async Task<IReadOnlyList<RecommendationDetailsResponse>> FetchRecommendationsAsync(string eventStore, string ns)
     {
         try
         {
-            return [.. await services.Recommendations.GetRecommendations(new GetRecommendationsRequest
+            var result = await services.Recommendations.GetRecommendations(new GetRecommendationsRequest
             {
                 EventStore = eventStore,
                 Namespace = ns
-            }).ConfigureAwait(false)];
+            }).ConfigureAwait(false);
+            return [.. result.Data ?? []];
         }
         catch { return []; }
     }
@@ -232,23 +235,24 @@ public class WorkbenchDataService(IServices services, WorkbenchSettings settings
     {
         try
         {
-            var tail = await services.EventSequences.GetTailSequenceNumber(new GetTailSequenceNumberRequest
+            var tail = await services.Sequences.TailSequenceNumber(new TailSequenceNumberRequest
             {
                 EventStore = eventStore,
                 Namespace = ns,
                 EventSequenceId = CliDefaults.DefaultEventSequenceId
             }).ConfigureAwait(false);
-            return tail.SequenceNumber == ulong.MaxValue ? null : tail.SequenceNumber;
+            return tail.Data.SequenceNumber == ulong.MaxValue ? null : tail.Data.SequenceNumber;
         }
         catch { return null; }
     }
 
-    async Task<IReadOnlyList<EventTypeRegistration>> FetchEventTypesAsync(string eventStore)
+    async Task<IReadOnlyList<EventTypeDetailsResponse>> FetchEventTypesAsync(string eventStore)
     {
         try
         {
-            return [.. await services.EventTypes.GetAllRegistrations(
-                new GetAllEventTypesRequest { EventStore = eventStore }).ConfigureAwait(false)];
+            var result = await services.EventTypes.AllEventTypes(
+                new AllEventTypesRequest { EventStore = eventStore }).ConfigureAwait(false);
+            return [.. result.Data ?? []];
         }
         catch { return []; }
     }
@@ -274,7 +278,7 @@ public class WorkbenchDataService(IServices services, WorkbenchSettings settings
         catch { return new Dictionary<string, string>(); }
     }
 
-    async Task<IReadOnlyList<AppendedEvent>> FetchRecentEventsAsync(string eventStore, string ns, ulong? tailSequenceNumber)
+    async Task<IReadOnlyList<AppendedEventResponse>> FetchRecentEventsAsync(string eventStore, string ns, ulong? tailSequenceNumber)
     {
         try
         {
@@ -282,15 +286,15 @@ public class WorkbenchDataService(IServices services, WorkbenchSettings settings
             var fromSeq = tailSequenceNumber.Value >= EventLogFetchWindow
                 ? tailSequenceNumber.Value - EventLogFetchWindow + 1
                 : 0;
-            var eventsResp = await services.EventSequences.GetEventsFromEventSequenceNumber(
-                new GetFromEventSequenceNumberRequest
+            var eventsResp = await services.Sequences.FromSequenceNumber(
+                new FromSequenceNumberRequest
                 {
                     EventStore = eventStore,
                     Namespace = ns,
                     EventSequenceId = CliDefaults.DefaultEventSequenceId,
                     FromEventSequenceNumber = fromSeq
                 }).ConfigureAwait(false);
-            return [.. eventsResp.Events.OrderByDescending(e => e.Context.SequenceNumber)];
+            return [.. (eventsResp.Data ?? []).OrderByDescending(e => e.Context.SequenceNumber)];
         }
         catch { return []; }
     }
@@ -318,7 +322,7 @@ public class WorkbenchDataService(IServices services, WorkbenchSettings settings
         {
             var result = await services.Namespaces.AllNamespaces(
                 new AllNamespacesRequest { EventStore = eventStore }).ConfigureAwait(false);
-            return [.. result.Data ?? []];
+            return [.. (result.Data ?? []).Select(x => x.Name)];
         }
         catch { return []; }
     }
@@ -343,15 +347,16 @@ public class WorkbenchDataService(IServices services, WorkbenchSettings settings
         catch { return []; }
     }
 
-    async Task<IReadOnlyList<Identity>> FetchIdentitiesAsync(string eventStore, string ns)
+    async Task<IReadOnlyList<IdentityDetailsResponse>> FetchIdentitiesAsync(string eventStore, string ns)
     {
         try
         {
-            return [.. await services.Identities.GetIdentities(new GetIdentitiesRequest
+            var result = await services.Identities.GetIdentities(new GetIdentitiesRequest
             {
                 EventStore = eventStore,
                 Namespace = ns
-            }).ConfigureAwait(false)];
+            }).ConfigureAwait(false);
+            return [.. result.Data ?? []];
         }
         catch { return []; }
     }

--- a/Source/Cli/Commands/Chronicle/Workbench/views/EventSequencesView.cs
+++ b/Source/Cli/Commands/Chronicle/Workbench/views/EventSequencesView.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Cratis.Chronicle.Contracts.EventTypes;
+using Cratis.Chronicle.Contracts.Sequences;
 using SharpConsoleUI.Layout;
 using SharpConsoleUI.Themes;
 
@@ -9,20 +11,20 @@ namespace Cratis.Cli.Commands.Chronicle.Workbench;
 /// <summary>
 /// Event Sequences navigation item — filterable, sortable table of recent events with a detail pane showing event content.
 /// </summary>
-public class EventSequencesView : FilterableTableView<AppendedEvent>
+public class EventSequencesView : FilterableTableView<AppendedEventResponse>
 {
     /// <summary>Gets the currently selected event, or <see langword="null"/> if none is selected.</summary>
-    public AppendedEvent? SelectedEvent => SelectedItem;
+    public AppendedEventResponse? SelectedEvent => SelectedItem;
 
     /// <summary>
     /// Gets or sets the callback invoked when the user requests to view the event type definition.
     /// </summary>
-    public Action<AppendedEvent>? OnViewEventTypeDefinition { get; set; }
+    public Action<AppendedEventResponse>? OnViewEventTypeDefinition { get; set; }
 
     /// <summary>
     /// Gets or sets the callback invoked when the user requests to view observers for this event type.
     /// </summary>
-    public Action<AppendedEvent>? OnViewObserversForType { get; set; }
+    public Action<AppendedEventResponse>? OnViewObserversForType { get; set; }
 
     /// <inheritdoc/>
     public override string ViewHelp =>
@@ -52,13 +54,13 @@ public class EventSequencesView : FilterableTableView<AppendedEvent>
     protected override string EmptyStateMessage => "No events yet.";
 
     /// <inheritdoc/>
-    protected override IEnumerable<AppendedEvent> GetItems(WorkbenchData data) => data.RecentEvents;
+    protected override IEnumerable<AppendedEventResponse> GetItems(WorkbenchData data) => data.RecentEvents;
 
     /// <inheritdoc/>
-    protected override string GetKey(AppendedEvent item) => item.Context.SequenceNumber.ToString();
+    protected override string GetKey(AppendedEventResponse item) => item.Context.SequenceNumber.ToString();
 
     /// <inheritdoc/>
-    protected override string[] BuildRow(AppendedEvent item) =>
+    protected override string[] BuildRow(AppendedEventResponse item) =>
     [
         item.Context.SequenceNumber.ToString().PadLeft(14),
         FormatRelativeTime(item.Context.Occurred),
@@ -84,20 +86,20 @@ public class EventSequencesView : FilterableTableView<AppendedEvent>
     }
 
     /// <inheritdoc/>
-    protected override IComparer<AppendedEvent> GetColumnComparer(int columnIndex) => columnIndex switch
+    protected override IComparer<AppendedEventResponse> GetColumnComparer(int columnIndex) => columnIndex switch
     {
-        0 => Comparer<AppendedEvent>.Create((a, b) =>
+        0 => Comparer<AppendedEventResponse>.Create((a, b) =>
             a.Context.SequenceNumber.CompareTo(b.Context.SequenceNumber)),
-        1 => Comparer<AppendedEvent>.Create((a, b) =>
+        1 => Comparer<AppendedEventResponse>.Create((a, b) =>
             ((DateTimeOffset)a.Context.Occurred).CompareTo((DateTimeOffset)b.Context.Occurred)),
         _ => base.GetColumnComparer(columnIndex)
     };
 
     /// <inheritdoc/>
-    protected override void OnInspect(AppendedEvent item) => OnViewEventTypeDefinition?.Invoke(item);
+    protected override void OnInspect(AppendedEventResponse item) => OnViewEventTypeDefinition?.Invoke(item);
 
     /// <inheritdoc/>
-    protected override string RenderDetail(AppendedEvent? item, WorkbenchData? data)
+    protected override string RenderDetail(AppendedEventResponse? item, WorkbenchData? data)
     {
         if (item is null)
         {
@@ -126,7 +128,7 @@ public class EventSequencesView : FilterableTableView<AppendedEvent>
     }
 
     /// <inheritdoc/>
-    protected override bool MatchesFilter(AppendedEvent item, string filter)
+    protected override bool MatchesFilter(AppendedEventResponse item, string filter)
     {
         if (filter.StartsWith("type:", StringComparison.OrdinalIgnoreCase))
         {

--- a/Source/Cli/Commands/Chronicle/Workbench/views/EventTypesView.cs
+++ b/Source/Cli/Commands/Chronicle/Workbench/views/EventTypesView.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Cratis.Chronicle.Contracts.EventTypes;
+using Cratis.Chronicle.Contracts.Sequences;
 using SharpConsoleUI.Controls;
 using SharpConsoleUI.Layout;
 using SharpConsoleUI.Themes;
@@ -10,15 +12,15 @@ namespace Cratis.Cli.Commands.Chronicle.Workbench;
 /// <summary>
 /// Event Types navigation item — filterable table of registered event types with schema details in the right pane.
 /// </summary>
-public class EventTypesView : FilterableTableView<EventTypeRegistration>
+public class EventTypesView : FilterableTableView<EventTypeDetailsResponse>
 {
     /// <summary>Gets the currently selected event type registration, or <see langword="null"/> if none is selected.</summary>
-    public EventTypeRegistration? SelectedEventType => SelectedItem;
+    public EventTypeDetailsResponse? SelectedEventType => SelectedItem;
 
     /// <summary>
     /// Gets or sets the callback invoked when the user requests to view observers for the selected event type.
     /// </summary>
-    public Action<EventTypeRegistration>? OnViewObservers { get; set; }
+    public Action<EventTypeDetailsResponse>? OnViewObservers { get; set; }
 
     /// <inheritdoc/>
     public override string ViewHelp =>
@@ -67,21 +69,21 @@ public class EventTypesView : FilterableTableView<EventTypeRegistration>
     }
 
     /// <inheritdoc/>
-    protected override IEnumerable<EventTypeRegistration> GetItems(WorkbenchData data) =>
+    protected override IEnumerable<EventTypeDetailsResponse> GetItems(WorkbenchData data) =>
         data.EventTypeRegistrations.OrderBy(r => r.Type.Id).ThenBy(r => r.Type.Generation);
 
     /// <inheritdoc/>
-    protected override string GetKey(EventTypeRegistration item) => $"{item.Type.Id}+{item.Type.Generation}";
+    protected override string GetKey(EventTypeDetailsResponse item) => $"{item.Type.Id}+{item.Type.Generation}";
 
     /// <inheritdoc/>
-    protected override string GetDetailTitle(EventTypeRegistration item) => item.Type.Id;
+    protected override string GetDetailTitle(EventTypeDetailsResponse item) => item.Type.Id;
 
     /// <inheritdoc/>
-    protected override string[] BuildRow(EventTypeRegistration item) =>
+    protected override string[] BuildRow(EventTypeDetailsResponse item) =>
         [item.Type.Id, item.Type.Generation.ToString().PadLeft(6), item.Owner.ToString()];
 
     /// <inheritdoc/>
-    protected override string RenderDetail(EventTypeRegistration? item, WorkbenchData? data)
+    protected override string RenderDetail(EventTypeDetailsResponse? item, WorkbenchData? data)
     {
         if (item is null)
         {
@@ -108,7 +110,7 @@ public class EventTypesView : FilterableTableView<EventTypeRegistration>
     }
 
     /// <inheritdoc/>
-    protected override bool MatchesFilter(EventTypeRegistration item, string filter)
+    protected override bool MatchesFilter(EventTypeDetailsResponse item, string filter)
     {
         if (filter.StartsWith("owner:", StringComparison.OrdinalIgnoreCase))
         {

--- a/Source/Cli/Commands/Chronicle/Workbench/views/IdentitiesView.cs
+++ b/Source/Cli/Commands/Chronicle/Workbench/views/IdentitiesView.cs
@@ -9,7 +9,7 @@ namespace Cratis.Cli.Commands.Chronicle.Workbench;
 /// <summary>
 /// Identities navigation item — filterable table of known identities with a detail pane.
 /// </summary>
-public class IdentitiesView : FilterableTableView<Identity>
+public class IdentitiesView : FilterableTableView<IdentityDetailsResponse>
 {
     /// <inheritdoc/>
     protected override IReadOnlyList<(string Name, TextJustification Justify, int? Width)> Columns =>
@@ -29,18 +29,18 @@ public class IdentitiesView : FilterableTableView<Identity>
     protected override string EmptyStateMessage => "No identities.";
 
     /// <inheritdoc/>
-    protected override IEnumerable<Identity> GetItems(WorkbenchData data) =>
+    protected override IEnumerable<IdentityDetailsResponse> GetItems(WorkbenchData data) =>
         data.Identities.OrderBy(i => i.Name);
 
     /// <inheritdoc/>
-    protected override string GetKey(Identity item) => item.Subject;
+    protected override string GetKey(IdentityDetailsResponse item) => item.Subject;
 
     /// <inheritdoc/>
-    protected override string[] BuildRow(Identity item) =>
+    protected override string[] BuildRow(IdentityDetailsResponse item) =>
         [item.Name, item.UserName, item.Subject];
 
     /// <inheritdoc/>
-    protected override string RenderDetail(Identity? item, WorkbenchData? data)
+    protected override string RenderDetail(IdentityDetailsResponse? item, WorkbenchData? data)
     {
         if (item is null)
         {
@@ -57,7 +57,7 @@ public class IdentitiesView : FilterableTableView<Identity>
     }
 
     /// <inheritdoc/>
-    protected override bool MatchesFilter(Identity item, string filter) =>
+    protected override bool MatchesFilter(IdentityDetailsResponse item, string filter) =>
         item.Name.Contains(filter, StringComparison.OrdinalIgnoreCase) ||
         item.UserName.Contains(filter, StringComparison.OrdinalIgnoreCase) ||
         item.Subject.Contains(filter, StringComparison.OrdinalIgnoreCase);

--- a/Source/Cli/Commands/Chronicle/Workbench/views/RecommendationsView.cs
+++ b/Source/Cli/Commands/Chronicle/Workbench/views/RecommendationsView.cs
@@ -9,10 +9,10 @@ namespace Cratis.Cli.Commands.Chronicle.Workbench;
 /// <summary>
 /// Recommendations tab — filterable table of pending recommendations with apply/ignore actions.
 /// </summary>
-public class RecommendationsView : FilterableTableView<Recommendation>
+public class RecommendationsView : FilterableTableView<RecommendationDetailsResponse>
 {
     /// <summary>Gets the currently selected recommendation, or <see langword="null"/> if none is selected.</summary>
-    public Recommendation? SelectedRecommendation => SelectedItem;
+    public RecommendationDetailsResponse? SelectedRecommendation => SelectedItem;
 
     /// <inheritdoc/>
     public override string ViewHelp =>
@@ -25,27 +25,27 @@ public class RecommendationsView : FilterableTableView<Recommendation>
     /// <summary>
     /// Gets or sets the callback invoked when the user applies a recommendation.
     /// </summary>
-    public Action<Recommendation>? OnApply { get; set; }
+    public Action<RecommendationDetailsResponse>? OnApply { get; set; }
 
     /// <summary>
     /// Gets or sets the callback invoked when the user ignores a recommendation.
     /// </summary>
-    public Action<Recommendation>? OnIgnore { get; set; }
+    public Action<RecommendationDetailsResponse>? OnIgnore { get; set; }
 
     /// <summary>
     /// Gets or sets the callback invoked when the user requests a bulk apply of all checked recommendations.
     /// </summary>
-    public Action<IReadOnlyList<Recommendation>>? OnApplyAll { get; set; }
+    public Action<IReadOnlyList<RecommendationDetailsResponse>>? OnApplyAll { get; set; }
 
     /// <summary>
     /// Gets or sets the callback invoked when the user requests a bulk ignore of all checked recommendations.
     /// </summary>
-    public Action<IReadOnlyList<Recommendation>>? OnIgnoreAll { get; set; }
+    public Action<IReadOnlyList<RecommendationDetailsResponse>>? OnIgnoreAll { get; set; }
 
     /// <summary>
     /// Gets all recommendations that are currently checked (checkbox mode).
     /// </summary>
-    public IReadOnlyList<Recommendation> Checked => CheckedItems;
+    public IReadOnlyList<RecommendationDetailsResponse> Checked => CheckedItems;
 
     /// <inheritdoc/>
     protected override IReadOnlyList<(string Name, TextJustification Justify, int? Width)> Columns =>
@@ -97,17 +97,17 @@ public class RecommendationsView : FilterableTableView<Recommendation>
     }
 
     /// <inheritdoc/>
-    protected override IEnumerable<Recommendation> GetItems(WorkbenchData data) => data.Recommendations;
+    protected override IEnumerable<RecommendationDetailsResponse> GetItems(WorkbenchData data) => data.Recommendations;
 
     /// <inheritdoc/>
-    protected override string GetKey(Recommendation item) => item.Id.ToString();
+    protected override string GetKey(RecommendationDetailsResponse item) => item.Id.ToString();
 
     /// <inheritdoc/>
-    protected override string[] BuildRow(Recommendation item) =>
+    protected override string[] BuildRow(RecommendationDetailsResponse item) =>
         [item.Name ?? item.Id.ToString(), item.Type ?? "—"];
 
     /// <inheritdoc/>
-    protected override string RenderDetail(Recommendation? item, WorkbenchData? data)
+    protected override string RenderDetail(RecommendationDetailsResponse? item, WorkbenchData? data)
     {
         if (item is null)
         {
@@ -133,7 +133,7 @@ public class RecommendationsView : FilterableTableView<Recommendation>
     }
 
     /// <inheritdoc/>
-    protected override bool MatchesFilter(Recommendation item, string filter) =>
+    protected override bool MatchesFilter(RecommendationDetailsResponse item, string filter) =>
         (item.Name ?? string.Empty).Contains(filter, StringComparison.OrdinalIgnoreCase) ||
         (item.Type ?? string.Empty).Contains(filter, StringComparison.OrdinalIgnoreCase) ||
         item.Id.ToString().Contains(filter, StringComparison.OrdinalIgnoreCase);

--- a/Source/Cli/Commands/Chronicle/Workbench/windows/MainWindow.cs
+++ b/Source/Cli/Commands/Chronicle/Workbench/windows/MainWindow.cs
@@ -385,7 +385,7 @@ public class MainWindow(
         {
             rv.OnApply = rec => _actionHandler!.ExecuteAction(
                 $"Apply recommendation '{TruncateId(rec.Name ?? rec.Id.ToString())}'",
-                () => services.Recommendations.Perform(new Perform
+                () => services.Recommendations.PerformRecommendation(new PerformRecommendationRequest
                 {
                     EventStore = ActiveEventStore,
                     Namespace = ActiveNamespace,
@@ -394,7 +394,7 @@ public class MainWindow(
 
             rv.OnIgnore = rec => _actionHandler!.ExecuteAction(
                 $"Ignore recommendation '{TruncateId(rec.Name ?? rec.Id.ToString())}'",
-                () => services.Recommendations.Ignore(new Perform
+                () => services.Recommendations.IgnoreRecommendation(new IgnoreRecommendationRequest
                 {
                     EventStore = ActiveEventStore,
                     Namespace = ActiveNamespace,
@@ -404,7 +404,7 @@ public class MainWindow(
             rv.OnApplyAll = recs => _actionHandler!.ConfirmThenExecuteAll(
                 $"Apply {recs.Count} recommendation{(recs.Count == 1 ? string.Empty : "s")}",
                 recs,
-                rec => services.Recommendations.Perform(new Perform
+                rec => services.Recommendations.PerformRecommendation(new PerformRecommendationRequest
                 {
                     EventStore = ActiveEventStore,
                     Namespace = ActiveNamespace,
@@ -415,7 +415,7 @@ public class MainWindow(
             rv.OnIgnoreAll = recs => _actionHandler!.ConfirmThenExecuteAll(
                 $"Ignore {recs.Count} recommendation{(recs.Count == 1 ? string.Empty : "s")}",
                 recs,
-                rec => services.Recommendations.Ignore(new Perform
+                rec => services.Recommendations.IgnoreRecommendation(new IgnoreRecommendationRequest
                 {
                     EventStore = ActiveEventStore,
                     Namespace = ActiveNamespace,

--- a/Source/Cli/Commands/Chronicle/Workbench/windows/WorkbenchOverlays.cs
+++ b/Source/Cli/Commands/Chronicle/Workbench/windows/WorkbenchOverlays.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Cratis.Chronicle.Contracts.EventTypes;
 using SharpConsoleUI;
 using SharpConsoleUI.Builders;
 using SharpConsoleUI.Controls;
@@ -474,7 +475,7 @@ public class WorkbenchOverlays(
         var acc = _theme.Accent.ToMarkup();
         var teal = _theme.Teal.ToMarkup();
 
-        EventTypeRegistration? reg = null;
+        EventTypeDetailsResponse? reg = null;
         if (snapshot is not null)
         {
             reg = snapshot.EventTypeRegistrations

--- a/Source/Cli/Commands/Completions/DynamicCompleteCommand.cs
+++ b/Source/Cli/Commands/Completions/DynamicCompleteCommand.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Reactive.Linq;
+using Cratis.Chronicle.Contracts.EventTypes;
 using Cratis.Chronicle.Contracts.Jobs;
 using Cratis.Chronicle.Contracts.Observation.EventStoreSubscriptions;
 using Cratis.Cli.Commands.Chronicle;
@@ -80,7 +81,7 @@ public class DynamicCompleteCommand : ChronicleCommand<DynamicCompleteSettings>
                     if (eventStore == CliDefaults.DefaultEventStoreName)
                     {
                         var allStores = await services.EventStores.AllEventStores();
-                        storeNames = allStores.Data ?? [];
+                        storeNames = (allStores.Data ?? []).Select(x => x.Name);
                     }
                     else
                     {
@@ -90,15 +91,15 @@ public class DynamicCompleteCommand : ChronicleCommand<DynamicCompleteSettings>
                     var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
                     foreach (var store in storeNames)
                     {
-                        var types = await services.EventTypes.GetAll(new GetAllEventTypesRequest
+                        var types = await services.EventTypes.AllEventTypes(new AllEventTypesRequest
                         {
                             EventStore = store
                         });
-                        foreach (var et in types ?? [])
+                        foreach (var et in types.Data ?? [])
                         {
-                            if (seen.Add(et.Id))
+                            if (seen.Add(et.Type.Id))
                             {
-                                Console.WriteLine(et.Id);
+                                Console.WriteLine(et.Type.Id);
                             }
                         }
                     }
@@ -109,7 +110,7 @@ public class DynamicCompleteCommand : ChronicleCommand<DynamicCompleteSettings>
                     var stores = await services.EventStores.AllEventStores();
                     foreach (var store in stores.Data ?? [])
                     {
-                        Console.WriteLine(store);
+                        Console.WriteLine(store.Name);
                     }
 
                     break;
@@ -132,7 +133,7 @@ public class DynamicCompleteCommand : ChronicleCommand<DynamicCompleteSettings>
                         EventStore = eventStore,
                         Namespace = ns
                     });
-                    foreach (var rec in recs ?? [])
+                    foreach (var rec in recs.Data ?? [])
                     {
                         Console.WriteLine(rec.Id);
                     }

--- a/scripts/test-packaged-screenplay-placement.sh
+++ b/scripts/test-packaged-screenplay-placement.sh
@@ -189,13 +189,13 @@ for declaration in (
 generation = json.loads(file_diagnostics_bytes)
 provenance = generation["provenance"]
 assert provenance["provider"] == "critter-stack"
-assert provenance["providerVersion"] == "0.23.0"
+assert provenance["providerVersion"] == "0.24.0"
 assert provenance["compatibility"] == {
     "supportTier": "Canonical",
     "recognitionStatus": "Recognized",
     "semanticConformance": "RequiresHumanReview",
     "loweringFidelity": "LossReported",
-    "explanation": "Marten 9.23.0 with WolverineFx 6.29.1 matches a pinned canonical package set for bundled provider 0.23.0; only fixture-asserted behaviors are canonical",
+    "explanation": "Marten 9.23.0 with WolverineFx 6.29.1 matches a pinned canonical package set for bundled provider 0.24.0; only fixture-asserted behaviors are canonical",
 }
 
 projects = provenance["projects"]


### PR DESCRIPTION
## Summary

Upgrades the CLI to Chronicle 18.1.0 and the latest versions of its other packages. **This is a major release: the CLI is no longer backwards compatible with a pre-18 Chronicle kernel.** It now requires a Chronicle 18 server to connect to.

## Changed

- Target Chronicle 18: the CLI now speaks the restructured 18 gRPC contracts (event-sequence operations moved to a dedicated `Sequences` service, renamed query methods, `QueryResult` response envelopes).
- `chronicle events get` range reads: Chronicle 18 dropped the server-side upper bound, so the `--to` value is now applied client-side instead of being sent to the server.
- Command (write) operations — perform/ignore a recommendation, resume/stop a job, and add/remove a user or application — now report a server-side failure (exit `3` with an error message) when the server rejects the operation. On a pre-18 kernel these surfaced as a thrown error; on 18 the failure travels in the returned `CommandResult`, which the CLI now inspects.
- Bumped the remaining Cratis, Roslyn, xunit, and driver packages to their latest versions.

## Removed

- Support for connecting to Chronicle servers prior to 18. The command surface and behavior against a pre-18 kernel are no longer guaranteed to work.

## Fixed

- Performing or ignoring a nonexistent recommendation (and the equivalent job/user/application operations) now fails with the server's error instead of silently reporting success.