### PR TITLE
Split project instructions by concern

### DIFF
--- a/Source/Cli.Specs/for_AiCorpusSynchronizer/when_synchronizing/and_agents_md_is_user_owned.cs
+++ b/Source/Cli.Specs/for_AiCorpusSynchronizer/when_synchronizing/and_agents_md_is_user_owned.cs
@@ -16,7 +16,7 @@ public class and_agents_md_is_user_owned : Specification
         Directory.CreateDirectory(Path.Combine(_project, ".cratis"));
         Directory.CreateDirectory(Path.Combine(_corpus, ".cratis", "ai", "rules"));
         File.WriteAllText(Path.Combine(_project, "AGENTS.md"), "Read the project-owned instructions.");
-        File.WriteAllText(Path.Combine(_project, ".cratis", "PROJECT.md"), "# Project-specific rule");
+        File.WriteAllText(Path.Combine(_project, ".cratis", "PROJECT.md"), "# Project-specific rules\n\nOverview.\n\n## Build\n\nBuild rule.\n\n## Security\n\nSecurity rule.");
         File.WriteAllText(Path.Combine(_corpus, ".cratis", "ai", "manifest.json"), "{\"harnesses\":[\"claude\",\"pi\"],\"profiles\":[\"cratis/example\"],\"languages\":[\"csharp\"]}");
         File.WriteAllText(Path.Combine(_corpus, ".cratis", "ai", "profile-catalog.json"), "{\"publicProfiles\":[{\"id\":\"cratis/example\"}],\"engineeringProfiles\":[]}");
         File.WriteAllText(Path.Combine(_corpus, ".cratis", "ai", "rules", "general.md"), "# General rule");
@@ -27,7 +27,9 @@ public class and_agents_md_is_user_owned : Specification
     [Fact] void should_preserve_the_project_owned_instructions() => File.ReadAllText(Path.Combine(_project, "AGENTS.md")).ShouldEqual("Read the project-owned instructions.");
     [Fact] void should_not_report_a_conflict() => _result.Conflicts.ShouldBeEmpty();
     [Fact] void should_still_install_the_managed_rules() => File.Exists(Path.Combine(_project, ".cratis", "ai", "rules", "general.md")).ShouldBeTrue();
-    [Fact] void should_migrate_the_project_specific_rule() => File.ReadAllText(Path.Combine(_project, ".cratis", "ai", "rules", "project.md")).ShouldEqual("# Project-specific rule");
+    [Fact] void should_create_a_project_instruction_index() => File.ReadAllText(Path.Combine(_project, ".cratis", "ai", "rules", "project.md")).ShouldContain("[Build](project/build.md)");
+    [Fact] void should_split_each_concern_into_its_own_rule() => File.ReadAllText(Path.Combine(_project, ".cratis", "ai", "rules", "project", "security.md")).ShouldContain("Security rule.");
+    [Fact] void should_add_rule_frontmatter_to_each_concern() => File.ReadAllText(Path.Combine(_project, ".cratis", "ai", "rules", "project", "build.md")).StartsWith("---", StringComparison.Ordinal).ShouldBeTrue();
     [Fact] void should_preserve_the_legacy_project_file() => File.Exists(Path.Combine(_project, ".cratis", "PROJECT.md")).ShouldBeTrue();
     [Fact] void should_link_claude_to_the_project_specific_rule() => new FileInfo(Path.Combine(_project, "CLAUDE.md")).LinkTarget.ShouldEqual(".cratis/ai/rules/project.md");
 

--- a/Source/Cli/Commands/Ai/AiCorpusSynchronizer.cs
+++ b/Source/Cli/Commands/Ai/AiCorpusSynchronizer.cs
@@ -45,13 +45,7 @@ public static class AiCorpusSynchronizer
         if (modified.Count > 0 && !force) return new([], [.. modified.Distinct(StringComparer.Ordinal).Order()]);
 
         var actions = new List<string>();
-        var projectInstructionsDestination = Path.Combine(projectPath, ProjectInstructionsPath);
-        if (projectInstructionsSource is not null && !PathExists(projectInstructionsDestination))
-        {
-            Directory.CreateDirectory(Path.GetDirectoryName(projectInstructionsDestination)!);
-            File.Copy(projectInstructionsSource, projectInstructionsDestination);
-            actions.Add($"Migrated {Path.GetRelativePath(projectPath, projectInstructionsSource).Replace('\\', '/')} to {ProjectInstructionsPath}");
-        }
+        if (projectInstructionsSource is not null) MigrateProjectInstructions(projectPath, projectInstructionsSource, actions);
 
         var installed = new List<AiManagedFile>();
         foreach (var asset in desired.Values.OrderBy(asset => asset.Destination, StringComparer.Ordinal))
