### PR TITLE
Add managed Cratis AI lifecycle commands

### DIFF
--- a/Source/Cli.Specs/Usings.cs
+++ b/Source/Cli.Specs/Usings.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+global using Cratis.Cli.Commands.Ai;
 global using Cratis.Cli.Commands.Arc;
 global using Cratis.Cli.Commands.Chronicle;
 global using Cratis.Cli.Commands.Chronicle.Diagnose;

--- a/Source/Cli.Specs/for_AiCorpusSynchronizer/when_synchronizing/and_a_managed_file_was_modified.cs
+++ b/Source/Cli.Specs/for_AiCorpusSynchronizer/when_synchronizing/and_a_managed_file_was_modified.cs
@@ -17,7 +17,7 @@ public class and_a_managed_file_was_modified : Specification
         Directory.CreateDirectory(Path.Combine(_corpus, ".cratis", "ai", "rules"));
         Directory.CreateDirectory(Path.Combine(_corpus, ".cratis", "ai", "skills", "example"));
         File.WriteAllText(Path.Combine(_corpus, ".cratis", "ai", "manifest.json"), "{\"harnesses\":[\"pi\"],\"profiles\":[\"cratis/example\"],\"languages\":[\"csharp\"]}");
-        File.WriteAllText(Path.Combine(_corpus, "distribution", "profile-catalog.json"), "{\"publicProfiles\":[{\"id\":\"cratis/example\",\"availableTargets\":[\"example\"]}],\"engineeringProfiles\":[]}");
+        File.WriteAllText(Path.Combine(_corpus, ".cratis", "ai", "profile-catalog.json"), "{\"publicProfiles\":[{\"id\":\"cratis/example\",\"availableTargets\":[\"example\"]}],\"engineeringProfiles\":[]}");
         File.WriteAllText(Path.Combine(_corpus, ".cratis", "ai", "rules", "general.md"), "# Rule");
         File.WriteAllText(Path.Combine(_corpus, ".cratis", "ai", "skills", "example", "SKILL.md"), "# Skill");
         AiCorpusSynchronizer.Synchronize(_project, _corpus, new(["pi"], ["cratis/example"], ["csharp"]));

--- a/Source/Cli.Specs/for_AiCorpusSynchronizer/when_synchronizing/and_a_managed_file_was_modified.cs
+++ b/Source/Cli.Specs/for_AiCorpusSynchronizer/when_synchronizing/and_a_managed_file_was_modified.cs
@@ -1,0 +1,38 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Cli.for_AiCorpusSynchronizer.when_synchronizing;
+
+public class and_a_managed_file_was_modified : Specification
+{
+    string _project = null!;
+    string _corpus = null!;
+    SyncResult _result = null!;
+
+    void Establish()
+    {
+        _project = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        _corpus = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(Path.Combine(_corpus, "distribution"));
+        Directory.CreateDirectory(Path.Combine(_corpus, ".ai", "rules"));
+        Directory.CreateDirectory(Path.Combine(_corpus, ".ai", "skills", "example"));
+        File.WriteAllText(Path.Combine(_corpus, ".ai", "manifest.json"), "{\"harnesses\":[\"pi\"],\"profiles\":[\"cratis/example\"],\"languages\":[\"csharp\"]}");
+        File.WriteAllText(Path.Combine(_corpus, "distribution", "profile-catalog.json"), "{\"publicProfiles\":[{\"id\":\"cratis/example\",\"availableTargets\":[\"example\"]}],\"engineeringProfiles\":[]}");
+        File.WriteAllText(Path.Combine(_corpus, ".ai", "rules", "general.md"), "# Rule");
+        File.WriteAllText(Path.Combine(_corpus, ".ai", "skills", "example", "SKILL.md"), "# Skill");
+        AiCorpusSynchronizer.Synchronize(_project, _corpus, new(["pi"], ["cratis/example"], ["csharp"]));
+        File.AppendAllText(Path.Combine(_project, ".ai", "skills", "example", "SKILL.md"), "\nUser addition");
+    }
+
+    void Because() => _result = AiCorpusSynchronizer.Synchronize(_project, _corpus, new(["pi"], ["cratis/example"], ["csharp"]));
+
+    [Fact] void should_report_the_conflict() => _result.Conflicts.ShouldContain("skills/example/SKILL.md");
+    [Fact] void should_preserve_the_user_change() => File.ReadAllText(Path.Combine(_project, ".ai", "skills", "example", "SKILL.md")).ShouldContain("User addition");
+    [Fact] void should_mark_installed_text_as_cratis_managed() => File.ReadAllText(Path.Combine(_project, ".ai", "rules", "general.md")).ShouldContain("cratis-ai-managed");
+
+    void Destroy()
+    {
+        Directory.Delete(_project, true);
+        Directory.Delete(_corpus, true);
+    }
+}

--- a/Source/Cli.Specs/for_AiCorpusSynchronizer/when_synchronizing/and_a_user_owned_file_occupies_a_managed_destination.cs
+++ b/Source/Cli.Specs/for_AiCorpusSynchronizer/when_synchronizing/and_a_user_owned_file_occupies_a_managed_destination.cs
@@ -3,7 +3,7 @@
 
 namespace Cratis.Cli.for_AiCorpusSynchronizer.when_synchronizing;
 
