### PR TITLE
Migrate project instructions into managed AI

### DIFF
--- a/Source/Cli.Specs/for_AiCorpusSynchronizer/when_synchronizing/and_agents_md_is_user_owned.cs
+++ b/Source/Cli.Specs/for_AiCorpusSynchronizer/when_synchronizing/and_agents_md_is_user_owned.cs
@@ -13,19 +13,23 @@ public class and_agents_md_is_user_owned : Specification
     {
         _project = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
         _corpus = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
-        Directory.CreateDirectory(_project);
+        Directory.CreateDirectory(Path.Combine(_project, ".cratis"));
         Directory.CreateDirectory(Path.Combine(_corpus, ".cratis", "ai", "rules"));
         File.WriteAllText(Path.Combine(_project, "AGENTS.md"), "Read the project-owned instructions.");
-        File.WriteAllText(Path.Combine(_corpus, ".cratis", "ai", "manifest.json"), "{\"harnesses\":[\"pi\"],\"profiles\":[\"cratis/example\"],\"languages\":[\"csharp\"]}");
+        File.WriteAllText(Path.Combine(_project, ".cratis", "PROJECT.md"), "# Project-specific rule");
+        File.WriteAllText(Path.Combine(_corpus, ".cratis", "ai", "manifest.json"), "{\"harnesses\":[\"claude\",\"pi\"],\"profiles\":[\"cratis/example\"],\"languages\":[\"csharp\"]}");
         File.WriteAllText(Path.Combine(_corpus, ".cratis", "ai", "profile-catalog.json"), "{\"publicProfiles\":[{\"id\":\"cratis/example\"}],\"engineeringProfiles\":[]}");
         File.WriteAllText(Path.Combine(_corpus, ".cratis", "ai", "rules", "general.md"), "# General rule");
     }
 
-    void Because() => _result = AiCorpusSynchronizer.Synchronize(_project, _corpus, new(["pi"], ["cratis/example"], ["csharp"]));
+    void Because() => _result = AiCorpusSynchronizer.Synchronize(_project, _corpus, new(["claude", "pi"], ["cratis/example"], ["csharp"]));
 
     [Fact] void should_preserve_the_project_owned_instructions() => File.ReadAllText(Path.Combine(_project, "AGENTS.md")).ShouldEqual("Read the project-owned instructions.");
     [Fact] void should_not_report_a_conflict() => _result.Conflicts.ShouldBeEmpty();
     [Fact] void should_still_install_the_managed_rules() => File.Exists(Path.Combine(_project, ".cratis", "ai", "rules", "general.md")).ShouldBeTrue();
+    [Fact] void should_migrate_the_project_specific_rule() => File.ReadAllText(Path.Combine(_project, ".cratis", "ai", "rules", "project.md")).ShouldEqual("# Project-specific rule");
+    [Fact] void should_preserve_the_legacy_project_file() => File.Exists(Path.Combine(_project, ".cratis", "PROJECT.md")).ShouldBeTrue();
+    [Fact] void should_link_claude_to_the_project_specific_rule() => new FileInfo(Path.Combine(_project, "CLAUDE.md")).LinkTarget.ShouldEqual(".cratis/ai/rules/project.md");
 
     void Destroy()
     {

--- a/Source/Cli/Commands/Ai/AiCorpusSynchronizer.cs
+++ b/Source/Cli/Commands/Ai/AiCorpusSynchronizer.cs
@@ -15,6 +15,7 @@ public static class AiCorpusSynchronizer
     const string ConfigurationPath = ".cratis/ai.json";
     const string ManifestPath = ".cratis/ai.manifest.json";
     const string ManagedRoot = ".cratis/ai";
+    const string ProjectInstructionsPath = ".cratis/ai/rules/project.md";
     static readonly JsonSerializerOptions _serializerOptions = new() { WriteIndented = true };
 
     /// <summary>Installs or updates the selected corpus, preserving changed and unknown files.</summary>
@@ -27,7 +28,8 @@ public static class AiCorpusSynchronizer
     {
         var previous = ReadManifest(projectPath);
         var desired = Resolve(corpusPath, configuration).ToDictionary(asset => asset.Destination, StringComparer.Ordinal);
-        var integrationPlans = PlanHarnessIntegrations(configuration.Harnesses, desired.Keys);
+        var projectInstructionsSource = FindProjectInstructions(projectPath);
+        var integrationPlans = PlanHarnessIntegrations(configuration.Harnesses, desired.Keys, projectInstructionsSource is not null);
         var previousIntegrations = (previous.Integrations ?? []).ToDictionary(integration => integration.Path, StringComparer.Ordinal);
         var modified = ModifiedFiles(projectPath, previous);
         modified.AddRange(ModifiedIntegrations(projectPath, previous));
@@ -43,6 +45,14 @@ public static class AiCorpusSynchronizer
         if (modified.Count > 0 && !force) return new([], [.. modified.Distinct(StringComparer.Ordinal).Order()]);
 
         var actions = new List<string>();
+        var projectInstructionsDestination = Path.Combine(projectPath, ProjectInstructionsPath);
+        if (projectInstructionsSource is not null && !PathExists(projectInstructionsDestination))
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(projectInstructionsDestination)!);
+            File.Copy(projectInstructionsSource, projectInstructionsDestination);
+            actions.Add($"Migrated {Path.GetRelativePath(projectPath, projectInstructionsSource).Replace('\\', '/')} to {ProjectInstructionsPath}");
+        }
+
         var installed = new List<AiManagedFile>();
         foreach (var asset in desired.Values.OrderBy(asset => asset.Destination, StringComparer.Ordinal))
         {
@@ -282,12 +292,26 @@ public static class AiCorpusSynchronizer
         return values.Contains("language-agnostic") || languages.Any(values.Contains);
     }
 
