### PR TITLE
Use valid markers for managed source files

### DIFF
--- a/Source/Cli.Specs/for_AiCorpusSynchronizer/when_synchronizing/and_pi_cursor_and_opencode_are_selected.cs
+++ b/Source/Cli.Specs/for_AiCorpusSynchronizer/when_synchronizing/and_pi_cursor_and_opencode_are_selected.cs
@@ -47,6 +47,7 @@ public class and_pi_cursor_and_opencode_are_selected : Specification
     [Fact] void should_configure_opencode_commands() => new FileInfo(Path.Combine(_project, ".opencode", "commands", "review.md")).LinkTarget.ShouldEqual("../../.cratis/ai/prompts/review.prompt.md");
     [Fact] void should_share_root_instructions() => new FileInfo(Path.Combine(_project, "AGENTS.md")).LinkTarget.ShouldEqual(".cratis/ai/rules/general.md");
     [Fact] void should_keep_skill_frontmatter_first() => File.ReadAllText(Path.Combine(_project, ".cratis", "ai", "skills", "example", "SKILL.md")).StartsWith("---\n", StringComparison.Ordinal).ShouldBeTrue();
+    [Fact] void should_use_typescript_comment_syntax_for_extensions() => File.ReadAllText(Path.Combine(_project, ".cratis", "ai", "harnesses", "pi", "extensions", "index.ts")).StartsWith("// cratis-ai-managed:", StringComparison.Ordinal).ShouldBeTrue();
 
     void Destroy()
     {

--- a/Source/Cli/Commands/Ai/AiCorpusSynchronizer.cs
+++ b/Source/Cli/Commands/Ai/AiCorpusSynchronizer.cs
@@ -438,6 +438,16 @@ public static class AiCorpusSynchronizer
             return frontmatterEnd < 0 ? $"<!-- {marker} -->\n{content}" : content.Insert(frontmatterEnd + 5, $"<!-- {marker} -->\n");
         }
         if (string.Equals(extension, ".html", StringComparison.Ordinal) || string.Equals(extension, ".htm", StringComparison.Ordinal)) return $"<!-- {marker} -->\n{content}";
+        if (string.Equals(extension, ".ts", StringComparison.Ordinal) ||
+            string.Equals(extension, ".tsx", StringComparison.Ordinal) ||
+            string.Equals(extension, ".js", StringComparison.Ordinal) ||
+            string.Equals(extension, ".mjs", StringComparison.Ordinal) ||
+            string.Equals(extension, ".cjs", StringComparison.Ordinal) ||
+            string.Equals(extension, ".cs", StringComparison.Ordinal))
+        {
+            return $"// {marker}\n{content}";
+        }
+        if (string.Equals(extension, ".css", StringComparison.Ordinal) || string.Equals(extension, ".scss", StringComparison.Ordinal)) return $"/* {marker} */\n{content}";
         if (extension == ".json")
         {
             if (JsonNode.Parse(content) is JsonObject json)


### PR DESCRIPTION
## Fixed
- Use `//` ownership markers for TypeScript, JavaScript, and C# managed files.
- Use block comments for CSS and SCSS managed files.
- Keep existing Markdown, JSON, shell, Python, and YAML marker behavior.

This fixes managed Pi extensions being installed with an invalid leading `#` token.

## Verification
- Release build succeeds with zero warnings and errors.
- Focused AI corpus specifications: 35 passed.
- A specification verifies installed TypeScript extensions start with valid comment syntax.