-public class and_force_is_requested : Specification
+public class and_a_user_owned_file_occupies_a_managed_destination : Specification
 {
     string _project = null!;
     string _corpus = null!;
@@ -13,21 +13,20 @@ public class and_force_is_requested : Specification
     {
         _project = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
         _corpus = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(Path.Combine(_project, ".cratis", "ai", "rules"));
         Directory.CreateDirectory(Path.Combine(_corpus, "distribution"));
         Directory.CreateDirectory(Path.Combine(_corpus, ".cratis", "ai", "rules"));
-        Directory.CreateDirectory(Path.Combine(_corpus, ".cratis", "ai", "skills", "example"));
+        File.WriteAllText(Path.Combine(_project, ".cratis", "ai", "rules", "general.md"), "# User rule");
         File.WriteAllText(Path.Combine(_corpus, ".cratis", "ai", "manifest.json"), "{\"harnesses\":[\"pi\"],\"profiles\":[\"cratis/example\"],\"languages\":[\"csharp\"]}");
-        File.WriteAllText(Path.Combine(_corpus, ".cratis", "ai", "profile-catalog.json"), "{\"publicProfiles\":[{\"id\":\"cratis/example\",\"availableTargets\":[\"example\"]}],\"engineeringProfiles\":[]}");
-        File.WriteAllText(Path.Combine(_corpus, ".cratis", "ai", "rules", "general.md"), "# Rule");
-        File.WriteAllText(Path.Combine(_corpus, ".cratis", "ai", "skills", "example", "SKILL.md"), "# Skill");
-        AiCorpusSynchronizer.Synchronize(_project, _corpus, new(["pi"], ["cratis/example"], ["csharp"]));
-        File.AppendAllText(Path.Combine(_project, ".cratis", "ai", "skills", "example", "SKILL.md"), "\nUser addition");
+        File.WriteAllText(Path.Combine(_corpus, ".cratis", "ai", "profile-catalog.json"), "{\"publicProfiles\":[{\"id\":\"cratis/example\"}],\"engineeringProfiles\":[]}");
+        File.WriteAllText(Path.Combine(_corpus, ".cratis", "ai", "rules", "general.md"), "# Cratis rule");
     }
 
     void Because() => _result = AiCorpusSynchronizer.Synchronize(_project, _corpus, new(["pi"], ["cratis/example"], ["csharp"]), force: true);
 
-    [Fact] void should_replace_the_modified_file() => File.ReadAllText(Path.Combine(_project, ".cratis", "ai", "skills", "example", "SKILL.md")).ShouldNotContain("User addition");
-    [Fact] void should_not_report_a_conflict() => _result.Conflicts.ShouldBeEmpty();
+    [Fact] void should_not_overwrite_the_user_file_even_when_forced() => File.ReadAllText(Path.Combine(_project, ".cratis", "ai", "rules", "general.md")).ShouldEqual("# User rule");
+    [Fact] void should_report_the_collision() => _result.Conflicts.ShouldContain("rules/general.md");
+    [Fact] void should_not_change_other_files() => _result.Actions.ShouldBeEmpty();
 
     void Destroy()
     {

--- a/Source/Cli.Specs/for_AiCorpusSynchronizer/when_synchronizing/and_force_is_requested.cs
+++ b/Source/Cli.Specs/for_AiCorpusSynchronizer/when_synchronizing/and_force_is_requested.cs
@@ -3,7 +3,7 @@
 
 namespace Cratis.Cli.for_AiCorpusSynchronizer.when_synchronizing;
 
-public class and_a_managed_file_was_modified : Specification
+public class and_force_is_requested : Specification
 {
     string _project = null!;
     string _corpus = null!;
@@ -24,13 +24,10 @@ public class and_a_managed_file_was_modified : Specification
         File.AppendAllText(Path.Combine(_project, ".cratis", "ai", "skills", "example", "SKILL.md"), "\nUser addition");
     }
 
-    void Because() => _result = AiCorpusSynchronizer.Synchronize(_project, _corpus, new(["pi"], ["cratis/example"], ["csharp"]));
+    void Because() => _result = AiCorpusSynchronizer.Synchronize(_project, _corpus, new(["pi"], ["cratis/example"], ["csharp"]), force: true);
 
-    [Fact] void should_stop_before_changing_any_managed_files() => _result.Actions.ShouldBeEmpty();
-    [Fact] void should_report_the_conflict() => _result.Conflicts.ShouldContain("skills/example/SKILL.md");
-    [Fact] void should_preserve_the_user_change() => File.ReadAllText(Path.Combine(_project, ".cratis", "ai", "skills", "example", "SKILL.md")).ShouldContain("User addition");
-    [Fact] void should_mark_installed_text_as_cratis_managed() => File.ReadAllText(Path.Combine(_project, ".cratis", "ai", "rules", "general.md")).ShouldContain("cratis-ai-managed");
-    [Fact] void should_link_the_harness_to_the_canonical_corpus() => new DirectoryInfo(Path.Combine(_project, ".pi", "skills")).LinkTarget.ShouldEqual("../.cratis/ai/skills");
+    [Fact] void should_replace_the_modified_file() => File.ReadAllText(Path.Combine(_project, ".cratis", "ai", "skills", "example", "SKILL.md")).ShouldNotContain("User addition");
+    [Fact] void should_not_report_a_conflict() => _result.Conflicts.ShouldBeEmpty();
 
     void Destroy()
     {

--- a/Source/Cli.Specs/for_AiCorpusSynchronizer/when_synchronizing/and_only_typescript_is_selected.cs
+++ b/Source/Cli.Specs/for_AiCorpusSynchronizer/when_synchronizing/and_only_typescript_is_selected.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Cli.for_AiCorpusSynchronizer.when_synchronizing;
+
+public class and_only_typescript_is_selected : Specification
+{
+    string _project = null!;
+    string _corpus = null!;
+
+    void Establish()
+    {
+        _project = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        _corpus = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(Path.Combine(_corpus, "distribution"));
+        Directory.CreateDirectory(Path.Combine(_corpus, ".cratis", "ai", "rules"));
+        Directory.CreateDirectory(Path.Combine(_corpus, ".cratis", "ai", "skills", "csharp-skill"));
+        Directory.CreateDirectory(Path.Combine(_corpus, ".cratis", "ai", "skills", "typescript-skill"));
+        File.WriteAllText(Path.Combine(_corpus, ".cratis", "ai", "manifest.json"), "{\"harnesses\":[\"pi\"],\"profiles\":[\"cratis/example\"],\"languages\":[\"csharp\",\"typescript\"]}");
+        File.WriteAllText(Path.Combine(_corpus, ".cratis", "ai", "profile-catalog.json"), "{\"publicProfiles\":[{\"id\":\"cratis/example\",\"composes\":[\"cratis/example/csharp\",\"cratis/example/typescript\"]},{\"id\":\"cratis/example/csharp\",\"languages\":[\"csharp\"],\"availableTargets\":[\"csharp-skill\"]},{\"id\":\"cratis/example/typescript\",\"languages\":[\"typescript\"],\"availableTargets\":[\"typescript-skill\"]}],\"engineeringProfiles\":[]}");
+        File.WriteAllText(Path.Combine(_corpus, ".cratis", "ai", "rules", "general.md"), "# Rule");
+        File.WriteAllText(Path.Combine(_corpus, ".cratis", "ai", "skills", "csharp-skill", "SKILL.md"), "# CSharp");
+        File.WriteAllText(Path.Combine(_corpus, ".cratis", "ai", "skills", "typescript-skill", "SKILL.md"), "# TypeScript");
+    }
+
+    void Because() => AiCorpusSynchronizer.Synchronize(_project, _corpus, new(["pi"], ["cratis/example"], ["typescript"]));
+
+    [Fact] void should_install_the_typescript_skill() => File.Exists(Path.Combine(_project, ".cratis", "ai", "skills", "typescript-skill", "SKILL.md")).ShouldBeTrue();
+    [Fact] void should_not_install_the_csharp_skill() => File.Exists(Path.Combine(_project, ".cratis", "ai", "skills", "csharp-skill", "SKILL.md")).ShouldBeFalse();
+
+    void Destroy()
+    {
+        Directory.Delete(_project, true);
+        Directory.Delete(_corpus, true);
+    }
+}

--- a/Source/Cli.Specs/for_AiCorpusSynchronizer/when_synchronizing/and_pi_cursor_and_opencode_are_selected.cs
+++ b/Source/Cli.Specs/for_AiCorpusSynchronizer/when_synchronizing/and_pi_cursor_and_opencode_are_selected.cs
@@ -1,0 +1,56 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Cli.for_AiCorpusSynchronizer.when_synchronizing;
+
+public class and_pi_cursor_and_opencode_are_selected : Specification
+{
+    string _project = null!;
+    string _corpus = null!;
+
+    void Establish()
+    {
+        _project = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        _corpus = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(Path.Combine(_corpus, "distribution"));
+        foreach (var directory in new[]
+        {
+            Path.Combine(_corpus, ".cratis", "ai", "rules"),
+            Path.Combine(_corpus, ".cratis", "ai", "agents"),
+            Path.Combine(_corpus, ".cratis", "ai", "prompts"),
+            Path.Combine(_corpus, ".cratis", "ai", "skills", "example"),
+            Path.Combine(_corpus, ".cratis", "ai", "harnesses", "pi", "extensions"),
+            Path.Combine(_corpus, ".cratis", "ai", "harnesses", "cursor", "rules"),
+        })
+        {
+            Directory.CreateDirectory(directory);
+        }
+        File.WriteAllText(Path.Combine(_corpus, ".cratis", "ai", "manifest.json"), "{\"harnesses\":[\"pi\",\"cursor\",\"opencode\"],\"profiles\":[\"cratis/example\"],\"languages\":[\"csharp\"]}");
+        File.WriteAllText(Path.Combine(_corpus, ".cratis", "ai", "profile-catalog.json"), "{\"publicProfiles\":[{\"id\":\"cratis/example\",\"availableTargets\":[\"example\"]}],\"engineeringProfiles\":[]}");
+        File.WriteAllText(Path.Combine(_corpus, ".cratis", "ai", "rules", "general.md"), "# Rule");
+        File.WriteAllText(Path.Combine(_corpus, ".cratis", "ai", "agents", "reviewer.md"), "# Agent");
+        File.WriteAllText(Path.Combine(_corpus, ".cratis", "ai", "prompts", "review.prompt.md"), "---\ndescription: Review\n---\nReview this.");
+        File.WriteAllText(Path.Combine(_corpus, ".cratis", "ai", "skills", "example", "SKILL.md"), "---\nname: example\ndescription: Example\n---\n# Skill");
+        File.WriteAllText(Path.Combine(_corpus, ".cratis", "ai", "harnesses", "pi", "extensions", "index.ts"), "export default () => {};");
+        File.WriteAllText(Path.Combine(_corpus, ".cratis", "ai", "harnesses", "cursor", "rules", "cratis.mdc"), "---\nalwaysApply: true\n---\nUse Cratis.");
+    }
+
+    void Because() => AiCorpusSynchronizer.Synchronize(_project, _corpus, new(["pi", "cursor", "opencode"], ["cratis/example"], ["csharp"]));
+
+    [Fact] void should_configure_pi_skills() => new DirectoryInfo(Path.Combine(_project, ".pi", "skills")).LinkTarget.ShouldEqual("../.cratis/ai/skills");
+    [Fact] void should_configure_pi_agents() => new DirectoryInfo(Path.Combine(_project, ".pi", "agents")).LinkTarget.ShouldEqual("../.cratis/ai/agents");
+    [Fact] void should_configure_pi_extensions() => new DirectoryInfo(Path.Combine(_project, ".pi", "extensions")).LinkTarget.ShouldEqual("../.cratis/ai/harnesses/pi/extensions");
+    [Fact] void should_configure_pi_prompts() => new FileInfo(Path.Combine(_project, ".pi", "prompts", "review.md")).LinkTarget.ShouldEqual("../../.cratis/ai/prompts/review.prompt.md");
+    [Fact] void should_configure_cursor_rules() => new DirectoryInfo(Path.Combine(_project, ".cursor", "rules")).LinkTarget.ShouldEqual("../.cratis/ai/harnesses/cursor/rules");
+    [Fact] void should_configure_cursor_skills() => new DirectoryInfo(Path.Combine(_project, ".cursor", "skills")).LinkTarget.ShouldEqual("../.cratis/ai/skills");
+    [Fact] void should_configure_opencode_agents() => new DirectoryInfo(Path.Combine(_project, ".opencode", "agents")).LinkTarget.ShouldEqual("../.cratis/ai/agents");
+    [Fact] void should_configure_opencode_commands() => new FileInfo(Path.Combine(_project, ".opencode", "commands", "review.md")).LinkTarget.ShouldEqual("../../.cratis/ai/prompts/review.prompt.md");
+    [Fact] void should_share_root_instructions() => new FileInfo(Path.Combine(_project, "AGENTS.md")).LinkTarget.ShouldEqual(".cratis/ai/rules/general.md");
+    [Fact] void should_keep_skill_frontmatter_first() => File.ReadAllText(Path.Combine(_project, ".cratis", "ai", "skills", "example", "SKILL.md")).StartsWith("---\n", StringComparison.Ordinal).ShouldBeTrue();
+
+    void Destroy()
+    {
+        Directory.Delete(_project, true);
+        Directory.Delete(_corpus, true);
+    }
+}

--- a/Source/Cli/Commands/Ai/AiBranch.cs
+++ b/Source/Cli/Commands/Ai/AiBranch.cs
@@ -1,0 +1,8 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Cli.Commands.Ai;
+
+/// <summary>Commands for installing and maintaining the Cratis AI corpus.</summary>
+[CliBranch("ai", "Install, update, inspect, and remove Cratis-managed AI guidance.")]
+public static class AiBranch;

--- a/Source/Cli/Commands/Ai/AiCommands.cs
+++ b/Source/Cli/Commands/Ai/AiCommands.cs
@@ -13,7 +13,7 @@ public sealed class AiInstallCommand : AsyncCommand<AiInstallSettings>
         return result.Conflicts.Count == 0 ? ExitCodes.Success : ExitCodes.ValidationError;
     }
 
-    public static string Source(AiSettings settings) => settings.Source ?? Environment.GetEnvironmentVariable("CRATIS_AI_SOURCE") ?? throw new InvalidOperationException("Provide --source with a Cratis/AI checkout, or set CRATIS_AI_SOURCE.");
+    public static string Source(AiSettings settings) => settings.Source ?? Environment.GetEnvironmentVariable("CRATIS_AI_SOURCE") ?? AiCorpusSource.Download();
 
     protected override Task<int> ExecuteAsync(CommandContext context, AiInstallSettings settings, CancellationToken cancellationToken)
     {

--- a/Source/Cli/Commands/Ai/AiCommands.cs
+++ b/Source/Cli/Commands/Ai/AiCommands.cs
@@ -11,7 +11,7 @@ public sealed class AiInstallCommand : AsyncCommand<AiInstallSettings>
     {
         OutputFormatter.WriteObject(format, new { actions = result.Actions, conflicts = result.Conflicts });
         if (result.Conflicts.Count == 0) return ExitCodes.Success;
-        OutputFormatter.WriteError(format, "Cratis-managed AI files were modified locally; no files were changed.", "Review the reported files, or re-run with --force to replace or remove them.", ExitCodes.ValidationErrorCode);
+        OutputFormatter.WriteError(format, "Cratis-managed AI files were modified or a user-owned path conflicts; no files were changed.", "Review the reported paths. Use --force only to replace or remove content already recorded as Cratis-managed.", ExitCodes.ValidationErrorCode);
         return ExitCodes.ValidationError;
     }
 
@@ -53,12 +53,22 @@ public sealed class AiUpdateCommand : AsyncCommand<AiSettings>
 
 /// <summary>Displays Cratis AI configuration and locally modified managed files.</summary>
 [CliCommand("status", "Show Cratis AI configuration, installed revision, and local conflicts", Branch = typeof(AiBranch))]
-public sealed class AiStatusCommand : AsyncCommand<GlobalSettings>
+public sealed class AiStatusCommand : AsyncCommand<AiSettings>
 {
-    protected override Task<int> ExecuteAsync(CommandContext context, GlobalSettings settings, CancellationToken cancellationToken)
+    protected override Task<int> ExecuteAsync(CommandContext context, AiSettings settings, CancellationToken cancellationToken)
     {
         var status = AiCorpusSynchronizer.Status(Directory.GetCurrentDirectory());
-        OutputFormatter.WriteObject(settings.ResolveOutputFormat(), new { harnesses = status.Configuration.Harnesses, profiles = status.Configuration.Profiles, languages = status.Configuration.Languages, sourceRevision = status.SourceRevision, modifiedFiles = status.ModifiedFiles });
+        var availableSourceRevision = AiCorpusSynchronizer.Revision(AiInstallCommand.Source(settings));
+        OutputFormatter.WriteObject(settings.ResolveOutputFormat(), new
+        {
+            harnesses = status.Configuration.Harnesses,
+            profiles = status.Configuration.Profiles,
+            languages = status.Configuration.Languages,
+            sourceRevision = status.SourceRevision,
+            availableSourceRevision,
+            updateAvailable = !string.Equals(status.SourceRevision, availableSourceRevision, StringComparison.Ordinal),
+            modifiedFiles = status.ModifiedFiles,
+        });
         return Task.FromResult(status.ModifiedFiles.Count == 0 ? ExitCodes.Success : ExitCodes.ValidationError);
     }
 }

--- a/Source/Cli/Commands/Ai/AiCommands.cs
+++ b/Source/Cli/Commands/Ai/AiCommands.cs
@@ -10,7 +10,9 @@ public sealed class AiInstallCommand : AsyncCommand<AiInstallSettings>
     public static int Write(SyncResult result, string format)
     {
         OutputFormatter.WriteObject(format, new { actions = result.Actions, conflicts = result.Conflicts });
-        return result.Conflicts.Count == 0 ? ExitCodes.Success : ExitCodes.ValidationError;
+        if (result.Conflicts.Count == 0) return ExitCodes.Success;
+        OutputFormatter.WriteError(format, "Cratis-managed AI files were modified locally; no files were changed.", "Review the reported files, or re-run with --force to replace or remove them.", ExitCodes.ValidationErrorCode);
+        return ExitCodes.ValidationError;
     }
 
     public static string Source(AiSettings settings) => settings.Source ?? Environment.GetEnvironmentVariable("CRATIS_AI_SOURCE") ?? AiCorpusSource.Download();
@@ -23,7 +25,7 @@ public sealed class AiInstallCommand : AsyncCommand<AiInstallSettings>
             Select(settings.Harnesses, "harnesses", available.Harnesses),
             Select(settings.Profiles, "profiles", available.Profiles),
             Select(settings.Languages, "languages", available.Languages));
-        return Task.FromResult(Write(AiCorpusSynchronizer.Synchronize(Directory.GetCurrentDirectory(), source, configuration), settings.ResolveOutputFormat()));
+        return Task.FromResult(Write(AiCorpusSynchronizer.Synchronize(Directory.GetCurrentDirectory(), source, configuration, settings.Force), settings.ResolveOutputFormat()));
     }
 
     static string[] Select(string? value, string label, IReadOnlyList<string> defaults)
@@ -45,7 +47,7 @@ public sealed class AiUpdateCommand : AsyncCommand<AiSettings>
     {
         var project = Directory.GetCurrentDirectory();
         var configuration = AiCorpusSynchronizer.Status(project).Configuration;
-        return Task.FromResult(AiInstallCommand.Write(AiCorpusSynchronizer.Synchronize(project, AiInstallCommand.Source(settings), configuration), settings.ResolveOutputFormat()));
+        return Task.FromResult(AiInstallCommand.Write(AiCorpusSynchronizer.Synchronize(project, AiInstallCommand.Source(settings), configuration, settings.Force), settings.ResolveOutputFormat()));
     }
 }
 