@@ -302,6 +296,63 @@ public static class AiCorpusSynchronizer
             if (File.Exists(path)) return path;
         }
         return null;
+    }
+
+    static void MigrateProjectInstructions(string projectPath, string source, List<string> actions)
+    {
+        var destination = Path.Combine(projectPath, ProjectInstructionsPath);
+        var concernsDirectory = Path.Combine(Path.GetDirectoryName(destination)!, "project");
+        if (Directory.Exists(concernsDirectory)) return;
+
+        var content = File.ReadAllText(source).Replace("\r\n", "\n", StringComparison.Ordinal);
+        var lines = content.Split('\n');
+        var headingIndexes = new List<int>();
+        var insideCodeFence = false;
+        for (var index = 0; index < lines.Length; index++)
+        {
+            if (lines[index].TrimStart().StartsWith("```", StringComparison.Ordinal)) insideCodeFence = !insideCodeFence;
+            else if (!insideCodeFence && lines[index].StartsWith("## ", StringComparison.Ordinal)) headingIndexes.Add(index);
+        }
+
+        Directory.CreateDirectory(Path.GetDirectoryName(destination)!);
+        if (headingIndexes.Count == 0)
+        {
+            if (!PathExists(destination)) File.Copy(source, destination);
+            return;
+        }
+
+        Directory.CreateDirectory(concernsDirectory);
+        var usedNames = new HashSet<string>(StringComparer.Ordinal);
+        var links = new List<string>();
+        for (var sectionIndex = 0; sectionIndex < headingIndexes.Count; sectionIndex++)
+        {
+            var start = headingIndexes[sectionIndex];
+            var end = sectionIndex + 1 < headingIndexes.Count ? headingIndexes[sectionIndex + 1] : lines.Length;
+            var title = lines[start][3..].Trim();
+            var baseName = Slug(title);
+            var name = baseName;
+            var suffix = 2;
+            while (!usedNames.Add(name)) name = $"{baseName}-{suffix++}";
+            var section = string.Join('\n', lines[start..end]).TrimEnd();
+            File.WriteAllText(Path.Combine(concernsDirectory, $"{name}.md"), $"---\napplyTo: \"**/*\"\n---\n\n{section}\n");
+            links.Add($"- [{title}](project/{name}.md)");
+        }
+
+        var preamble = string.Join('\n', lines[..headingIndexes[0]]).TrimEnd();
+        var indexContent = $"{preamble}\n\n## Project concerns\n\nRead every concern below before working in this repository. Together they are the project-owned instructions and override conflicting shared guidance.\n\n{string.Join('\n', links)}\n";
+        File.WriteAllText(destination, indexContent);
+        actions.Add($"Split {Path.GetRelativePath(projectPath, source).Replace('\\', '/')} into {ProjectInstructionsPath} and {ProjectInstructionsPath[..^3]}/");
+    }
+
+    static string Slug(string value)
+    {
+        var slug = new StringBuilder();
+        foreach (var character in value.ToLowerInvariant())
+        {
+            if (char.IsLetterOrDigit(character)) slug.Append(character);
+            else if (slug.Length > 0 && slug[^1] != '-') slug.Append('-');
+        }
+        return slug.ToString().Trim('-') is { Length: > 0 } result ? result : "instructions";
     }
 
     static Dictionary<string, AiManagedIntegration> PlanHarnessIntegrations(IEnumerable<string> harnesses, IEnumerable<string> files, bool hasProjectInstructions)


### PR DESCRIPTION
## Fixed
- Split legacy project instruction files into focused concern rules under `.cratis/ai/rules/project/`.
- Generate a shared `.cratis/ai/rules/project.md` index that tells every harness to load the concern files.
- Preserve headings, content, code fences, duplicate concern names, and the original legacy source.
- Keep all generated concern rules user-owned and outside the managed manifest.

## Verification
- Release build succeeds with zero warnings and errors.
- Focused AI corpus specifications: 37 passed.
- Specifications verify the shared index, concern files, frontmatter, legacy preservation, existing `AGENTS.md`, and Claude adapter.