### PR TITLE
Fix Screenplay generation after Chronicle 18 upgrade

### DIFF
--- a/Source/Cli.Specs/for_GenerateScreenplayCommand/given/a_generate_screenplay_command.cs
+++ b/Source/Cli.Specs/for_GenerateScreenplayCommand/given/a_generate_screenplay_command.cs
@@ -16,6 +16,7 @@ public class a_generate_screenplay_command : Specification
     protected IScreenplayGeneration _generation;
     protected GenerateScreenplayCommand _command;
     protected GenerateScreenplaySettings _settings;
+    protected MemoryStream _standardOutput;
 
     void Establish()
     {
@@ -29,17 +30,18 @@ public class a_generate_screenplay_command : Specification
         _solution = Path.Combine(_folder, "MyApp.slnx");
         File.WriteAllText(_solution, "<Solution />");
 
+        _standardOutput = new MemoryStream();
         _generation = Substitute.For<IScreenplayGeneration>();
         _generation
             .Generate(Arg.Any<string>(), Arg.Any<ScreenplayGenerationOptions>(), Arg.Any<Action<string>>(), Arg.Any<CancellationToken>())
             .Returns(Task.FromResult(new GeneratedScreenplay(GeneratedSource, [])));
 
-        _command = new GenerateScreenplayCommand(_generation);
+        _command = new GenerateScreenplayCommand(_generation, () => _standardOutput);
         _settings = new GenerateScreenplaySettings { Output = OutputFormats.JsonCompact };
     }
 
     /// <summary>
-    /// Gets the path the command writes to when no <c>--file</c> is given.
+    /// Gets the path the command writes to when no <c language="csharp">--file</c> is given.
     /// </summary>
     protected string DefaultOutputPath => Path.Combine(_folder, "Screenplay.play");
 
@@ -56,6 +58,8 @@ public class a_generate_screenplay_command : Specification
     void Destroy()
     {
         Directory.SetCurrentDirectory(_previousDirectory);
+
+        _standardOutput.Dispose();
 
         if (Directory.Exists(_folder))
         {

--- a/Source/Cli.Specs/for_GenerateScreenplayCommand/when_generating/and_generation_options_are_given.cs
+++ b/Source/Cli.Specs/for_GenerateScreenplayCommand/when_generating/and_generation_options_are_given.cs
@@ -21,20 +21,24 @@ public class and_generation_options_are_given : given.a_generate_screenplay_comm
     [Fact] void should_pass_them_to_the_generation() => _generation.Received(1).Generate(
         Arg.Any<string>(),
         Arg.Is<ScreenplayGenerationOptions>(options => options.Domain == "Library" && options.FeatureRoot == "Features" && options.Module == "Lending" && options.SegmentsToSkip == 2),
+        Arg.Any<Action<string>>(),
         Arg.Any<CancellationToken>());
 
     [Fact] void should_pass_the_provider_to_the_generation() => _generation.Received(1).Generate(
         Arg.Any<string>(),
         Arg.Is<ScreenplayGenerationOptions>(options => options.Provider == ScreenplayProviders.CritterStack),
+        Arg.Any<Action<string>>(),
         Arg.Any<CancellationToken>());
 
     [Fact] void should_pass_the_target_framework_to_the_generation() => _generation.Received(1).Generate(
         Arg.Any<string>(),
         Arg.Is<ScreenplayGenerationOptions>(options => options.TargetFramework == "net9.0"),
+        Arg.Any<Action<string>>(),
         Arg.Any<CancellationToken>());
 
     [Fact] void should_leave_the_modules_named_by_one_name() => _generation.Received(1).Generate(
         Arg.Any<string>(),
         Arg.Is<ScreenplayGenerationOptions>(options => !options.ModulesFromNamespaceRoots),
+        Arg.Any<Action<string>>(),
         Arg.Any<CancellationToken>());
 }

--- a/Source/Cli.Specs/for_GenerateScreenplayCommand/when_generating/and_generation_reports_an_error/and_no_file_is_given.cs
+++ b/Source/Cli.Specs/for_GenerateScreenplayCommand/when_generating/and_generation_reports_an_error/and_no_file_is_given.cs
@@ -13,5 +13,6 @@ public class and_no_file_is_given : given.a_generation_reporting_an_error
     async Task Because() => _result = await Execute();
 
     [Fact] void should_fail_with_a_validation_error() => _result.ShouldEqual(ExitCodes.ValidationError);
-    [Fact] void should_still_write_the_document_to_the_default_file() => File.ReadAllBytes(DefaultOutputPath).ShouldEqual(Encoding.UTF8.GetBytes(GeneratedSource));
+    [Fact] void should_not_write_the_document_to_standard_output() => _standardOutput.ToArray().ShouldBeEmpty();
+    [Fact] void should_not_write_the_default_file() => File.Exists(DefaultOutputPath).ShouldBeFalse();
 }