@@ -63,8 +65,8 @@ public sealed class AiStatusCommand : AsyncCommand<GlobalSettings>
 
 /// <summary>Removes unchanged Cratis-managed AI content while preserving user files.</summary>
 [CliCommand("uninstall", "Remove Cratis-owned AI content while preserving user-owned files", Branch = typeof(AiBranch))]
-public sealed class AiUninstallCommand : AsyncCommand<GlobalSettings>
+public sealed class AiUninstallCommand : AsyncCommand<AiUninstallSettings>
 {
-    protected override Task<int> ExecuteAsync(CommandContext context, GlobalSettings settings, CancellationToken cancellationToken) =>
-        Task.FromResult(AiInstallCommand.Write(AiCorpusSynchronizer.Uninstall(Directory.GetCurrentDirectory()), settings.ResolveOutputFormat()));
+    protected override Task<int> ExecuteAsync(CommandContext context, AiUninstallSettings settings, CancellationToken cancellationToken) =>
+        Task.FromResult(AiInstallCommand.Write(AiCorpusSynchronizer.Uninstall(Directory.GetCurrentDirectory(), settings.Force), settings.ResolveOutputFormat()));
 }

--- a/Source/Cli/Commands/Ai/AiCommands.cs
+++ b/Source/Cli/Commands/Ai/AiCommands.cs
@@ -1,0 +1,70 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Cli.Commands.Ai;
+
+/// <summary>Installs selected Cratis AI guidance into the current repository.</summary>
+[CliCommand("install", "Install selected Cratis AI rules, skills, and harness integration", Branch = typeof(AiBranch))]
+public sealed class AiInstallCommand : AsyncCommand<AiInstallSettings>
+{
+    public static int Write(SyncResult result, string format)
+    {
+        OutputFormatter.WriteObject(format, new { actions = result.Actions, conflicts = result.Conflicts });
+        return result.Conflicts.Count == 0 ? ExitCodes.Success : ExitCodes.ValidationError;
+    }
+
+    public static string Source(AiSettings settings) => settings.Source ?? Environment.GetEnvironmentVariable("CRATIS_AI_SOURCE") ?? throw new InvalidOperationException("Provide --source with a Cratis/AI checkout, or set CRATIS_AI_SOURCE.");
+
+    protected override Task<int> ExecuteAsync(CommandContext context, AiInstallSettings settings, CancellationToken cancellationToken)
+    {
+        var source = Source(settings);
+        var available = AiCorpusSynchronizer.Available(source);
+        var configuration = new AiConfiguration(
+            Select(settings.Harnesses, "harnesses", available.Harnesses),
+            Select(settings.Profiles, "profiles", available.Profiles),
+            Select(settings.Languages, "languages", available.Languages));
+        return Task.FromResult(Write(AiCorpusSynchronizer.Synchronize(Directory.GetCurrentDirectory(), source, configuration), settings.ResolveOutputFormat()));
+    }
+
+    static string[] Select(string? value, string label, IReadOnlyList<string> defaults)
+    {
+        if (!string.IsNullOrWhiteSpace(value)) return value.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        if (Console.IsInputRedirected) throw new InvalidOperationException($"--{label} is required when input is redirected.");
+        var prompt = new MultiSelectionPrompt<string>()
+            .Title($"Select {label}")
+            .AddChoices(defaults);
+        return [.. AnsiConsole.Prompt(prompt)];
+    }
+}
+
+/// <summary>Synchronizes the configured Cratis AI corpus.</summary>
+[CliCommand("update", "Synchronize configured Cratis-owned AI content without overwriting local changes", Branch = typeof(AiBranch))]
+public sealed class AiUpdateCommand : AsyncCommand<AiSettings>
+{
+    protected override Task<int> ExecuteAsync(CommandContext context, AiSettings settings, CancellationToken cancellationToken)
+    {
+        var project = Directory.GetCurrentDirectory();
+        var configuration = AiCorpusSynchronizer.Status(project).Configuration;
+        return Task.FromResult(AiInstallCommand.Write(AiCorpusSynchronizer.Synchronize(project, AiInstallCommand.Source(settings), configuration), settings.ResolveOutputFormat()));
+    }
+}
+
+/// <summary>Displays Cratis AI configuration and locally modified managed files.</summary>
+[CliCommand("status", "Show Cratis AI configuration, installed revision, and local conflicts", Branch = typeof(AiBranch))]
+public sealed class AiStatusCommand : AsyncCommand<GlobalSettings>
+{
+    protected override Task<int> ExecuteAsync(CommandContext context, GlobalSettings settings, CancellationToken cancellationToken)
+    {
+        var status = AiCorpusSynchronizer.Status(Directory.GetCurrentDirectory());
+        OutputFormatter.WriteObject(settings.ResolveOutputFormat(), new { harnesses = status.Configuration.Harnesses, profiles = status.Configuration.Profiles, languages = status.Configuration.Languages, sourceRevision = status.SourceRevision, modifiedFiles = status.ModifiedFiles });
+        return Task.FromResult(status.ModifiedFiles.Count == 0 ? ExitCodes.Success : ExitCodes.ValidationError);
+    }
+}
+
+/// <summary>Removes unchanged Cratis-managed AI content while preserving user files.</summary>
+[CliCommand("uninstall", "Remove Cratis-owned AI content while preserving user-owned files", Branch = typeof(AiBranch))]
+public sealed class AiUninstallCommand : AsyncCommand<GlobalSettings>
+{
+    protected override Task<int> ExecuteAsync(CommandContext context, GlobalSettings settings, CancellationToken cancellationToken) =>
+        Task.FromResult(AiInstallCommand.Write(AiCorpusSynchronizer.Uninstall(Directory.GetCurrentDirectory()), settings.ResolveOutputFormat()));
+}

