### PR TITLE
Filter managed AI rules by profile and language

### DIFF
--- a/Source/Cli.Specs/for_AiCorpusSynchronizer/when_synchronizing/and_framework_csharp_documentation_are_selected.cs
+++ b/Source/Cli.Specs/for_AiCorpusSynchronizer/when_synchronizing/and_framework_csharp_documentation_are_selected.cs
@@ -1,0 +1,41 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Cli.for_AiCorpusSynchronizer.when_synchronizing;
+
+public class and_framework_csharp_documentation_are_selected : Specification
+{
+    string _project = null!;
+    string _corpus = null!;
+
+    void Establish()
+    {
+        _project = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        _corpus = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        var rules = Path.Combine(_corpus, ".cratis", "ai", "rules");
+        Directory.CreateDirectory(rules);
+        File.WriteAllText(Path.Combine(_corpus, ".cratis", "ai", "manifest.json"), "{\"harnesses\":[\"pi\"],\"profiles\":[\"cratis/engineering/csharp\",\"cratis/documentation\"],\"languages\":[\"csharp\",\"typescript\"]}");
+        File.WriteAllText(Path.Combine(_corpus, ".cratis", "ai", "profile-catalog.json"), "{\"publicProfiles\":[{\"id\":\"cratis/documentation\"}],\"engineeringProfiles\":[{\"id\":\"cratis/engineering/csharp\"}]}");
+        File.WriteAllText(Path.Combine(rules, "general.md"), "# General");
+        File.WriteAllText(Path.Combine(rules, "csharp.md"), "---\napplyTo: \"**/*.cs\"\n---\n# CSharp");
+        File.WriteAllText(Path.Combine(rules, "typescript.md"), "---\napplyTo: \"**/*.ts,**/*.tsx\"\n---\n# TypeScript");
+        File.WriteAllText(Path.Combine(rules, "framework.md"), "---\napplyTo: \"**/*\"\nprofile: framework\n---\n# Framework");
+        File.WriteAllText(Path.Combine(rules, "vertical-slices.md"), "---\napplyTo: \"**/*.cs\"\nprofile: application\n---\n# Vertical slices");
+        File.WriteAllText(Path.Combine(rules, "documentation.md"), "---\napplyTo: \"**/Documentation/**/*.{md,mdx}\"\n---\n# Documentation");
+    }
+
+    void Because() => AiCorpusSynchronizer.Synchronize(_project, _corpus, new(["pi"], ["cratis/engineering/csharp", "cratis/documentation"], ["csharp"]));
+
+    [Fact] void should_install_general_rules() => File.Exists(Path.Combine(_project, ".cratis", "ai", "rules", "general.md")).ShouldBeTrue();
+    [Fact] void should_install_csharp_rules() => File.Exists(Path.Combine(_project, ".cratis", "ai", "rules", "csharp.md")).ShouldBeTrue();
+    [Fact] void should_install_framework_rules() => File.Exists(Path.Combine(_project, ".cratis", "ai", "rules", "framework.md")).ShouldBeTrue();
+    [Fact] void should_install_documentation_rules() => File.Exists(Path.Combine(_project, ".cratis", "ai", "rules", "documentation.md")).ShouldBeTrue();
+    [Fact] void should_not_install_typescript_rules() => File.Exists(Path.Combine(_project, ".cratis", "ai", "rules", "typescript.md")).ShouldBeFalse();
+    [Fact] void should_not_install_application_rules() => File.Exists(Path.Combine(_project, ".cratis", "ai", "rules", "vertical-slices.md")).ShouldBeFalse();
+
+    void Destroy()
+    {
+        Directory.Delete(_project, true);
+        Directory.Delete(_corpus, true);
+    }
+}

--- a/Source/Cli/Commands/Ai/AiCorpusSynchronizer.cs
+++ b/Source/Cli/Commands/Ai/AiCorpusSynchronizer.cs
@@ -182,7 +182,11 @@ public static class AiCorpusSynchronizer
             .SelectMany(AvailableTargets)
             .ToHashSet(StringComparer.Ordinal);
         var corpusRoot = Path.Combine(corpusPath, ManagedRoot);
