### PR TITLE
Use root-relative project concern links

### DIFF
--- a/Source/Cli.Specs/for_AiCorpusSynchronizer/when_synchronizing/and_agents_md_is_user_owned.cs
+++ b/Source/Cli.Specs/for_AiCorpusSynchronizer/when_synchronizing/and_agents_md_is_user_owned.cs
@@ -27,7 +27,7 @@ public class and_agents_md_is_user_owned : Specification
     [Fact] void should_preserve_the_project_owned_instructions() => File.ReadAllText(Path.Combine(_project, "AGENTS.md")).ShouldEqual("Read the project-owned instructions.");
     [Fact] void should_not_report_a_conflict() => _result.Conflicts.ShouldBeEmpty();
     [Fact] void should_still_install_the_managed_rules() => File.Exists(Path.Combine(_project, ".cratis", "ai", "rules", "general.md")).ShouldBeTrue();
-    [Fact] void should_create_a_project_instruction_index() => File.ReadAllText(Path.Combine(_project, ".cratis", "ai", "rules", "project.md")).ShouldContain("[Build](project/build.md)");
+    [Fact] void should_create_a_project_instruction_index() => File.ReadAllText(Path.Combine(_project, ".cratis", "ai", "rules", "project.md")).ShouldContain("[Build](.cratis/ai/rules/project/build.md)");
     [Fact] void should_split_each_concern_into_its_own_rule() => File.ReadAllText(Path.Combine(_project, ".cratis", "ai", "rules", "project", "security.md")).ShouldContain("Security rule.");
     [Fact] void should_add_rule_frontmatter_to_each_concern() => File.ReadAllText(Path.Combine(_project, ".cratis", "ai", "rules", "project", "build.md")).StartsWith("---", StringComparison.Ordinal).ShouldBeTrue();
     [Fact] void should_preserve_the_legacy_project_file() => File.Exists(Path.Combine(_project, ".cratis", "PROJECT.md")).ShouldBeTrue();

--- a/Source/Cli/Commands/Ai/AiCorpusSynchronizer.cs
+++ b/Source/Cli/Commands/Ai/AiCorpusSynchronizer.cs
@@ -335,7 +335,7 @@ public static class AiCorpusSynchronizer
             while (!usedNames.Add(name)) name = $"{baseName}-{suffix++}";
             var section = string.Join('\n', lines[start..end]).TrimEnd();
             File.WriteAllText(Path.Combine(concernsDirectory, $"{name}.md"), $"---\napplyTo: \"**/*\"\n---\n\n{section}\n");
-            links.Add($"- [{title}](project/{name}.md)");
+            links.Add($"- [{title}]({ProjectInstructionsPath[..^3]}/{name}.md)");
         }
 
         var preamble = string.Join('\n', lines[..headingIndexes[0]]).TrimEnd();


### PR DESCRIPTION
## Fixed
- Generate project concern links from the repository root so they resolve through symlinked `AGENTS.md` and `CLAUDE.md` adapters.
- Keep concern links valid when the index is consumed directly from `.cratis/ai/rules/project.md`.

## Verification
- Release build succeeds with zero warnings and errors.
- Focused AI corpus specifications: 37 passed.