--- a/Source/Cli/Commands/Ai/AiConfiguration.cs
+++ b/Source/Cli/Commands/Ai/AiConfiguration.cs
@@ -19,7 +19,14 @@ public sealed record AiConfiguration(IReadOnlyList<string> Harnesses, IReadOnlyL
 /// <param name="Hash">The hash of the installed bytes.</param>
 public sealed record AiManagedFile(string Source, string Destination, string Hash);
 
+/// <summary>A harness integration created by Cratis AI.</summary>
+/// <param name="Path">The path relative to the consuming repository.</param>
+/// <param name="Target">The relative symbolic-link target.</param>
+/// <param name="IsDirectory">Whether the target is a directory.</param>
+public sealed record AiManagedIntegration(string Path, string Target, bool IsDirectory);
+
 /// <summary>Metadata used to make synchronization deterministic without claiming user files.</summary>
 /// <param name="SourceRevision">The corpus revision used during installation.</param>
 /// <param name="Files">The Cratis-managed files.</param>
-public sealed record AiInstallationManifest(string SourceRevision, IReadOnlyList<AiManagedFile> Files);
+/// <param name="Integrations">The harness integrations created by Cratis.</param>
+public sealed record AiInstallationManifest(string SourceRevision, IReadOnlyList<AiManagedFile> Files, IReadOnlyList<AiManagedIntegration>? Integrations = null);

--- a/Source/Cli/Commands/Ai/AiConfiguration.cs
+++ b/Source/Cli/Commands/Ai/AiConfiguration.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Cli.Commands.Ai;
+
+/// <summary>The project-owned selection used to resolve the Cratis AI corpus.</summary>
+/// <param name="Harnesses">The harnesses to integrate.</param>
+/// <param name="Profiles">The Cratis profiles to resolve.</param>
+/// <param name="Languages">The languages used by the repository.</param>
+public sealed record AiConfiguration(IReadOnlyList<string> Harnesses, IReadOnlyList<string> Profiles, IReadOnlyList<string> Languages)
+{
+    /// <summary>Gets the current configuration schema version.</summary>
+    public const string SchemaVersion = "1.0";
+}
+
+/// <summary>A Cratis-owned file and the bytes installed for it.</summary>
+/// <param name="Source">The stable source identity.</param>
+/// <param name="Destination">The managed relative path.</param>
+/// <param name="Hash">The hash of the installed bytes.</param>
+public sealed record AiManagedFile(string Source, string Destination, string Hash);
+
+/// <summary>Metadata used to make synchronization deterministic without claiming user files.</summary>
+/// <param name="SourceRevision">The corpus revision used during installation.</param>
+/// <param name="Files">The Cratis-managed files.</param>
+public sealed record AiInstallationManifest(string SourceRevision, IReadOnlyList<AiManagedFile> Files);

--- a/Source/Cli/Commands/Ai/AiCorpusSource.cs
+++ b/Source/Cli/Commands/Ai/AiCorpusSource.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Diagnostics;
+
+namespace Cratis.Cli.Commands.Ai;
+
+/// <summary>Obtains the canonical AI repository when a local checkout was not supplied.</summary>
+public static class AiCorpusSource
+{
+    const string Repository = "https://github.com/Cratis/AI.git";
+
+    /// <summary>Clones the current default branch into a temporary directory.</summary>
+    /// <returns>The temporary checkout path.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when Git cannot start or clone the corpus.</exception>
+    public static string Download()
+    {
+        var destination = Path.Combine(Path.GetTempPath(), "cratis-ai", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(Path.GetDirectoryName(destination)!);
+        using var process = Process.Start(new ProcessStartInfo("git", $"clone --depth 1 {Repository} \"{destination}\"")
+        {
+            RedirectStandardError = true,
+            RedirectStandardOutput = true,
+            UseShellExecute = false,
+        }) ?? throw new InvalidOperationException("Could not start git to download the Cratis AI corpus.");
+        process.WaitForExit();
+        if (process.ExitCode != 0) throw new InvalidOperationException($"Could not download the Cratis AI corpus: {process.StandardError.ReadToEnd()}");
+        return destination;
+    }
+}

--- a/Source/Cli/Commands/Ai/AiCorpusSynchronizer.cs
+++ b/Source/Cli/Commands/Ai/AiCorpusSynchronizer.cs
@@ -1,0 +1,237 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+
+namespace Cratis.Cli.Commands.Ai;
+
+/// <summary>Synchronizes only the files recorded as Cratis-owned in a project.</summary>
+public static class AiCorpusSynchronizer
+{
+    const string ConfigurationPath = ".cratis/ai.json";
+    const string ManifestPath = ".cratis/ai.manifest.json";
+    static readonly JsonSerializerOptions _serializerOptions = new() { WriteIndented = true };
+
+    /// <summary>Installs or updates the selected corpus, preserving changed and unknown files.</summary>
+    /// <param name="projectPath">The consuming repository root.</param>
+    /// <param name="corpusPath">The Cratis AI repository root.</param>
+    /// <param name="configuration">The requested harnesses, profiles, and languages.</param>
+    /// <returns>The changes made and files requiring user attention.</returns>
+    public static SyncResult Synchronize(string projectPath, string corpusPath, AiConfiguration configuration)
+    {
+        var previous = ReadManifest(projectPath);
+        var desired = Resolve(corpusPath, configuration).ToDictionary(asset => asset.Destination, StringComparer.Ordinal);
+        var conflicts = new List<string>();
+        var actions = new List<string>();
+        var installed = new List<AiManagedFile>();
+
+        foreach (var asset in desired.Values)
+        {
+            var destination = Path.Combine(projectPath, ".ai", asset.Destination);
+            var content = AddMarker(asset.Source, File.ReadAllText(asset.Path));
+            var hash = Hash(content);
+            var existed = File.Exists(destination);
+            var existing = previous.Files.FirstOrDefault(file => file.Destination == asset.Destination);
+            if (existed && existing is not null && !string.Equals(Hash(File.ReadAllText(destination)), existing.Hash, StringComparison.Ordinal))
+            {
+                conflicts.Add(asset.Destination);
+                installed.Add(existing);
+                continue;
+            }
+
+            Directory.CreateDirectory(Path.GetDirectoryName(destination)!);
+            File.WriteAllText(destination, content);
+            installed.Add(new(asset.Source, asset.Destination, hash));
+            actions.Add(existed ? $"Updated {asset.Destination}" : $"Added {asset.Destination}");
+        }
+
+        foreach (var existing in previous.Files.Where(file => !desired.ContainsKey(file.Destination)))
+        {
+            var destination = Path.Combine(projectPath, ".ai", existing.Destination);
+            if (!File.Exists(destination)) continue;
+            if (!string.Equals(Hash(File.ReadAllText(destination)), existing.Hash, StringComparison.Ordinal))
+            {
+                conflicts.Add(existing.Destination);
+                installed.Add(existing);
+                continue;
+            }
+
+            File.Delete(destination);
+            actions.Add($"Removed {existing.Destination}");
+        }
+
+        ConfigureHarnesses(projectPath, configuration.Harnesses, installed.Select(file => file.Destination));
+        WriteJson(Path.Combine(projectPath, ConfigurationPath), new { schemaVersion = AiConfiguration.SchemaVersion, harnesses = configuration.Harnesses, profiles = configuration.Profiles, languages = configuration.Languages });
+        var manifest = new AiInstallationManifest(Revision(corpusPath), [.. installed.OrderBy(file => file.Destination, StringComparer.Ordinal)]);
+        WriteJson(Path.Combine(projectPath, ManifestPath), manifest);
+        return new(actions, conflicts);
+    }
+
+    /// <summary>Reads the selections offered by a Cratis AI corpus.</summary>
+    /// <param name="corpusPath">The Cratis AI repository root.</param>
+    /// <returns>The harnesses, profiles, and languages published by the corpus manifest.</returns>
+    public static AiConfiguration Available(string corpusPath)
+    {
+        using var manifest = JsonDocument.Parse(File.ReadAllText(Path.Combine(corpusPath, ".ai", "manifest.json")));
+        return new(ReadArray(manifest, "harnesses"), ReadArray(manifest, "profiles"), ReadArray(manifest, "languages"));
+    }
+
+    /// <summary>Returns configured and locally modified managed files without changing the project.</summary>
+    /// <param name="projectPath">The consuming repository root.</param>
+    /// <returns>The current installation state.</returns>
+    public static AiStatus Status(string projectPath)
+    {
+        var configuration = ReadConfiguration(projectPath);
+        var manifest = ReadManifest(projectPath);
+        var modified = manifest.Files.Where(file =>
+        {
+            var path = Path.Combine(projectPath, ".ai", file.Destination);
+            return !File.Exists(path) || !string.Equals(Hash(File.ReadAllText(path)), file.Hash, StringComparison.Ordinal);
+        }).Select(file => file.Destination).ToArray();
+        return new(configuration, manifest.SourceRevision, modified);
+    }
+
+    /// <summary>Removes only unchanged managed files and Cratis-created harness settings.</summary>
+    /// <param name="projectPath">The consuming repository root.</param>
+    /// <returns>The changes made and files requiring user attention.</returns>
+    public static SyncResult Uninstall(string projectPath)
+    {
+        var manifest = ReadManifest(projectPath);
+        var actions = new List<string>();
+        var conflicts = new List<string>();
+        foreach (var file in manifest.Files)
+        {
+            var path = Path.Combine(projectPath, ".ai", file.Destination);
+            if (!File.Exists(path)) continue;
+            if (!string.Equals(Hash(File.ReadAllText(path)), file.Hash, StringComparison.Ordinal))
+            {
+                conflicts.Add(file.Destination);
+                continue;
+            }
+
+            File.Delete(path);
+            actions.Add($"Removed {file.Destination}");
+        }
+
+        var manifestPath = Path.Combine(projectPath, ManifestPath);
+        if (conflicts.Count == 0 && File.Exists(manifestPath)) File.Delete(manifestPath);
+        return new(actions, conflicts);
+    }
+
+    static IEnumerable<CorpusAsset> Resolve(string corpusPath, AiConfiguration configuration)
+    {
+        ValidateSelection(corpusPath, configuration);
+        var catalogPath = Path.Combine(corpusPath, "distribution", "profile-catalog.json");
+        using var catalog = JsonDocument.Parse(File.ReadAllText(catalogPath));
+        var profiles = catalog.RootElement.EnumerateObject()
+            .Where(property => string.Equals(property.Name, "publicProfiles", StringComparison.Ordinal) || string.Equals(property.Name, "engineeringProfiles", StringComparison.Ordinal))
+            .SelectMany(property => property.Value.EnumerateArray())
+            .ToArray();
+        var selected = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var profile in configuration.Profiles) SelectProfile(profile, selected, profiles);
+
+        var skillNames = profiles.Where(profile => selected.Contains(profile.GetProperty("id").GetString()!))
+            .SelectMany(AvailableTargets)
+            .ToHashSet(StringComparer.Ordinal);
+        var rulesRoot = Path.Combine(corpusPath, ".ai", "rules");
+        foreach (var rule in Directory.EnumerateFiles(rulesRoot, "*.md", SearchOption.AllDirectories))
+        {
+            var relative = Path.GetRelativePath(rulesRoot, rule).Replace('\\', '/');
+            yield return new(rule, $"rules/{relative}", $"rules/{relative}");
+        }
+
+        foreach (var skill in skillNames)
+        {
+            var directory = Path.Combine(corpusPath, ".ai", "skills", skill);
+            foreach (var file in Directory.EnumerateFiles(directory, "*", SearchOption.AllDirectories))
+            {
+                var relative = Path.GetRelativePath(directory, file).Replace('\\', '/');
+                yield return new(file, $"skills/{skill}/{relative}", $"skills/{skill}/{relative}");
+            }
+        }
+    }
+
+    static void ValidateSelection(string corpusPath, AiConfiguration configuration)
+    {
+        var available = Available(corpusPath);
+        Validate("harness", configuration.Harnesses, available.Harnesses);
+        Validate("profile", configuration.Profiles, available.Profiles);
+        Validate("language", configuration.Languages, available.Languages);
+    }
+
+    static void Validate(string dimension, IEnumerable<string> selected, IEnumerable<string> available)
+    {
+        var known = available.ToHashSet(StringComparer.OrdinalIgnoreCase);
+        foreach (var value in selected)
+        {
+            if (!known.Contains(value)) throw new InvalidOperationException($"Cratis AI does not offer {dimension} '{value}'.");
+        }
+    }
+
+    static IEnumerable<string> AvailableTargets(JsonElement profile) => profile.TryGetProperty("availableTargets", out var targets)
+        ? targets.EnumerateArray().Select(target => target.GetString()!)
+        : [];
+
+    static void SelectProfile(string id, ISet<string> selected, IEnumerable<JsonElement> profiles)
+    {
+        if (!selected.Add(id)) return;
+        var profile = profiles.FirstOrDefault(item => item.GetProperty("id").GetString() == id);
+        if (profile.ValueKind == JsonValueKind.Undefined) throw new InvalidOperationException($"Unknown Cratis AI profile '{id}'.");
+        if (!profile.TryGetProperty("composes", out var composes)) return;
+        foreach (var child in composes.EnumerateArray()) SelectProfile(child.GetString()!, selected, profiles);
+    }
+
+    static void ConfigureHarnesses(string projectPath, IEnumerable<string> harnesses, IEnumerable<string> files)
+    {
+        var skills = files.Where(file => file.StartsWith("skills/", StringComparison.Ordinal))
+            .Select(file => ".ai/" + file[..file.LastIndexOf('/')])
+            .Distinct()
+            .Order()
+            .ToArray();
+        if (harnesses.Contains("pi", StringComparer.OrdinalIgnoreCase))
+        {
+            WriteJson(Path.Combine(projectPath, ".pi", "settings.json"), new { skillPaths = skills, enableSkillCommands = true, cratisAiManaged = true });
+        }
+    }
+
+    static AiConfiguration ReadConfiguration(string projectPath)
+    {
+        var path = Path.Combine(projectPath, ConfigurationPath);
+        if (!File.Exists(path)) throw new InvalidOperationException("No .cratis/ai.json exists. Run 'cratis ai install' first.");
+        using var document = JsonDocument.Parse(File.ReadAllText(path));
+        return new(ReadArray(document, "harnesses"), ReadArray(document, "profiles"), ReadArray(document, "languages"));
+    }
+
+    static string[] ReadArray(JsonDocument document, string name) => [.. document.RootElement.GetProperty(name).EnumerateArray().Select(item => item.GetString()!)];
+
+    static AiInstallationManifest ReadManifest(string projectPath)
+    {
+        var path = Path.Combine(projectPath, ManifestPath);
+        return File.Exists(path) ? JsonSerializer.Deserialize<AiInstallationManifest>(File.ReadAllText(path))! : new("unknown", []);
+    }
+
+    static string AddMarker(string source, string content) => $"<!-- cratis-ai-managed: {source} -->\n{content}";
+    static string Hash(string content) => Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(content)));
+    static string Revision(string corpusPath) => Directory.GetLastWriteTimeUtc(corpusPath).ToString("O");
+
+    static void WriteJson(string path, object value)
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        File.WriteAllText(path, JsonSerializer.Serialize(value, _serializerOptions));
+    }
+
+    record CorpusAsset(string Path, string Destination, string Source);
+}
+
+/// <summary>The result of an install, update, or uninstall operation.</summary>
+/// <param name="Actions">The files added, changed, or removed.</param>
+/// <param name="Conflicts">Managed files that were changed locally.</param>
+public sealed record SyncResult(IReadOnlyList<string> Actions, IReadOnlyList<string> Conflicts);
+
+/// <summary>Read-only installation state.</summary>
+/// <param name="Configuration">The configured selection.</param>
+/// <param name="SourceRevision">The corpus revision used to synchronize.</param>
+/// <param name="ModifiedFiles">Managed files changed or removed locally.</param>
+public sealed record AiStatus(AiConfiguration Configuration, string SourceRevision, IReadOnlyList<string> ModifiedFiles);