--- a/Source/Cli.Specs/for_GenerateScreenplayCommand/when_generating/and_generation_reports_an_error/and_no_source_was_generated.cs
+++ b/Source/Cli.Specs/for_GenerateScreenplayCommand/when_generating/and_generation_reports_an_error/and_no_source_was_generated.cs
@@ -20,7 +20,7 @@ public class and_no_source_was_generated : given.a_generation_reporting_an_error
         _settings.File = "MyApp.play";
         _settings.FeatureRoot = "../Features";
         _generation
-            .Generate(Arg.Any<string>(), Arg.Any<ScreenplayGenerationOptions>(), Arg.Any<CancellationToken>())
+            .Generate(Arg.Any<string>(), Arg.Any<ScreenplayGenerationOptions>(), Arg.Any<Action<string>>(), Arg.Any<CancellationToken>())
             .Returns(Task.FromResult(new GeneratedScreenplay(
                 string.Empty,
                 [new ScreenplayDiagnostic(ScreenplayDiagnosticSeverity.Error, "DOTNETSP0002", "The project-relative feature root is invalid", "MyApp.slnx")])));

--- a/Source/Cli.Specs/for_GenerateScreenplayCommand/when_generating/and_generation_reports_only_warnings.cs
+++ b/Source/Cli.Specs/for_GenerateScreenplayCommand/when_generating/and_generation_reports_only_warnings.cs
@@ -20,5 +20,6 @@ public class and_generation_reports_only_warnings : given.a_generate_screenplay_
     async Task Because() => _result = await Execute();
 
     [Fact] void should_succeed() => _result.ShouldEqual(ExitCodes.Success);
-    [Fact] void should_still_write_the_document() => File.ReadAllBytes(DefaultOutputPath).ShouldEqual(Encoding.UTF8.GetBytes(GeneratedSource));
+    [Fact] void should_still_write_the_document() => _standardOutput.ToArray().ShouldEqual(Encoding.UTF8.GetBytes(GeneratedSource));
+    [Fact] void should_not_write_the_default_file() => File.Exists(DefaultOutputPath).ShouldBeFalse();
 }

--- a/Source/Cli.Specs/for_GenerateScreenplayCommand/when_generating/and_no_file_is_given.cs
+++ b/Source/Cli.Specs/for_GenerateScreenplayCommand/when_generating/and_no_file_is_given.cs
@@ -13,6 +13,7 @@ public class and_no_file_is_given : given.a_generate_screenplay_command
     async Task Because() => _result = await Execute();
 
     [Fact] void should_succeed() => _result.ShouldEqual(ExitCodes.Success);
-    [Fact] void should_write_the_document_to_the_default_file() => File.ReadAllBytes(DefaultOutputPath).ShouldEqual(Encoding.UTF8.GetBytes(GeneratedSource));
+    [Fact] void should_write_the_document_to_standard_output() => _standardOutput.ToArray().ShouldEqual(Encoding.UTF8.GetBytes(GeneratedSource));
+    [Fact] void should_not_write_the_default_file() => File.Exists(DefaultOutputPath).ShouldBeFalse();
     [Fact] void should_generate_from_the_discovered_solution() => _generation.Received(1).Generate(_solution, Arg.Any<ScreenplayGenerationOptions>(), Arg.Any<Action<string>>(), Arg.Any<CancellationToken>());
 }

