### PR TITLE
Preserve project-owned agent instructions

### DIFF
--- a/Source/Cli.Specs/for_AiCorpusSynchronizer/when_synchronizing/and_agents_md_is_user_owned.cs
+++ b/Source/Cli.Specs/for_AiCorpusSynchronizer/when_synchronizing/and_agents_md_is_user_owned.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Cli.for_AiCorpusSynchronizer.when_synchronizing;
+
+public class and_agents_md_is_user_owned : Specification
+{
+    string _project = null!;
+    string _corpus = null!;
+    SyncResult _result = null!;
+
+    void Establish()
+    {
+        _project = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        _corpus = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(_project);
+        Directory.CreateDirectory(Path.Combine(_corpus, ".cratis", "ai", "rules"));
+        File.WriteAllText(Path.Combine(_project, "AGENTS.md"), "Read the project-owned instructions.");
+        File.WriteAllText(Path.Combine(_corpus, ".cratis", "ai", "manifest.json"), "{\"harnesses\":[\"pi\"],\"profiles\":[\"cratis/example\"],\"languages\":[\"csharp\"]}");
+        File.WriteAllText(Path.Combine(_corpus, ".cratis", "ai", "profile-catalog.json"), "{\"publicProfiles\":[{\"id\":\"cratis/example\"}],\"engineeringProfiles\":[]}");
+        File.WriteAllText(Path.Combine(_corpus, ".cratis", "ai", "rules", "general.md"), "# General rule");
+    }
+
+    void Because() => _result = AiCorpusSynchronizer.Synchronize(_project, _corpus, new(["pi"], ["cratis/example"], ["csharp"]));
+
+    [Fact] void should_preserve_the_project_owned_instructions() => File.ReadAllText(Path.Combine(_project, "AGENTS.md")).ShouldEqual("Read the project-owned instructions.");
+    [Fact] void should_not_report_a_conflict() => _result.Conflicts.ShouldBeEmpty();
+    [Fact] void should_still_install_the_managed_rules() => File.Exists(Path.Combine(_project, ".cratis", "ai", "rules", "general.md")).ShouldBeTrue();
+
+    void Destroy()
+    {
+        Directory.Delete(_project, true);
+        Directory.Delete(_corpus, true);
+    }
+}

--- a/Source/Cli/Commands/Ai/AiConfiguration.cs
+++ b/Source/Cli/Commands/Ai/AiConfiguration.cs
@@ -23,7 +23,8 @@ public sealed record AiManagedFile(string Source, string Destination, string Has
 /// <param name="Path">The path relative to the consuming repository.</param>
 /// <param name="Target">The relative symbolic-link target.</param>
 /// <param name="IsDirectory">Whether the target is a directory.</param>
-public sealed record AiManagedIntegration(string Path, string Target, bool IsDirectory);
+/// <param name="PreserveExisting">Whether an existing user-owned path satisfies the integration without becoming managed.</param>
+public sealed record AiManagedIntegration(string Path, string Target, bool IsDirectory, bool PreserveExisting = false);
 
 /// <summary>Metadata used to make synchronization deterministic without claiming user files.</summary>
 /// <param name="SourceRevision">The corpus revision used during installation.</param>

--- a/Source/Cli/Commands/Ai/AiCorpusSynchronizer.cs
+++ b/Source/Cli/Commands/Ai/AiCorpusSynchronizer.cs
@@ -36,7 +36,7 @@ public static class AiCorpusSynchronizer
             .Where(destination => PathExists(Path.Combine(projectPath, ManagedRoot, destination)) && !previous.Files.Any(file => file.Destination == destination))
             .ToList();
         unknownCollisions.AddRange(integrationPlans.Values
-            .Where(plan => PathExists(Path.Combine(projectPath, plan.Path)) && !previousIntegrations.ContainsKey(plan.Path) && !IntegrationMatches(projectPath, plan))
+            .Where(plan => !plan.PreserveExisting && PathExists(Path.Combine(projectPath, plan.Path)) && !previousIntegrations.ContainsKey(plan.Path) && !IntegrationMatches(projectPath, plan))
             .Select(plan => plan.Path));
 
         if (unknownCollisions.Count > 0) return new([], [.. unknownCollisions.Distinct(StringComparer.Ordinal).Order()]);
@@ -73,6 +73,7 @@ public static class AiCorpusSynchronizer
         var installedIntegrations = new List<AiManagedIntegration>();
         foreach (var plan in integrationPlans.Values.OrderBy(plan => plan.Path, StringComparer.Ordinal))
         {
+            if (!previousIntegrations.ContainsKey(plan.Path) && plan.PreserveExisting && PathExists(Path.Combine(projectPath, plan.Path))) continue;
             if (!previousIntegrations.ContainsKey(plan.Path) && IntegrationMatches(projectPath, plan)) continue;
             if (!IntegrationMatches(projectPath, plan))
             {
@@ -250,8 +251,8 @@ public static class AiCorpusSynchronizer
     {
         var plans = new Dictionary<string, AiManagedIntegration>(StringComparer.Ordinal);
         var selected = harnesses.ToHashSet(StringComparer.OrdinalIgnoreCase);
-        void Add(string path, string target, bool isDirectory) => plans.TryAdd(path, new(path, target, isDirectory));
-        void AddRootInstructions() => Add("AGENTS.md", ".cratis/ai/rules/general.md", false);
+        void Add(string path, string target, bool isDirectory, bool preserveExisting = false) => plans.TryAdd(path, new(path, target, isDirectory, preserveExisting));
+        void AddRootInstructions() => Add("AGENTS.md", ".cratis/ai/rules/general.md", false, preserveExisting: true);
         void AddCommands(string directory)
         {
             foreach (var prompt in files.Where(file => file.StartsWith("prompts/", StringComparison.Ordinal) && file.EndsWith(".prompt.md", StringComparison.Ordinal)))


### PR DESCRIPTION
## Fixed
- Preserve an existing user-owned `AGENTS.md` when configuring Codex, OpenCode, or Pi.
- Continue installing managed rules and native harness resources without claiming or replacing project instructions.
- Record whether an integration harness integration accepts an existing user-owned path.

## Verification
- Release build succeeds with zero warnings and errors.
- Focused AI corpus specifications: 25 passed.