--- a/Source/Cli/Commands/Ai/AiCorpusSynchronizer.cs
+++ b/Source/Cli/Commands/Ai/AiCorpusSynchronizer.cs
@@ -18,23 +18,26 @@ public static class AiCorpusSynchronizer
     /// <param name="projectPath">The consuming repository root.</param>
     /// <param name="corpusPath">The Cratis AI repository root.</param>
     /// <param name="configuration">The requested harnesses, profiles, and languages.</param>
+    /// <param name="force">Whether modified managed files may be replaced or removed.</param>
     /// <returns>The changes made and files requiring user attention.</returns>
-    public static SyncResult Synchronize(string projectPath, string corpusPath, AiConfiguration configuration)
+    public static SyncResult Synchronize(string projectPath, string corpusPath, AiConfiguration configuration, bool force = false)
     {
         var previous = ReadManifest(projectPath);
         var desired = Resolve(corpusPath, configuration).ToDictionary(asset => asset.Destination, StringComparer.Ordinal);
-        var conflicts = new List<string>();
+        var conflicts = ModifiedFiles(projectPath, previous);
+        if (conflicts.Count > 0 && !force) return new([], conflicts);
+        conflicts.Clear();
         var actions = new List<string>();
         var installed = new List<AiManagedFile>();
 
         foreach (var asset in desired.Values)
         {
-            var destination = Path.Combine(projectPath, ".ai", asset.Destination);
+            var destination = Path.Combine(projectPath, ".cratis", "ai", asset.Destination);
             var content = AddMarker(asset.Source, File.ReadAllText(asset.Path));
             var hash = Hash(content);
             var existed = File.Exists(destination);
             var existing = previous.Files.FirstOrDefault(file => file.Destination == asset.Destination);
-            if (existed && existing is not null && !string.Equals(Hash(File.ReadAllText(destination)), existing.Hash, StringComparison.Ordinal))
+            if (!force && existed && existing is not null && !string.Equals(Hash(File.ReadAllText(destination)), existing.Hash, StringComparison.Ordinal))
             {
                 conflicts.Add(asset.Destination);
                 installed.Add(existing);
@@ -49,9 +52,9 @@ public static class AiCorpusSynchronizer
 
         foreach (var existing in previous.Files.Where(file => !desired.ContainsKey(file.Destination)))
         {
-            var destination = Path.Combine(projectPath, ".ai", existing.Destination);
+            var destination = Path.Combine(projectPath, ".cratis", "ai", existing.Destination);
             if (!File.Exists(destination)) continue;
-            if (!string.Equals(Hash(File.ReadAllText(destination)), existing.Hash, StringComparison.Ordinal))
+            if (!force && !string.Equals(Hash(File.ReadAllText(destination)), existing.Hash, StringComparison.Ordinal))
             {
                 conflicts.Add(existing.Destination);
                 installed.Add(existing);
@@ -74,7 +77,7 @@ public static class AiCorpusSynchronizer
     /// <returns>The harnesses, profiles, and languages published by the corpus manifest.</returns>
     public static AiConfiguration Available(string corpusPath)
     {
-        using var manifest = JsonDocument.Parse(File.ReadAllText(Path.Combine(corpusPath, ".ai", "manifest.json")));
+        using var manifest = JsonDocument.Parse(File.ReadAllText(Path.Combine(corpusPath, ".cratis", "ai", "manifest.json")));
         return new(ReadArray(manifest, "harnesses"), ReadArray(manifest, "profiles"), ReadArray(manifest, "languages"));
     }
 
@@ -87,7 +90,7 @@ public static class AiCorpusSynchronizer
         var manifest = ReadManifest(projectPath);
         var modified = manifest.Files.Where(file =>
         {
-            var path = Path.Combine(projectPath, ".ai", file.Destination);
+            var path = Path.Combine(projectPath, ".cratis", "ai", file.Destination);
             return !File.Exists(path) || !string.Equals(Hash(File.ReadAllText(path)), file.Hash, StringComparison.Ordinal);
         }).Select(file => file.Destination).ToArray();
         return new(configuration, manifest.SourceRevision, modified);
@@ -95,17 +98,20 @@ public static class AiCorpusSynchronizer
 
     /// <summary>Removes only unchanged managed files and Cratis-created harness settings.</summary>
     /// <param name="projectPath">The consuming repository root.</param>
+    /// <param name="force">Whether modified managed files may be removed.</param>
     /// <returns>The changes made and files requiring user attention.</returns>
-    public static SyncResult Uninstall(string projectPath)
+    public static SyncResult Uninstall(string projectPath, bool force = false)
     {
         var manifest = ReadManifest(projectPath);
         var actions = new List<string>();
-        var conflicts = new List<string>();
+        var conflicts = ModifiedFiles(projectPath, manifest);
+        if (conflicts.Count > 0 && !force) return new([], conflicts);
+        conflicts.Clear();
         foreach (var file in manifest.Files)
         {
-            var path = Path.Combine(projectPath, ".ai", file.Destination);
+            var path = Path.Combine(projectPath, ".cratis", "ai", file.Destination);
             if (!File.Exists(path)) continue;
-            if (!string.Equals(Hash(File.ReadAllText(path)), file.Hash, StringComparison.Ordinal))
+            if (!force && !string.Equals(Hash(File.ReadAllText(path)), file.Hash, StringComparison.Ordinal))
             {
                 conflicts.Add(file.Destination);
                 continue;
@@ -115,8 +121,9 @@ public static class AiCorpusSynchronizer
             actions.Add($"Removed {file.Destination}");
         }
 
+        RemoveHarnessIntegrations(projectPath);
         var manifestPath = Path.Combine(projectPath, ManifestPath);
-        if (conflicts.Count == 0 && File.Exists(manifestPath)) File.Delete(manifestPath);
+        if (File.Exists(manifestPath)) File.Delete(manifestPath);
         return new(actions, conflicts);
     }
 
@@ -135,7 +142,7 @@ public static class AiCorpusSynchronizer
         var skillNames = profiles.Where(profile => selected.Contains(profile.GetProperty("id").GetString()!))
             .SelectMany(AvailableTargets)
             .ToHashSet(StringComparer.Ordinal);
-        var rulesRoot = Path.Combine(corpusPath, ".ai", "rules");
+        var rulesRoot = Path.Combine(corpusPath, ".cratis", "ai", "rules");
         foreach (var rule in Directory.EnumerateFiles(rulesRoot, "*.md", SearchOption.AllDirectories))
         {
             var relative = Path.GetRelativePath(rulesRoot, rule).Replace('\\', '/');
@@ -144,7 +151,7 @@ public static class AiCorpusSynchronizer
 
         foreach (var skill in skillNames)
         {
-            var directory = Path.Combine(corpusPath, ".ai", "skills", skill);
+            var directory = Path.Combine(corpusPath, ".cratis", "ai", "skills", skill);
             foreach (var file in Directory.EnumerateFiles(directory, "*", SearchOption.AllDirectories))
             {
                 var relative = Path.GetRelativePath(directory, file).Replace('\\', '/');
@@ -186,15 +193,46 @@ public static class AiCorpusSynchronizer
     static void ConfigureHarnesses(string projectPath, IEnumerable<string> harnesses, IEnumerable<string> files)
     {
         var skills = files.Where(file => file.StartsWith("skills/", StringComparison.Ordinal))
-            .Select(file => ".ai/" + file[..file.LastIndexOf('/')])
+            .Select(file => ".cratis/ai/" + file[..file.LastIndexOf('/')])
             .Distinct()
             .Order()
             .ToArray();
+        if (harnesses.Contains("claude", StringComparer.OrdinalIgnoreCase)) CreateSkillLink(projectPath, ".claude", "../.cratis/ai/skills");
+        if (harnesses.Contains("codex", StringComparer.OrdinalIgnoreCase)) CreateSkillLink(projectPath, ".agents", "../.cratis/ai/skills");
+        if (harnesses.Contains("copilot", StringComparer.OrdinalIgnoreCase)) CreateSkillLink(projectPath, ".github", "../.cratis/ai/skills");
         if (harnesses.Contains("pi", StringComparer.OrdinalIgnoreCase))
         {
+            CreateSkillLink(projectPath, ".pi", "../.cratis/ai/skills");
             WriteJson(Path.Combine(projectPath, ".pi", "settings.json"), new { skillPaths = skills, enableSkillCommands = true, cratisAiManaged = true });
         }
     }
+
+    static void CreateSkillLink(string projectPath, string harnessDirectory, string target)
+    {
+        var directory = Path.Combine(projectPath, harnessDirectory);
+        var link = Path.Combine(directory, "skills");
+        if (Directory.Exists(link) || File.Exists(link)) return;
+        Directory.CreateDirectory(directory);
+        Directory.CreateSymbolicLink(link, target);
+    }
+
+    static void RemoveHarnessIntegrations(string projectPath)
+    {
+        foreach (var harness in new[] { ".claude", ".agents", ".github", ".pi" })
+        {
+            var link = new DirectoryInfo(Path.Combine(projectPath, harness, "skills"));
+            if (string.Equals(link.LinkTarget, "../.cratis/ai/skills", StringComparison.Ordinal)) link.Delete();
+        }
+
+        var piSettings = Path.Combine(projectPath, ".pi", "settings.json");
+        if (File.Exists(piSettings) && File.ReadAllText(piSettings).Contains("\"cratisAiManaged\": true", StringComparison.Ordinal)) File.Delete(piSettings);
+    }
+
+    static List<string> ModifiedFiles(string projectPath, AiInstallationManifest manifest) => [.. manifest.Files.Where(file =>
+    {
+        var path = Path.Combine(projectPath, ".cratis", "ai", file.Destination);
+        return !File.Exists(path) || !string.Equals(Hash(File.ReadAllText(path)), file.Hash, StringComparison.Ordinal);
+    }).Select(file => file.Destination)];
 
     static AiConfiguration ReadConfiguration(string projectPath)
     {

--- a/Source/Cli/Commands/Ai/AiCorpusSynchronizer.cs
+++ b/Source/Cli/Commands/Ai/AiCorpusSynchronizer.cs
@@ -1,17 +1,20 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Diagnostics;
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
+using System.Text.Json.Nodes;
 
 namespace Cratis.Cli.Commands.Ai;
 
-/// <summary>Synchronizes only the files recorded as Cratis-owned in a project.</summary>
+/// <summary>Synchronizes only the files and harness integrations recorded as Cratis-owned in a project.</summary>
 public static class AiCorpusSynchronizer
 {
     const string ConfigurationPath = ".cratis/ai.json";
     const string ManifestPath = ".cratis/ai.manifest.json";
+    const string ManagedRoot = ".cratis/ai";
     static readonly JsonSerializerOptions _serializerOptions = new() { WriteIndented = true };
 
     /// <summary>Installs or updates the selected corpus, preserving changed and unknown files.</summary>
@@ -24,26 +27,29 @@ public static class AiCorpusSynchronizer
     {
         var previous = ReadManifest(projectPath);
         var desired = Resolve(corpusPath, configuration).ToDictionary(asset => asset.Destination, StringComparer.Ordinal);
-        var conflicts = ModifiedFiles(projectPath, previous);
-        if (conflicts.Count > 0 && !force) return new([], conflicts);
-        conflicts.Clear();
+        var integrationPlans = PlanHarnessIntegrations(configuration.Harnesses, desired.Keys);
+        var previousIntegrations = (previous.Integrations ?? []).ToDictionary(integration => integration.Path, StringComparer.Ordinal);
+        var modified = ModifiedFiles(projectPath, previous);
+        modified.AddRange(ModifiedIntegrations(projectPath, previous));
+
+        var unknownCollisions = desired.Keys
+            .Where(destination => PathExists(Path.Combine(projectPath, ManagedRoot, destination)) && !previous.Files.Any(file => file.Destination == destination))
+            .ToList();
+        unknownCollisions.AddRange(integrationPlans.Values
+            .Where(plan => PathExists(Path.Combine(projectPath, plan.Path)) && !previousIntegrations.ContainsKey(plan.Path) && !IntegrationMatches(projectPath, plan))
+            .Select(plan => plan.Path));
+
+        if (unknownCollisions.Count > 0) return new([], [.. unknownCollisions.Distinct(StringComparer.Ordinal).Order()]);
+        if (modified.Count > 0 && !force) return new([], [.. modified.Distinct(StringComparer.Ordinal).Order()]);
+
         var actions = new List<string>();
         var installed = new List<AiManagedFile>();
-
-        foreach (var asset in desired.Values)
+        foreach (var asset in desired.Values.OrderBy(asset => asset.Destination, StringComparer.Ordinal))
         {
-            var destination = Path.Combine(projectPath, ".cratis", "ai", asset.Destination);
-            var content = AddMarker(asset.Source, File.ReadAllText(asset.Path));
+            var destination = Path.Combine(projectPath, ManagedRoot, asset.Destination);
+            var content = AddMarker(asset.Source, asset.Path, File.ReadAllText(asset.Path));
             var hash = Hash(content);
             var existed = File.Exists(destination);
-            var existing = previous.Files.FirstOrDefault(file => file.Destination == asset.Destination);
-            if (!force && existed && existing is not null && !string.Equals(Hash(File.ReadAllText(destination)), existing.Hash, StringComparison.Ordinal))
-            {
-                conflicts.Add(asset.Destination);
-                installed.Add(existing);
-                continue;
-            }
-
             Directory.CreateDirectory(Path.GetDirectoryName(destination)!);
             File.WriteAllText(destination, content);
             installed.Add(new(asset.Source, asset.Destination, hash));
@@ -52,24 +58,38 @@ public static class AiCorpusSynchronizer
 
         foreach (var existing in previous.Files.Where(file => !desired.ContainsKey(file.Destination)))
         {
-            var destination = Path.Combine(projectPath, ".cratis", "ai", existing.Destination);
+            var destination = Path.Combine(projectPath, ManagedRoot, existing.Destination);
             if (!File.Exists(destination)) continue;
-            if (!force && !string.Equals(Hash(File.ReadAllText(destination)), existing.Hash, StringComparison.Ordinal))
-            {
-                conflicts.Add(existing.Destination);
-                installed.Add(existing);
-                continue;
-            }
-
             File.Delete(destination);
             actions.Add($"Removed {existing.Destination}");
         }
 
-        ConfigureHarnesses(projectPath, configuration.Harnesses, installed.Select(file => file.Destination));
+        foreach (var existing in previousIntegrations.Values.Where(integration => !integrationPlans.ContainsKey(integration.Path)))
+        {
+            DeleteIntegration(projectPath, existing);
+            actions.Add($"Removed {existing.Path}");
+        }
+
+        var installedIntegrations = new List<AiManagedIntegration>();
+        foreach (var plan in integrationPlans.Values.OrderBy(plan => plan.Path, StringComparer.Ordinal))
+        {
+            if (!previousIntegrations.ContainsKey(plan.Path) && IntegrationMatches(projectPath, plan)) continue;
+            if (!IntegrationMatches(projectPath, plan))
+            {
+                if (PathExists(Path.Combine(projectPath, plan.Path))) DeleteIntegration(projectPath, plan);
+                CreateIntegration(projectPath, plan);
+                actions.Add($"Configured {plan.Path}");
+            }
+            installedIntegrations.Add(plan);
+        }
+
         WriteJson(Path.Combine(projectPath, ConfigurationPath), new { schemaVersion = AiConfiguration.SchemaVersion, harnesses = configuration.Harnesses, profiles = configuration.Profiles, languages = configuration.Languages });
-        var manifest = new AiInstallationManifest(Revision(corpusPath), [.. installed.OrderBy(file => file.Destination, StringComparer.Ordinal)]);
+        var manifest = new AiInstallationManifest(
+            Revision(corpusPath),
+            [.. installed.OrderBy(file => file.Destination, StringComparer.Ordinal)],
+            [.. installedIntegrations.OrderBy(integration => integration.Path, StringComparer.Ordinal)]);
         WriteJson(Path.Combine(projectPath, ManifestPath), manifest);
-        return new(actions, conflicts);
+        return new(actions, []);
     }
 
     /// <summary>Reads the selections offered by a Cratis AI corpus.</summary>
@@ -77,7 +97,7 @@ public static class AiCorpusSynchronizer
     /// <returns>The harnesses, profiles, and languages published by the corpus manifest.</returns>
     public static AiConfiguration Available(string corpusPath)
     {
-        using var manifest = JsonDocument.Parse(File.ReadAllText(Path.Combine(corpusPath, ".cratis", "ai", "manifest.json")));
+        using var manifest = JsonDocument.Parse(File.ReadAllText(Path.Combine(corpusPath, ManagedRoot, "manifest.json")));
         return new(ReadArray(manifest, "harnesses"), ReadArray(manifest, "profiles"), ReadArray(manifest, "languages"));
     }
 
@@ -88,75 +108,104 @@ public static class AiCorpusSynchronizer
     {
         var configuration = ReadConfiguration(projectPath);
         var manifest = ReadManifest(projectPath);
-        var modified = manifest.Files.Where(file =>
-        {
-            var path = Path.Combine(projectPath, ".cratis", "ai", file.Destination);
-            return !File.Exists(path) || !string.Equals(Hash(File.ReadAllText(path)), file.Hash, StringComparison.Ordinal);
-        }).Select(file => file.Destination).ToArray();
-        return new(configuration, manifest.SourceRevision, modified);
+        var modified = ModifiedFiles(projectPath, manifest);
+        modified.AddRange(ModifiedIntegrations(projectPath, manifest));
+        return new(configuration, manifest.SourceRevision, [.. modified.Distinct(StringComparer.Ordinal).Order()]);
     }
 
-    /// <summary>Removes only unchanged managed files and Cratis-created harness settings.</summary>
+    /// <summary>Removes only unchanged managed files and Cratis-created harness integrations.</summary>
     /// <param name="projectPath">The consuming repository root.</param>
     /// <param name="force">Whether modified managed files may be removed.</param>
     /// <returns>The changes made and files requiring user attention.</returns>
     public static SyncResult Uninstall(string projectPath, bool force = false)
     {
         var manifest = ReadManifest(projectPath);
+        var modified = ModifiedFiles(projectPath, manifest);
+        modified.AddRange(ModifiedIntegrations(projectPath, manifest));
+        if (modified.Count > 0 && !force) return new([], [.. modified.Distinct(StringComparer.Ordinal).Order()]);
+
         var actions = new List<string>();
-        var conflicts = ModifiedFiles(projectPath, manifest);
-        if (conflicts.Count > 0 && !force) return new([], conflicts);
-        conflicts.Clear();
         foreach (var file in manifest.Files)
         {
-            var path = Path.Combine(projectPath, ".cratis", "ai", file.Destination);
+            var path = Path.Combine(projectPath, ManagedRoot, file.Destination);
             if (!File.Exists(path)) continue;
-            if (!force && !string.Equals(Hash(File.ReadAllText(path)), file.Hash, StringComparison.Ordinal))
-            {
-                conflicts.Add(file.Destination);
-                continue;
-            }
-
             File.Delete(path);
             actions.Add($"Removed {file.Destination}");
         }
 
-        RemoveHarnessIntegrations(projectPath);
+        foreach (var integration in manifest.Integrations ?? [])
+        {
+            if (!PathExists(Path.Combine(projectPath, integration.Path))) continue;
+            DeleteIntegration(projectPath, integration);
+            actions.Add($"Removed {integration.Path}");
+        }
+
         var manifestPath = Path.Combine(projectPath, ManifestPath);
         if (File.Exists(manifestPath)) File.Delete(manifestPath);
-        return new(actions, conflicts);
+        return new(actions, []);
+    }
+
+    /// <summary>Gets the immutable Git revision for a corpus checkout, or its last-write timestamp when it is not a Git checkout.</summary>
+    /// <param name="corpusPath">The Cratis AI repository root.</param>
+    /// <returns>The source revision identity.</returns>
+    public static string Revision(string corpusPath)
+    {
+        using var process = Process.Start(new ProcessStartInfo("git", $"-C \"{corpusPath}\" rev-parse HEAD")
+        {
+            RedirectStandardError = true,
+            RedirectStandardOutput = true,
+            UseShellExecute = false,
+        });
+        if (process is not null)
+        {
+            var revision = process.StandardOutput.ReadToEnd().Trim();
+            process.WaitForExit();
+            if (process.ExitCode == 0 && revision.Length > 0) return revision;
+        }
+        return Directory.GetLastWriteTimeUtc(corpusPath).ToString("O");
     }
 
     static IEnumerable<CorpusAsset> Resolve(string corpusPath, AiConfiguration configuration)
     {
         ValidateSelection(corpusPath, configuration);
-        var catalogPath = Path.Combine(corpusPath, "distribution", "profile-catalog.json");
+        var catalogPath = Path.Combine(corpusPath, ManagedRoot, "profile-catalog.json");
         using var catalog = JsonDocument.Parse(File.ReadAllText(catalogPath));
         var profiles = catalog.RootElement.EnumerateObject()
             .Where(property => string.Equals(property.Name, "publicProfiles", StringComparison.Ordinal) || string.Equals(property.Name, "engineeringProfiles", StringComparison.Ordinal))
             .SelectMany(property => property.Value.EnumerateArray())
             .ToArray();
         var selected = new HashSet<string>(StringComparer.Ordinal);
-        foreach (var profile in configuration.Profiles) SelectProfile(profile, selected, profiles);
+        foreach (var profile in configuration.Profiles) SelectProfile(profile, selected, profiles, configuration.Languages, explicitSelection: true);
 
         var skillNames = profiles.Where(profile => selected.Contains(profile.GetProperty("id").GetString()!))
             .SelectMany(AvailableTargets)
             .ToHashSet(StringComparer.Ordinal);
-        var rulesRoot = Path.Combine(corpusPath, ".cratis", "ai", "rules");
-        foreach (var rule in Directory.EnumerateFiles(rulesRoot, "*.md", SearchOption.AllDirectories))
+        var corpusRoot = Path.Combine(corpusPath, ManagedRoot);
+        foreach (var category in new[] { "rules", "agents", "prompts", "hooks" })
         {
-            var relative = Path.GetRelativePath(rulesRoot, rule).Replace('\\', '/');
-            yield return new(rule, $"rules/{relative}", $"rules/{relative}");
+            foreach (var asset in AssetsUnder(corpusRoot, category)) yield return asset;
         }
 
         foreach (var skill in skillNames)
         {
-            var directory = Path.Combine(corpusPath, ".cratis", "ai", "skills", skill);
-            foreach (var file in Directory.EnumerateFiles(directory, "*", SearchOption.AllDirectories))
-            {
-                var relative = Path.GetRelativePath(directory, file).Replace('\\', '/');
-                yield return new(file, $"skills/{skill}/{relative}", $"skills/{skill}/{relative}");
-            }
+            foreach (var asset in AssetsUnder(corpusRoot, $"skills/{skill}", excludeVerification: true)) yield return asset;
+        }
+
+        foreach (var harness in configuration.Harnesses)
+        {
+            foreach (var asset in AssetsUnder(corpusRoot, $"harnesses/{harness}")) yield return asset;
+        }
+    }
+
+    static IEnumerable<CorpusAsset> AssetsUnder(string corpusRoot, string relativeRoot, bool excludeVerification = false)
+    {
+        var root = Path.Combine(corpusRoot, relativeRoot.Replace('/', Path.DirectorySeparatorChar));
+        if (!Directory.Exists(root)) yield break;
+        foreach (var path in Directory.EnumerateFiles(root, "*", SearchOption.AllDirectories))
+        {
+            var relative = Path.GetRelativePath(corpusRoot, path).Replace('\\', '/');
+            if (excludeVerification && (relative.EndsWith("/verification.json", StringComparison.Ordinal) || relative.Contains("/evals/", StringComparison.Ordinal))) continue;
+            yield return new(path, relative, relative);
         }
     }
 
@@ -181,58 +230,125 @@ public static class AiCorpusSynchronizer
         ? targets.EnumerateArray().Select(target => target.GetString()!)
         : [];
 
-    static void SelectProfile(string id, ISet<string> selected, IEnumerable<JsonElement> profiles)
+    static void SelectProfile(string id, ISet<string> selected, IReadOnlyList<JsonElement> profiles, IReadOnlyList<string> languages, bool explicitSelection)
     {
-        if (!selected.Add(id)) return;
         var profile = profiles.FirstOrDefault(item => item.GetProperty("id").GetString() == id);
         if (profile.ValueKind == JsonValueKind.Undefined) throw new InvalidOperationException($"Unknown Cratis AI profile '{id}'.");
-        if (!profile.TryGetProperty("composes", out var composes)) return;
-        foreach (var child in composes.EnumerateArray()) SelectProfile(child.GetString()!, selected, profiles);
+        if (!explicitSelection && !SupportsAnyLanguage(profile, languages)) return;
+        if (!selected.Add(id) || !profile.TryGetProperty("composes", out var composes)) return;
+        foreach (var child in composes.EnumerateArray()) SelectProfile(child.GetString()!, selected, profiles, languages, explicitSelection: false);
     }
 
-    static void ConfigureHarnesses(string projectPath, IEnumerable<string> harnesses, IEnumerable<string> files)
+    static bool SupportsAnyLanguage(JsonElement profile, IReadOnlyList<string> languages)
     {
-        var skills = files.Where(file => file.StartsWith("skills/", StringComparison.Ordinal))
-            .Select(file => ".cratis/ai/" + file[..file.LastIndexOf('/')])
-            .Distinct()
-            .Order()
-            .ToArray();
-        if (harnesses.Contains("claude", StringComparer.OrdinalIgnoreCase)) CreateSkillLink(projectPath, ".claude", "../.cratis/ai/skills");
-        if (harnesses.Contains("codex", StringComparer.OrdinalIgnoreCase)) CreateSkillLink(projectPath, ".agents", "../.cratis/ai/skills");
-        if (harnesses.Contains("copilot", StringComparer.OrdinalIgnoreCase)) CreateSkillLink(projectPath, ".github", "../.cratis/ai/skills");
-        if (harnesses.Contains("pi", StringComparer.OrdinalIgnoreCase))
+        if (!profile.TryGetProperty("languages", out var supported)) return true;
+        var values = supported.EnumerateArray().Select(language => language.GetString()).ToHashSet(StringComparer.OrdinalIgnoreCase);
+        return values.Contains("language-agnostic") || languages.Any(values.Contains);
+    }
+
+    static Dictionary<string, AiManagedIntegration> PlanHarnessIntegrations(IEnumerable<string> harnesses, IEnumerable<string> files)
+    {
+        var plans = new Dictionary<string, AiManagedIntegration>(StringComparer.Ordinal);
+        var selected = harnesses.ToHashSet(StringComparer.OrdinalIgnoreCase);
+        void Add(string path, string target, bool isDirectory) => plans.TryAdd(path, new(path, target, isDirectory));
+        void AddRootInstructions() => Add("AGENTS.md", ".cratis/ai/rules/general.md", false);
+        void AddCommands(string directory)
         {
-            CreateSkillLink(projectPath, ".pi", "../.cratis/ai/skills");
-            WriteJson(Path.Combine(projectPath, ".pi", "settings.json"), new { skillPaths = skills, enableSkillCommands = true, cratisAiManaged = true });
+            foreach (var prompt in files.Where(file => file.StartsWith("prompts/", StringComparison.Ordinal) && file.EndsWith(".prompt.md", StringComparison.Ordinal)))
+            {
+                var name = Path.GetFileName(prompt)[..^".prompt.md".Length];
+                Add($"{directory}/{name}.md", $"../../.cratis/ai/{prompt}", false);
+            }
         }
-    }
-
-    static void CreateSkillLink(string projectPath, string harnessDirectory, string target)
-    {
-        var directory = Path.Combine(projectPath, harnessDirectory);
-        var link = Path.Combine(directory, "skills");
-        if (Directory.Exists(link) || File.Exists(link)) return;
-        Directory.CreateDirectory(directory);
-        Directory.CreateSymbolicLink(link, target);
-    }
-
-    static void RemoveHarnessIntegrations(string projectPath)
-    {
-        foreach (var harness in new[] { ".claude", ".agents", ".github", ".pi" })
+        void AddAgents(string directory, string suffix)
         {
-            var link = new DirectoryInfo(Path.Combine(projectPath, harness, "skills"));
-            if (string.Equals(link.LinkTarget, "../.cratis/ai/skills", StringComparison.Ordinal)) link.Delete();
+            foreach (var agent in files.Where(file => file.StartsWith("agents/", StringComparison.Ordinal) && file.EndsWith(".md", StringComparison.Ordinal)))
+            {
+                var name = Path.GetFileNameWithoutExtension(agent);
+                Add($"{directory}/{name}{suffix}", $"../../.cratis/ai/{agent}", false);
+            }
         }
 
-        var piSettings = Path.Combine(projectPath, ".pi", "settings.json");
-        if (File.Exists(piSettings) && File.ReadAllText(piSettings).Contains("\"cratisAiManaged\": true", StringComparison.Ordinal)) File.Delete(piSettings);
+        if (selected.Contains("claude"))
+        {
+            Add(".claude/CLAUDE.md", "../.cratis/ai/rules/general.md", false);
+            Add(".claude/agents", "../.cratis/ai/agents", true);
+            Add(".claude/hooks", "../.cratis/ai/hooks", true);
+            Add(".claude/prompts", "../.cratis/ai/prompts", true);
+            Add(".claude/rules", "../.cratis/ai/rules", true);
+            Add(".claude/settings.json", "../.cratis/ai/hooks/settings.template.json", false);
+            Add(".claude/skills", "../.cratis/ai/skills", true);
+            AddCommands(".claude/commands");
+        }
+        if (selected.Contains("codex"))
+        {
+            AddRootInstructions();
+            Add(".agents/skills", "../.cratis/ai/skills", true);
+        }
+        if (selected.Contains("copilot"))
+        {
+            Add(".github/copilot-instructions.md", "../.cratis/ai/rules/general.md", false);
+            Add(".github/instructions", "../.cratis/ai/rules", true);
+            Add(".github/prompts", "../.cratis/ai/prompts", true);
+            Add(".github/skills", "../.cratis/ai/skills", true);
+            AddAgents(".github/agents", ".agent.md");
+        }
+        if (selected.Contains("pi"))
+        {
+            AddRootInstructions();
+            Add(".pi/agents", "../.cratis/ai/agents", true);
+            Add(".pi/extensions", "../.cratis/ai/harnesses/pi/extensions", true);
+            Add(".pi/skills", "../.cratis/ai/skills", true);
+            AddCommands(".pi/prompts");
+        }
+        if (selected.Contains("cursor"))
+        {
+            Add(".cursor/agents", "../.cratis/ai/agents", true);
+            Add(".cursor/rules", "../.cratis/ai/harnesses/cursor/rules", true);
+            Add(".cursor/skills", "../.cratis/ai/skills", true);
+            AddCommands(".cursor/commands");
+        }
+        if (selected.Contains("opencode"))
+        {
+            AddRootInstructions();
+            Add(".opencode/agents", "../.cratis/ai/agents", true);
+            Add(".opencode/skills", "../.cratis/ai/skills", true);
+            AddCommands(".opencode/commands");
+        }
+        return plans;
+    }
+
+    static void CreateIntegration(string projectPath, AiManagedIntegration integration)
+    {
+        var path = Path.Combine(projectPath, integration.Path);
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        if (integration.IsDirectory) Directory.CreateSymbolicLink(path, integration.Target);
+        else File.CreateSymbolicLink(path, integration.Target);
+    }
+
+    static void DeleteIntegration(string projectPath, AiManagedIntegration integration)
+    {
+        var path = Path.Combine(projectPath, integration.Path);
+        if (new DirectoryInfo(path).LinkTarget is not null) Directory.Delete(path);
+        else File.Delete(path);
+    }
+
+    static bool IntegrationMatches(string projectPath, AiManagedIntegration integration)
+    {
+        var path = Path.Combine(projectPath, integration.Path);
+        var target = integration.IsDirectory ? new DirectoryInfo(path).LinkTarget : new FileInfo(path).LinkTarget;
+        return string.Equals(target, integration.Target, StringComparison.Ordinal);
     }
 
     static List<string> ModifiedFiles(string projectPath, AiInstallationManifest manifest) => [.. manifest.Files.Where(file =>
     {
-        var path = Path.Combine(projectPath, ".cratis", "ai", file.Destination);
+        var path = Path.Combine(projectPath, ManagedRoot, file.Destination);
         return !File.Exists(path) || !string.Equals(Hash(File.ReadAllText(path)), file.Hash, StringComparison.Ordinal);
     }).Select(file => file.Destination)];
+
+    static List<string> ModifiedIntegrations(string projectPath, AiInstallationManifest manifest) => [.. (manifest.Integrations ?? [])
+        .Where(integration => !IntegrationMatches(projectPath, integration))
+        .Select(integration => integration.Path)];
 
     static AiConfiguration ReadConfiguration(string projectPath)
     {
@@ -247,12 +363,62 @@ public static class AiCorpusSynchronizer
     static AiInstallationManifest ReadManifest(string projectPath)
     {
         var path = Path.Combine(projectPath, ManifestPath);
-        return File.Exists(path) ? JsonSerializer.Deserialize<AiInstallationManifest>(File.ReadAllText(path))! : new("unknown", []);
+        return File.Exists(path) ? JsonSerializer.Deserialize<AiInstallationManifest>(File.ReadAllText(path))! : new("unknown", [], []);
     }
 
-    static string AddMarker(string source, string content) => $"<!-- cratis-ai-managed: {source} -->\n{content}";
+    static string AddMarker(string source, string path, string content)
+    {
+        var marker = $"cratis-ai-managed: {source}";
+        var extension = Path.GetExtension(path).ToLowerInvariant();
+        if (string.Equals(extension, ".md", StringComparison.Ordinal) || string.Equals(extension, ".mdc", StringComparison.Ordinal))
+        {
+            if (!content.StartsWith("---\n", StringComparison.Ordinal)) return $"<!-- {marker} -->\n{content}";
+            var frontmatterEnd = content.IndexOf("\n---\n", 4, StringComparison.Ordinal);
+            return frontmatterEnd < 0 ? $"<!-- {marker} -->\n{content}" : content.Insert(frontmatterEnd + 5, $"<!-- {marker} -->\n");
+        }
+        if (string.Equals(extension, ".html", StringComparison.Ordinal) || string.Equals(extension, ".htm", StringComparison.Ordinal)) return $"<!-- {marker} -->\n{content}";
+        if (extension == ".json")
+        {
+            if (JsonNode.Parse(content) is JsonObject json)
+            {
+                json["$cratisAiManaged"] = source;
+                return json.ToJsonString(_serializerOptions);
+            }
+            return content;
+        }
+        if (string.Equals(extension, ".sh", StringComparison.Ordinal) ||
+            string.Equals(extension, ".py", StringComparison.Ordinal) ||
+            string.Equals(extension, ".yml", StringComparison.Ordinal) ||
+            string.Equals(extension, ".yaml", StringComparison.Ordinal))
+        {
+            if (content.StartsWith("#!", StringComparison.Ordinal))
+            {
+                var lineEnd = content.IndexOf('\n');
+                if (lineEnd >= 0) return content.Insert(lineEnd + 1, $"# {marker}\n");
+            }
+            return $"# {marker}\n{content}";
+        }
+        return $"# {marker}\n{content}";
+    }
+
     static string Hash(string content) => Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(content)));
-    static string Revision(string corpusPath) => Directory.GetLastWriteTimeUtc(corpusPath).ToString("O");
+
+    static bool PathExists(string path)
+    {
+        try
+        {
+            _ = File.GetAttributes(path);
+            return true;
+        }
+        catch (FileNotFoundException)
+        {
+            return new FileInfo(path).LinkTarget is not null || new DirectoryInfo(path).LinkTarget is not null;
+        }
+        catch (DirectoryNotFoundException)
+        {
+            return false;
+        }
+    }
 
     static void WriteJson(string path, object value)
     {
@@ -260,16 +426,16 @@ public static class AiCorpusSynchronizer
         File.WriteAllText(path, JsonSerializer.Serialize(value, _serializerOptions));
     }
 
-    record CorpusAsset(string Path, string Destination, string Source);
+    sealed record CorpusAsset(string Path, string Destination, string Source);
 }
 
 /// <summary>The result of an install, update, or uninstall operation.</summary>
 /// <param name="Actions">The files added, changed, or removed.</param>
-/// <param name="Conflicts">Managed files that were changed locally.</param>
+/// <param name="Conflicts">Managed files that were changed locally or user-owned paths that would be overwritten.</param>
 public sealed record SyncResult(IReadOnlyList<string> Actions, IReadOnlyList<string> Conflicts);
 
 /// <summary>Read-only installation state.</summary>
 /// <param name="Configuration">The configured selection.</param>
 /// <param name="SourceRevision">The corpus revision used to synchronize.</param>
-/// <param name="ModifiedFiles">Managed files changed or removed locally.</param>
+/// <param name="ModifiedFiles">Managed files or integrations changed or removed locally.</param>
 public sealed record AiStatus(AiConfiguration Configuration, string SourceRevision, IReadOnlyList<string> ModifiedFiles);

--- a/Source/Cli/Commands/Ai/AiSettings.cs
+++ b/Source/Cli/Commands/Ai/AiSettings.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Cli.Commands.Ai;
+
+/// <summary>Common settings for Cratis AI corpus commands.</summary>
+public class AiSettings : GlobalSettings
+{
+    /// <summary>Gets or sets a local checkout of Cratis/AI. It makes installs deterministic in CI and offline environments.</summary>
+    [CommandOption("--source <PATH>")]
+    public string? Source { get; set; }
+}
+
+/// <summary>Settings used to create a Cratis AI configuration.</summary>
+public class AiInstallSettings : AiSettings
+{
+    /// <summary>Gets or sets selected harnesses as a comma-separated list.</summary>
+    [CommandOption("--harnesses <NAMES>")]
+    public string? Harnesses { get; set; }
+
+    /// <summary>Gets or sets selected profiles as a comma-separated list.</summary>
+    [CommandOption("--profiles <NAMES>")]
+    public string? Profiles { get; set; }
+
+    /// <summary>Gets or sets selected languages as a comma-separated list.</summary>
+    [CommandOption("--languages <NAMES>")]
+    public string? Languages { get; set; }
+}

--- a/Source/Cli/Commands/Ai/AiSettings.cs
+++ b/Source/Cli/Commands/Ai/AiSettings.cs
@@ -9,6 +9,10 @@ public class AiSettings : GlobalSettings
     /// <summary>Gets or sets a local checkout of Cratis/AI. It makes installs deterministic in CI and offline environments.</summary>
     [CommandOption("--source <PATH>")]
     public string? Source { get; set; }
+
+    /// <summary>Gets or sets whether locally modified Cratis-managed files may be replaced or removed.</summary>
+    [CommandOption("-f|--force")]
+    public bool Force { get; set; }
 }
 
 /// <summary>Settings used to create a Cratis AI configuration.</summary>
@@ -26,3 +30,6 @@ public class AiInstallSettings : AiSettings
     [CommandOption("--languages <NAMES>")]
     public string? Languages { get; set; }
 }
+
+/// <summary>Settings used to uninstall Cratis AI content.</summary>
+public class AiUninstallSettings : AiSettings;


### PR DESCRIPTION
## Added
- Add `cratis ai install`, `update`, `status`, and `uninstall` with manifest-driven profile, language, and harness selection.
- Configure complete Claude Code, Codex, Copilot, Pi, Cursor, and OpenCode integrations against `.cratis/ai`.
- Preserve user-owned paths, hash managed content and integrations, stop safely on modifications, and limit `--force` to content already recorded as managed.
- Preserve skill frontmatter while marking managed files, use comment syntax appropriate to each file type, report available updates, and record the source Git revision.

## Verification
- Debug and Release builds: zero warnings and errors
- Full specification suite: 1,093 passed
- Real install against the AI corpus: Pi, Cursor, and OpenCode adapters created; 12 TypeScript Chronicle skills resolved with frontmatter intact