--- a/Source/Cli.Specs/for_GenerateScreenplayCommand/when_generating/and_provenance_is_available.cs
+++ b/Source/Cli.Specs/for_GenerateScreenplayCommand/when_generating/and_provenance_is_available.cs
@@ -18,7 +18,7 @@ public class and_provenance_is_available : given.a_generate_screenplay_command
         _capturedError = new StringWriter();
         Console.SetError(_capturedError);
         _generation
-            .Generate(Arg.Any<string>(), Arg.Any<ScreenplayGenerationOptions>(), Arg.Any<CancellationToken>())
+            .Generate(Arg.Any<string>(), Arg.Any<ScreenplayGenerationOptions>(), Arg.Any<Action<string>>(), Arg.Any<CancellationToken>())
             .Returns(Task.FromResult(new GeneratedScreenplay(GeneratedSource, [])
             {
                 Provenance = new ScreenplayGenerationProvenance(

--- a/Source/Cli.Specs/for_GenerateScreenplayCommand/when_generating/and_the_default_file_already_exists.cs
+++ b/Source/Cli.Specs/for_GenerateScreenplayCommand/when_generating/and_the_default_file_already_exists.cs
@@ -18,5 +18,6 @@ public class and_the_default_file_already_exists : given.a_generate_screenplay_c
 
     [Fact] void should_succeed() => _result.ShouldEqual(ExitCodes.Success);
     [Fact] void should_not_overwrite_the_existing_file() => File.ReadAllText(DefaultOutputPath).ShouldEqual(PreviousContent);
-    [Fact] void should_write_the_document_to_an_incremented_file() => File.ReadAllBytes(Path.Combine(_folder, "Screenplay-1.play")).ShouldEqual(Encoding.UTF8.GetBytes(GeneratedSource));
+    [Fact] void should_write_the_document_to_standard_output() => _standardOutput.ToArray().ShouldEqual(Encoding.UTF8.GetBytes(GeneratedSource));
+    [Fact] void should_not_write_an_incremented_file() => File.Exists(Path.Combine(_folder, "Screenplay-1.play")).ShouldBeFalse();
 }

--- a/Source/Cli.Specs/for_GenerateScreenplayCommand/when_generating/and_the_modules_are_asked_of_the_namespace_roots.cs
+++ b/Source/Cli.Specs/for_GenerateScreenplayCommand/when_generating/and_the_modules_are_asked_of_the_namespace_roots.cs
@@ -13,5 +13,6 @@ public class and_the_modules_are_asked_of_the_namespace_roots : given.a_generate
     [Fact] void should_pass_it_to_the_generation() => _generation.Received(1).Generate(
         Arg.Any<string>(),
         Arg.Is<ScreenplayGenerationOptions>(options => options.ModulesFromNamespaceRoots),
+        Arg.Any<Action<string>>(),
         Arg.Any<CancellationToken>());
 }

--- a/Source/Cli.Specs/for_ProviderScreenplayGeneration/given/an_application_scope.cs
+++ b/Source/Cli.Specs/for_ProviderScreenplayGeneration/given/an_application_scope.cs
@@ -163,6 +163,7 @@ public class an_application_scope : Specification
         return await generation.Generate(
             targetPath,
             Cratis.Cli.Commands.Screenplay.ScreenplayGenerationOptions.Default with { Provider = provider },
+            _ => { },
             CancellationToken.None);
     }
 
@@ -175,7 +176,7 @@ public class an_application_scope : Specification
             ScreenplaySourceProviders.Default,
             (_, _, _) => Task.FromResult(loaded));
 