-        foreach (var category in new[] { "rules", "agents", "prompts", "hooks" })
+        foreach (var rule in AssetsUnder(corpusRoot, "rules"))
+        {
+            if (RuleMatchesConfiguration(rule.Path, configuration)) yield return rule;
+        }
+        foreach (var category in new[] { "agents", "prompts", "hooks" })
         {
             foreach (var asset in AssetsUnder(corpusRoot, category)) yield return asset;
         }
@@ -208,6 +212,37 @@ public static class AiCorpusSynchronizer
             if (excludeVerification && (relative.EndsWith("/verification.json", StringComparison.Ordinal) || relative.Contains("/evals/", StringComparison.Ordinal))) continue;
             yield return new(path, relative, relative);
         }
+    }
+
+    static bool RuleMatchesConfiguration(string path, AiConfiguration configuration)
+    {
+        var content = File.ReadAllText(path);
+        var frontmatterEnd = content.StartsWith("---\n", StringComparison.Ordinal) ? content.IndexOf("\n---\n", 4, StringComparison.Ordinal) : -1;
+        var frontmatter = frontmatterEnd < 0 ? string.Empty : content[4..frontmatterEnd];
+        var profile = FrontmatterValue(frontmatter, "profile");
+        var hasApplicationProfile = configuration.Profiles.Any(candidate => candidate.StartsWith("cratis/application", StringComparison.OrdinalIgnoreCase));
+        var hasEngineeringProfile = configuration.Profiles.Any(candidate => candidate.StartsWith("cratis/engineering", StringComparison.OrdinalIgnoreCase));
+        if (string.Equals(profile, "application", StringComparison.OrdinalIgnoreCase) && !hasApplicationProfile) return false;
+        if (string.Equals(profile, "framework", StringComparison.OrdinalIgnoreCase) && !hasEngineeringProfile) return false;
+
+        var applyTo = FrontmatterValue(frontmatter, "applyTo") ?? string.Empty;
+        var needsCSharp = applyTo.Contains(".cs", StringComparison.OrdinalIgnoreCase);
+        var needsTypeScript = applyTo.Contains(".ts", StringComparison.OrdinalIgnoreCase);
+        var needsDocumentation = applyTo.Contains("md", StringComparison.OrdinalIgnoreCase);
+        if (string.Equals(Path.GetFileName(path), "rtk.md", StringComparison.OrdinalIgnoreCase)) needsTypeScript = true;
+        if (!needsCSharp && !needsTypeScript && !needsDocumentation) return true;
+
+        var hasCSharp = configuration.Languages.Contains("csharp", StringComparer.OrdinalIgnoreCase);
+        var hasTypeScript = configuration.Languages.Contains("typescript", StringComparer.OrdinalIgnoreCase);
+        var hasDocumentation = configuration.Profiles.Contains("cratis/documentation", StringComparer.OrdinalIgnoreCase);
+        return (needsCSharp && hasCSharp) || (needsTypeScript && hasTypeScript) || (needsDocumentation && hasDocumentation);
+    }
+
+    static string? FrontmatterValue(string frontmatter, string name)
+    {
+        var prefix = $"{name}:";
+        var line = frontmatter.Split('\n').FirstOrDefault(candidate => candidate.StartsWith(prefix, StringComparison.Ordinal));
+        return line?[prefix.Length..].Trim().Trim('"');
     }
 
     static void ValidateSelection(string corpusPath, AiConfiguration configuration)


### PR DESCRIPTION
## Fixed
- Resolve managed rules using the selected repository profile and languages instead of installing every rule.
- Framework engineering profiles receive framework and universal guidance without application vertical-slice or CQRS rules.
- C#-only repositories do not receive TypeScript rules; selecting the documentation profile includes documentation rules.

## Verification
- Release build succeeds with zero warnings and errors.
- Focused AI corpus specifications: 31 passed.
- A framework C# + documentation specification proves application and TypeScript rules are excluded.