### PR TITLE
Fix cross-agent project concern links

### DIFF
--- a/.cratis/ai/rules/project.md
+++ b/.cratis/ai/rules/project.md
@@ -10,7 +10,7 @@ regenerate with `cratis init --refresh`.
 
 Read every concern below before working in this repository. Together they are the project-owned instructions and override conflicting shared guidance.
 
-- [Commands](project/commands.md)
-- [Conventions](project/conventions.md)
-- [Command catalogue](project/command-catalogue.md)
-- [AI-assisted development](project/ai-assisted-development.md)
+- [Commands](.cratis/ai/rules/project/commands.md)
+- [Conventions](.cratis/ai/rules/project/conventions.md)
+- [Command catalogue](.cratis/ai/rules/project/command-catalogue.md)
+- [AI-assisted development](.cratis/ai/rules/project/ai-assisted-development.md)


### PR DESCRIPTION
## Fixed
- Make every project concern link repository-root-relative so it resolves through symlinked `AGENTS.md`, `CLAUDE.md`, and native harness adapters.
- Keep every concern file project-owned and outside the managed manifest.

## Verification
- Every linked concern exists.
- `git diff --check` passes.