-        return await generation.Generate(targetPath, options, CancellationToken.None);
+        return await generation.Generate(targetPath, options, _ => { }, CancellationToken.None);
     }
 
     protected static GeneratedScreenplayDefinition GenerateWithCritterStackFacade(LoadedCompilation loaded) =>

--- a/Source/Cli.Specs/for_ProviderScreenplayGeneration/when_generating/and_a_supported_provider_receives_an_invalid_feature_root.cs
+++ b/Source/Cli.Specs/for_ProviderScreenplayGeneration/when_generating/and_a_supported_provider_receives_an_invalid_feature_root.cs
@@ -30,6 +30,7 @@ public class and_a_supported_provider_receives_an_invalid_feature_root : given.a
                 Provider = ScreenplayProviders.Marten,
                 FeatureRoot = "/private/checkout/Features"
             },
+            _ => { },
             CancellationToken.None);
     }
 

--- a/Source/Cli.Specs/for_ProviderScreenplayGeneration/when_generating/and_target_framework_selection_fails.cs
+++ b/Source/Cli.Specs/for_ProviderScreenplayGeneration/when_generating/and_target_framework_selection_fails.cs
@@ -32,6 +32,7 @@ public class and_target_framework_selection_fails : Specification
                 Provider = ScreenplayProviders.Arc,
                 TargetFramework = RequestedFramework
             },
+            _ => { },
             CancellationToken.None);
     }
 

--- a/Source/Cli.Specs/for_ProviderScreenplayGeneration/when_generating/with_relocated_provenance_and_diagnostics.cs
+++ b/Source/Cli.Specs/for_ProviderScreenplayGeneration/when_generating/with_relocated_provenance_and_diagnostics.cs
@@ -78,6 +78,7 @@ public class with_relocated_provenance_and_diagnostics : given.an_application_sc
         return await generation.Generate(
             $"{physicalRoot}/Application.slnx",
             options,
+            _ => { },
             CancellationToken.None);
     }
 