-    static Dictionary<string, AiManagedIntegration> PlanHarnessIntegrations(IEnumerable<string> harnesses, IEnumerable<string> files)
+    static string? FindProjectInstructions(string projectPath)
+    {
+        var destination = Path.Combine(projectPath, ProjectInstructionsPath);
+        if (File.Exists(destination)) return destination;
+        foreach (var candidate in new[] { ".cratis/PROJECT.md", ".ai/PROJECT.md", ".agents/PROJECT.md" })
+        {
+            var path = Path.Combine(projectPath, candidate);
+            if (File.Exists(path)) return path;
+        }
+        return null;
+    }
+
+    static Dictionary<string, AiManagedIntegration> PlanHarnessIntegrations(IEnumerable<string> harnesses, IEnumerable<string> files, bool hasProjectInstructions)
     {
         var plans = new Dictionary<string, AiManagedIntegration>(StringComparer.Ordinal);
         var selected = harnesses.ToHashSet(StringComparer.OrdinalIgnoreCase);
+        var rootInstructionsTarget = hasProjectInstructions ? ProjectInstructionsPath : ".cratis/ai/rules/general.md";
+        var nestedInstructionsTarget = hasProjectInstructions ? "../.cratis/ai/rules/project.md" : "../.cratis/ai/rules/general.md";
         void Add(string path, string target, bool isDirectory, bool preserveExisting = false) => plans.TryAdd(path, new(path, target, isDirectory, preserveExisting));
-        void AddRootInstructions() => Add("AGENTS.md", ".cratis/ai/rules/general.md", false, preserveExisting: true);
+        void AddRootInstructions() => Add("AGENTS.md", rootInstructionsTarget, false, preserveExisting: true);
         void AddCommands(string directory)
         {
             foreach (var prompt in files.Where(file => file.StartsWith("prompts/", StringComparison.Ordinal) && file.EndsWith(".prompt.md", StringComparison.Ordinal)))
@@ -307,7 +331,8 @@ public static class AiCorpusSynchronizer
 
         if (selected.Contains("claude"))
         {
-            Add(".claude/CLAUDE.md", "../.cratis/ai/rules/general.md", false);
+            Add("CLAUDE.md", rootInstructionsTarget, false, preserveExisting: true);
+            Add(".claude/CLAUDE.md", nestedInstructionsTarget, false, preserveExisting: true);
             Add(".claude/agents", "../.cratis/ai/agents", true);
             Add(".claude/hooks", "../.cratis/ai/hooks", true);
             Add(".claude/prompts", "../.cratis/ai/prompts", true);
@@ -323,7 +348,7 @@ public static class AiCorpusSynchronizer
         }
         if (selected.Contains("copilot"))
         {
-            Add(".github/copilot-instructions.md", "../.cratis/ai/rules/general.md", false);
+            Add(".github/copilot-instructions.md", nestedInstructionsTarget, false, preserveExisting: true);
             Add(".github/instructions", "../.cratis/ai/rules", true);
             Add(".github/prompts", "../.cratis/ai/prompts", true);
             Add(".github/skills", "../.cratis/ai/skills", true);


### PR DESCRIPTION
## Fixed
- Detect `.cratis/PROJECT.md`, `.ai/PROJECT.md`, and `.agents/PROJECT.md` during managed AI installation.
- Copy project-owned guidance to `.cratis/ai/rules/project.md` without deleting or claiming the legacy source.
- Point new `AGENTS.md`, `CLAUDE.md`, Claude, and Copilot instruction adapters at the shared project rule.
- Preserve existing user-owned instruction files while Pi and harness rule adapters still load the migrated project rule.

## Verification
- Release build succeeds with zero warnings and errors.
- Focused AI corpus specifications: 34 passed.
- Specifications prove project content is copied, legacy content survives, existing `AGENTS.md` survives, and Claude links to the cross-agent project rule.