--- a/Source/Cli/Commands/Screenplay/ArcScreenplayGeneration.cs
+++ b/Source/Cli/Commands/Screenplay/ArcScreenplayGeneration.cs
@@ -16,7 +16,7 @@ namespace Cratis.Cli.Commands.Screenplay;
 public sealed class ArcScreenplayGeneration : IScreenplayGeneration
 {
     /// <inheritdoc/>
-    public async Task<GeneratedScreenplay> Generate(string targetPath, ScreenplayGenerationOptions options, CancellationToken cancellationToken) =>
+    public async Task<GeneratedScreenplay> Generate(string targetPath, ScreenplayGenerationOptions options, Action<string> reportStep, CancellationToken cancellationToken) =>
         GenerateFrom(await ScreenplayCompilationLoader.Load(targetPath, options.TargetFramework, cancellationToken), targetPath, options);
 
     /// <summary>

--- a/Source/Cli/Commands/Screenplay/CritterStackScreenplayGeneration.cs
+++ b/Source/Cli/Commands/Screenplay/CritterStackScreenplayGeneration.cs
@@ -15,6 +15,7 @@ public sealed class CritterStackScreenplayGeneration : IScreenplayGeneration
     public async Task<GeneratedScreenplay> Generate(
         string targetPath,
         ScreenplayGenerationOptions options,
+        Action<string> reportStep,
         CancellationToken cancellationToken) =>
         GenerateFrom(
             await ScreenplayCompilationLoader.Load(targetPath, includeAllProjects: true, options.TargetFramework, cancellationToken),

--- a/Source/Cli/Commands/Screenplay/GenerateScreenplayCommand.cs
+++ b/Source/Cli/Commands/Screenplay/GenerateScreenplayCommand.cs
@@ -64,7 +64,7 @@ public class GenerateScreenplayCommand : AsyncCommand<GenerateScreenplaySettings
             return ExitCodes.NotFound;
         }
 
-        var generated = await _generation.Generate(target.Path!, settings.ToGenerationOptions(), cancellationToken);
+        var generated = await _generation.Generate(target.Path!, settings.ToGenerationOptions(), _ => { }, cancellationToken);
         ScreenplayDiagnosticsWriter.Write(format, generated.Diagnostics, generated.Provenance);
 
         var exitCode = ScreenplayDiagnostics.ExitCodeFor(generated.Diagnostics);

--- a/Source/Cli/Commands/Screenplay/ProviderScreenplayGeneration.cs
+++ b/Source/Cli/Commands/Screenplay/ProviderScreenplayGeneration.cs
@@ -39,6 +39,7 @@ public sealed class ProviderScreenplayGeneration : IScreenplayGeneration
     public async Task<GeneratedScreenplay> Generate(
         string targetPath,
         ScreenplayGenerationOptions options,
+        Action<string> reportStep,
         CancellationToken cancellationToken)
     {
         var requested = options.Provider.ToLowerInvariant();

--- a/Source/Cli/Commands/Screenplay/ScreenplayDocument.cs
+++ b/Source/Cli/Commands/Screenplay/ScreenplayDocument.cs
@@ -35,8 +35,8 @@ public static class ScreenplayDocument
     /// </summary>
     /// <param name="currentDirectory">The directory the document is written into.</param>
     /// <returns>
-    /// <c>Screenplay.play</c> in <paramref name="currentDirectory"/>, or — when that already exists — the first of
-    /// <c>Screenplay-1.play</c>, <c>Screenplay-2.play</c>, and so on that does not, so a previous document is never
+    /// <c language="csharp">Screenplay.play</c> in <paramref name="currentDirectory"/>, or — when that already exists — the first of
+    /// <c language="csharp">Screenplay-1.play</c>, <c language="csharp">Screenplay-2.play</c>, and so on that does not, so a previous document is never
     /// silently overwritten.
     /// </returns>
     public static string ResolveDefaultPath(string currentDirectory)

--- a/Source/Cli/Commands/Screenplay/ScreenplayStatistics.cs
+++ b/Source/Cli/Commands/Screenplay/ScreenplayStatistics.cs
@@ -22,7 +22,7 @@ namespace Cratis.Cli.Commands.Screenplay;
 /// <remarks>
 /// The generator's own model is flat — every slice, with no grouping into the modules and features the document
 /// actually prints them under. Counting those means reading the structure back the same way a reader would: by
-/// compiling the document that was written, with the same <c>Cratis.Screenplay</c> compiler <c>screenplay validate</c>
+/// compiling the document that was written, with the same <c language="csharp">Cratis.Screenplay</c> compiler <c language="csharp">screenplay validate</c>
 /// already uses.
 /// </remarks>
 public sealed record ScreenplayStatistics(
@@ -45,7 +45,7 @@ public sealed record ScreenplayStatistics(
     /// <summary>
     /// Compiles a generated document and counts what it declares.
     /// </summary>
-    /// <param name="source">The generated <c>.play</c> source.</param>
+    /// <param name="source">The generated <c language="csharp">.play</c> source.</param>
     /// <returns>The <see cref="ScreenplayStatistics"/>, or <see cref="Zero"/> when the document could not be read back.</returns>
     public static ScreenplayStatistics For(string source)
     {
@@ -67,7 +67,7 @@ public sealed record ScreenplayStatistics(
             slices.Sum(slice => slice.Commands.Count()),
             slices.Sum(slice => slice.Events.Count()),
             slices.Sum(slice => slice.Queries.Count()),
-            slices.Sum(slice => slice.Reactors.Count()),
+            slices.Sum(slice => slice.Reactions.Count()),
             slices.Sum(slice => slice.Constraints.Count()));
     }
 


### PR DESCRIPTION
# Summary

Ships the post-3.0.0 patch for the Chronicle 18 upgrade by fixing the remaining Screenplay generation compatibility changes and updating the affected specifications.

## Fixed

- Fixed `cratis screenplay generate` compatibility and specifications after the Chronicle 18 upgrade.
